### PR TITLE
Adding support for a couple of tensor ops.

### DIFF
--- a/TorchSharp/TypeGeneration.cs
+++ b/TorchSharp/TypeGeneration.cs
@@ -1,9 +1,15 @@
-﻿using System;
+﻿
+
+
+
+
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 using System.Text;
 
 namespace TorchSharp {
+
     public partial class ByteTensor : IDisposable {
         /// <summary>
         ///    The storage class provides a mechanism to access the underlying data representation for tensors.
@@ -287,6 +293,51 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
+        extern static void THByteTensor_maskedFill (HType handle1, ByteTensor.HType handle2, byte value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, byte value)
+        {
+            THByteTensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, ByteTensor src)
+        {
+            THByteTensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, ByteTensor src)
+        {
+            THByteTensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static ByteStorage.HType THByteTensor_storage (HType handle);
 
         /// <summary>
@@ -405,6 +456,42 @@ namespace TorchSharp {
         /// <param name="step"></param>
         public ByteTensor Unfold (int dim, long size, long step) => new ByteTensor (THByteTensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            THByteTensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (ByteTensor src, int dimension)
+        {
+            THByteTensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (ByteTensor src, int dimension)
+        {
+            THByteTensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void THByteTensor_resize1d (HType handle, long size);
         
@@ -1130,6 +1217,7 @@ namespace TorchSharp {
             return result;
         }
 
+
                 
         [DllImport ("caffe2")]
         extern static void THByteTensor_cadd (HType result, HType t, byte value, HType src);
@@ -1169,6 +1257,8 @@ namespace TorchSharp {
             THByteTensor_csub (result.handle, this.handle, value, src.handle);
             return result;
         }
+
+
 
 
 
@@ -1368,6 +1458,7 @@ namespace TorchSharp {
             return result;
         }
 
+
  
         [DllImport ("caffe2")]
         extern static byte THByteTensor_minall (HType result);
@@ -1459,6 +1550,7 @@ namespace TorchSharp {
 
 
 
+
         [DllImport ("caffe2")]
         extern static void THByteTensor_indexSelect (HType tensor, HType src, int dim, LongTensor.HType index);
         
@@ -1501,6 +1593,7 @@ namespace TorchSharp {
             THByteTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
     }
+
     public partial class ShortTensor : IDisposable {
         /// <summary>
         ///    The storage class provides a mechanism to access the underlying data representation for tensors.
@@ -1784,6 +1877,51 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
+        extern static void THShortTensor_maskedFill (HType handle1, ByteTensor.HType handle2, short value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, short value)
+        {
+            THShortTensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, ShortTensor src)
+        {
+            THShortTensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, ShortTensor src)
+        {
+            THShortTensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static ShortStorage.HType THShortTensor_storage (HType handle);
 
         /// <summary>
@@ -1902,6 +2040,42 @@ namespace TorchSharp {
         /// <param name="step"></param>
         public ShortTensor Unfold (int dim, long size, long step) => new ShortTensor (THShortTensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            THShortTensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (ShortTensor src, int dimension)
+        {
+            THShortTensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (ShortTensor src, int dimension)
+        {
+            THShortTensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void THShortTensor_resize1d (HType handle, long size);
         
@@ -2627,6 +2801,7 @@ namespace TorchSharp {
             return result;
         }
 
+
                 
         [DllImport ("caffe2")]
         extern static void THShortTensor_cadd (HType result, HType t, short value, HType src);
@@ -2666,6 +2841,8 @@ namespace TorchSharp {
             THShortTensor_csub (result.handle, this.handle, value, src.handle);
             return result;
         }
+
+
 
 
 
@@ -2865,6 +3042,7 @@ namespace TorchSharp {
             return result;
         }
 
+
  
         [DllImport ("caffe2")]
         extern static short THShortTensor_minall (HType result);
@@ -2956,6 +3134,7 @@ namespace TorchSharp {
 
 
 
+
         [DllImport ("caffe2")]
         extern static void THShortTensor_indexSelect (HType tensor, HType src, int dim, LongTensor.HType index);
         
@@ -2998,6 +3177,7 @@ namespace TorchSharp {
             THShortTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
     }
+
     public partial class IntTensor : IDisposable {
         /// <summary>
         ///    The storage class provides a mechanism to access the underlying data representation for tensors.
@@ -3281,6 +3461,51 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
+        extern static void THIntTensor_maskedFill (HType handle1, ByteTensor.HType handle2, int value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, int value)
+        {
+            THIntTensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, IntTensor src)
+        {
+            THIntTensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, IntTensor src)
+        {
+            THIntTensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static IntStorage.HType THIntTensor_storage (HType handle);
 
         /// <summary>
@@ -3399,6 +3624,42 @@ namespace TorchSharp {
         /// <param name="step"></param>
         public IntTensor Unfold (int dim, long size, long step) => new IntTensor (THIntTensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            THIntTensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (IntTensor src, int dimension)
+        {
+            THIntTensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (IntTensor src, int dimension)
+        {
+            THIntTensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void THIntTensor_resize1d (HType handle, long size);
         
@@ -4124,6 +4385,7 @@ namespace TorchSharp {
             return result;
         }
 
+
                 
         [DllImport ("caffe2")]
         extern static void THIntTensor_cadd (HType result, HType t, int value, HType src);
@@ -4163,6 +4425,8 @@ namespace TorchSharp {
             THIntTensor_csub (result.handle, this.handle, value, src.handle);
             return result;
         }
+
+
 
 
 
@@ -4362,6 +4626,7 @@ namespace TorchSharp {
             return result;
         }
 
+
  
         [DllImport ("caffe2")]
         extern static int THIntTensor_minall (HType result);
@@ -4453,6 +4718,7 @@ namespace TorchSharp {
 
 
 
+
         [DllImport ("caffe2")]
         extern static void THIntTensor_indexSelect (HType tensor, HType src, int dim, LongTensor.HType index);
         
@@ -4495,6 +4761,7 @@ namespace TorchSharp {
             THIntTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
     }
+
     public partial class LongTensor : IDisposable {
         /// <summary>
         ///    The storage class provides a mechanism to access the underlying data representation for tensors.
@@ -4778,6 +5045,51 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
+        extern static void THLongTensor_maskedFill (HType handle1, ByteTensor.HType handle2, long value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, long value)
+        {
+            THLongTensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, LongTensor src)
+        {
+            THLongTensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, LongTensor src)
+        {
+            THLongTensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static LongStorage.HType THLongTensor_storage (HType handle);
 
         /// <summary>
@@ -4896,6 +5208,42 @@ namespace TorchSharp {
         /// <param name="step"></param>
         public LongTensor Unfold (int dim, long size, long step) => new LongTensor (THLongTensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            THLongTensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (LongTensor src, int dimension)
+        {
+            THLongTensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (LongTensor src, int dimension)
+        {
+            THLongTensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void THLongTensor_resize1d (HType handle, long size);
         
@@ -5621,6 +5969,7 @@ namespace TorchSharp {
             return result;
         }
 
+
                 
         [DllImport ("caffe2")]
         extern static void THLongTensor_cadd (HType result, HType t, long value, HType src);
@@ -5660,6 +6009,8 @@ namespace TorchSharp {
             THLongTensor_csub (result.handle, this.handle, value, src.handle);
             return result;
         }
+
+
 
 
 
@@ -5859,6 +6210,7 @@ namespace TorchSharp {
             return result;
         }
 
+
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_minall (HType result);
@@ -5950,6 +6302,7 @@ namespace TorchSharp {
 
 
 
+
         [DllImport ("caffe2")]
         extern static void THLongTensor_indexSelect (HType tensor, HType src, int dim, LongTensor.HType index);
         
@@ -5992,6 +6345,7 @@ namespace TorchSharp {
             THLongTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
     }
+
     public partial class DoubleTensor : IDisposable {
         /// <summary>
         ///    The storage class provides a mechanism to access the underlying data representation for tensors.
@@ -6275,6 +6629,51 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
+        extern static void THDoubleTensor_maskedFill (HType handle1, ByteTensor.HType handle2, double value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, double value)
+        {
+            THDoubleTensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, DoubleTensor src)
+        {
+            THDoubleTensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, DoubleTensor src)
+        {
+            THDoubleTensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static DoubleStorage.HType THDoubleTensor_storage (HType handle);
 
         /// <summary>
@@ -6393,6 +6792,42 @@ namespace TorchSharp {
         /// <param name="step"></param>
         public DoubleTensor Unfold (int dim, long size, long step) => new DoubleTensor (THDoubleTensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            THDoubleTensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (DoubleTensor src, int dimension)
+        {
+            THDoubleTensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (DoubleTensor src, int dimension)
+        {
+            THDoubleTensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void THDoubleTensor_resize1d (HType handle, long size);
         
@@ -7030,6 +7465,7 @@ namespace TorchSharp {
             return result;
         }
 
+
                 
         [DllImport ("caffe2")]
         extern static void THDoubleTensor_cadd (HType result, HType t, double value, HType src);
@@ -7069,6 +7505,7 @@ namespace TorchSharp {
             THDoubleTensor_csub (result.handle, this.handle, value, src.handle);
             return result;
         }
+
 
 
                 
@@ -7718,6 +8155,7 @@ namespace TorchSharp {
         }
 
 
+
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_dot (HType self, HType other);
         
@@ -7914,6 +8352,7 @@ namespace TorchSharp {
             return result;
         }
 
+
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_minall (HType result);
@@ -8005,6 +8444,7 @@ namespace TorchSharp {
 
 
 
+
         [DllImport ("caffe2")]
         extern static void THDoubleTensor_indexSelect (HType tensor, HType src, int dim, LongTensor.HType index);
         
@@ -8047,6 +8487,7 @@ namespace TorchSharp {
             THDoubleTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
     }
+
     public partial class FloatTensor : IDisposable {
         /// <summary>
         ///    The storage class provides a mechanism to access the underlying data representation for tensors.
@@ -8330,6 +8771,51 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
+        extern static void THFloatTensor_maskedFill (HType handle1, ByteTensor.HType handle2, float value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, float value)
+        {
+            THFloatTensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, FloatTensor src)
+        {
+            THFloatTensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, FloatTensor src)
+        {
+            THFloatTensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static FloatStorage.HType THFloatTensor_storage (HType handle);
 
         /// <summary>
@@ -8448,6 +8934,42 @@ namespace TorchSharp {
         /// <param name="step"></param>
         public FloatTensor Unfold (int dim, long size, long step) => new FloatTensor (THFloatTensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            THFloatTensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (FloatTensor src, int dimension)
+        {
+            THFloatTensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (FloatTensor src, int dimension)
+        {
+            THFloatTensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void THFloatTensor_resize1d (HType handle, long size);
         
@@ -9085,6 +9607,7 @@ namespace TorchSharp {
             return result;
         }
 
+
                 
         [DllImport ("caffe2")]
         extern static void THFloatTensor_cadd (HType result, HType t, float value, HType src);
@@ -9124,6 +9647,7 @@ namespace TorchSharp {
             THFloatTensor_csub (result.handle, this.handle, value, src.handle);
             return result;
         }
+
 
 
                 
@@ -9773,6 +10297,7 @@ namespace TorchSharp {
         }
 
 
+
         [DllImport ("caffe2")]
         extern static double THFloatTensor_dot (HType self, HType other);
         
@@ -9969,6 +10494,7 @@ namespace TorchSharp {
             return result;
         }
 
+
  
         [DllImport ("caffe2")]
         extern static float THFloatTensor_minall (HType result);
@@ -10060,6 +10586,7 @@ namespace TorchSharp {
 
 
 
+
         [DllImport ("caffe2")]
         extern static void THFloatTensor_indexSelect (HType tensor, HType src, int dim, LongTensor.HType index);
         
@@ -10102,4 +10629,5 @@ namespace TorchSharp {
             THFloatTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
     }
+
 }

--- a/TorchSharp/TypeGeneration.cs
+++ b/TorchSharp/TypeGeneration.cs
@@ -647,18 +647,63 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
-        extern static byte THByteTensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static byte THByteTensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            THByteTensor_randperm (handle, source.handle, n);
+            THByteTensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static byte THByteTensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THByteTensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static byte THByteTensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THByteTensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static byte THByteTensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THByteTensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -668,8 +713,10 @@ namespace TorchSharp {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -1281,6 +1328,28 @@ namespace TorchSharp {
            
             return THByteTensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_match (HType result, HType m1, HType m2, byte gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor Match (ByteTensor m2, byte gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new ByteTensor ();
+            THByteTensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
                 
         [DllImport ("caffe2")]
         extern static void THByteTensor_cmul (HType result, HType t, HType src);
@@ -1462,6 +1531,183 @@ namespace TorchSharp {
         }
 
 
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_addcmul (HType result, HType t, byte value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCMul of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor AddCMul (byte value, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_addcmul (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_addcdiv (HType result, HType t, byte value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCDiv of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor AddCDiv (byte value, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_addcdiv (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_addmv (HType result, byte beta, HType t, byte alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMV of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor AddMV (byte beta, byte alpha, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_addmv (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_addmm (HType result, byte beta, HType t, byte alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor AddMM (byte beta, byte alpha, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_addmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_addr (HType result, byte beta, HType t, byte alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddR of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor AddR (byte beta, byte alpha, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_addr (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_addbmm (HType result, byte beta, HType t, byte alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor AddBMM (byte beta, byte alpha, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_addbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_baddbmm (HType result, byte beta, HType t, byte alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs BAddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ByteTensor BAddBMM (byte beta, byte alpha, ByteTensor src1, ByteTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ByteTensor ();
+            THByteTensor_baddbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+
  
         [DllImport ("caffe2")]
         extern static byte THByteTensor_minall (HType result);
@@ -1475,8 +1721,6 @@ namespace TorchSharp {
         {
             return THByteTensor_minall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static byte THByteTensor_maxall (HType result);
@@ -1490,8 +1734,6 @@ namespace TorchSharp {
         {
             return THByteTensor_maxall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static byte THByteTensor_medianall (HType result);
@@ -1505,8 +1747,6 @@ namespace TorchSharp {
         {
             return THByteTensor_medianall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THByteTensor_sumall (HType result);
@@ -1520,8 +1760,6 @@ namespace TorchSharp {
         {
             return THByteTensor_sumall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THByteTensor_prodall (HType result);
@@ -1535,8 +1773,6 @@ namespace TorchSharp {
         {
             return THByteTensor_prodall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THByteTensor_meanall (HType result);
@@ -1550,8 +1786,6 @@ namespace TorchSharp {
         {
             return THByteTensor_meanall (this.handle);
         }
-
-
 
 
         [DllImport ("caffe2")]
@@ -1595,6 +1829,127 @@ namespace TorchSharp {
             
             THByteTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copy (this.handle, src.handle);
+        }
+
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copyByte (HType tensor, ByteTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a byte tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyByte (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copyByte (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copyShort (HType tensor, ShortTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a short tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyShort (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copyShort (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copyInt (HType tensor, IntTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a int tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyInt (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copyInt (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copyLong (HType tensor, LongTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a long tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyLong (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copyLong (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copyFloat (HType tensor, FloatTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a float tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyFloat (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copyFloat (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THByteTensor_copyDouble (HType tensor, DoubleTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a double tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyDouble (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THByteTensor_copyDouble (this.handle, src.handle);
+        }
+        
     }
 
     public partial class ShortTensor : IDisposable {
@@ -2234,18 +2589,63 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
-        extern static short THShortTensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static short THShortTensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            THShortTensor_randperm (handle, source.handle, n);
+            THShortTensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static short THShortTensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THShortTensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static short THShortTensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THShortTensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static short THShortTensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THShortTensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -2255,8 +2655,10 @@ namespace TorchSharp {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -2868,6 +3270,28 @@ namespace TorchSharp {
            
             return THShortTensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_match (HType result, HType m1, HType m2, short gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor Match (ShortTensor m2, short gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new ShortTensor ();
+            THShortTensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
                 
         [DllImport ("caffe2")]
         extern static void THShortTensor_cmul (HType result, HType t, HType src);
@@ -3049,6 +3473,183 @@ namespace TorchSharp {
         }
 
 
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_addcmul (HType result, HType t, short value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCMul of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor AddCMul (short value, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_addcmul (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_addcdiv (HType result, HType t, short value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCDiv of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor AddCDiv (short value, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_addcdiv (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_addmv (HType result, short beta, HType t, short alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMV of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor AddMV (short beta, short alpha, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_addmv (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_addmm (HType result, short beta, HType t, short alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor AddMM (short beta, short alpha, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_addmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_addr (HType result, short beta, HType t, short alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddR of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor AddR (short beta, short alpha, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_addr (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_addbmm (HType result, short beta, HType t, short alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor AddBMM (short beta, short alpha, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_addbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_baddbmm (HType result, short beta, HType t, short alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs BAddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public ShortTensor BAddBMM (short beta, short alpha, ShortTensor src1, ShortTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new ShortTensor ();
+            THShortTensor_baddbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+
  
         [DllImport ("caffe2")]
         extern static short THShortTensor_minall (HType result);
@@ -3062,8 +3663,6 @@ namespace TorchSharp {
         {
             return THShortTensor_minall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static short THShortTensor_maxall (HType result);
@@ -3077,8 +3676,6 @@ namespace TorchSharp {
         {
             return THShortTensor_maxall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static short THShortTensor_medianall (HType result);
@@ -3092,8 +3689,6 @@ namespace TorchSharp {
         {
             return THShortTensor_medianall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THShortTensor_sumall (HType result);
@@ -3107,8 +3702,6 @@ namespace TorchSharp {
         {
             return THShortTensor_sumall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THShortTensor_prodall (HType result);
@@ -3122,8 +3715,6 @@ namespace TorchSharp {
         {
             return THShortTensor_prodall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THShortTensor_meanall (HType result);
@@ -3137,8 +3728,6 @@ namespace TorchSharp {
         {
             return THShortTensor_meanall (this.handle);
         }
-
-
 
 
         [DllImport ("caffe2")]
@@ -3182,6 +3771,127 @@ namespace TorchSharp {
             
             THShortTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copy (this.handle, src.handle);
+        }
+
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copyByte (HType tensor, ByteTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a byte tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyByte (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copyByte (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copyShort (HType tensor, ShortTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a short tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyShort (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copyShort (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copyInt (HType tensor, IntTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a int tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyInt (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copyInt (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copyLong (HType tensor, LongTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a long tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyLong (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copyLong (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copyFloat (HType tensor, FloatTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a float tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyFloat (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copyFloat (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THShortTensor_copyDouble (HType tensor, DoubleTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a double tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyDouble (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THShortTensor_copyDouble (this.handle, src.handle);
+        }
+        
     }
 
     public partial class IntTensor : IDisposable {
@@ -3821,18 +4531,63 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
-        extern static int THIntTensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static int THIntTensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            THIntTensor_randperm (handle, source.handle, n);
+            THIntTensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static int THIntTensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THIntTensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static int THIntTensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THIntTensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static int THIntTensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THIntTensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -3842,8 +4597,10 @@ namespace TorchSharp {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -4455,6 +5212,28 @@ namespace TorchSharp {
            
             return THIntTensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_match (HType result, HType m1, HType m2, int gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor Match (IntTensor m2, int gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new IntTensor ();
+            THIntTensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
                 
         [DllImport ("caffe2")]
         extern static void THIntTensor_cmul (HType result, HType t, HType src);
@@ -4636,6 +5415,183 @@ namespace TorchSharp {
         }
 
 
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_addcmul (HType result, HType t, int value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCMul of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor AddCMul (int value, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_addcmul (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_addcdiv (HType result, HType t, int value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCDiv of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor AddCDiv (int value, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_addcdiv (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_addmv (HType result, int beta, HType t, int alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMV of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor AddMV (int beta, int alpha, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_addmv (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_addmm (HType result, int beta, HType t, int alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor AddMM (int beta, int alpha, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_addmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_addr (HType result, int beta, HType t, int alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddR of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor AddR (int beta, int alpha, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_addr (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_addbmm (HType result, int beta, HType t, int alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor AddBMM (int beta, int alpha, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_addbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_baddbmm (HType result, int beta, HType t, int alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs BAddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public IntTensor BAddBMM (int beta, int alpha, IntTensor src1, IntTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new IntTensor ();
+            THIntTensor_baddbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+
  
         [DllImport ("caffe2")]
         extern static int THIntTensor_minall (HType result);
@@ -4649,8 +5605,6 @@ namespace TorchSharp {
         {
             return THIntTensor_minall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static int THIntTensor_maxall (HType result);
@@ -4664,8 +5618,6 @@ namespace TorchSharp {
         {
             return THIntTensor_maxall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static int THIntTensor_medianall (HType result);
@@ -4679,8 +5631,6 @@ namespace TorchSharp {
         {
             return THIntTensor_medianall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THIntTensor_sumall (HType result);
@@ -4694,8 +5644,6 @@ namespace TorchSharp {
         {
             return THIntTensor_sumall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THIntTensor_prodall (HType result);
@@ -4709,8 +5657,6 @@ namespace TorchSharp {
         {
             return THIntTensor_prodall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THIntTensor_meanall (HType result);
@@ -4724,8 +5670,6 @@ namespace TorchSharp {
         {
             return THIntTensor_meanall (this.handle);
         }
-
-
 
 
         [DllImport ("caffe2")]
@@ -4769,6 +5713,127 @@ namespace TorchSharp {
             
             THIntTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copy (this.handle, src.handle);
+        }
+
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copyByte (HType tensor, ByteTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a byte tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyByte (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copyByte (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copyShort (HType tensor, ShortTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a short tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyShort (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copyShort (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copyInt (HType tensor, IntTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a int tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyInt (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copyInt (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copyLong (HType tensor, LongTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a long tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyLong (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copyLong (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copyFloat (HType tensor, FloatTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a float tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyFloat (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copyFloat (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THIntTensor_copyDouble (HType tensor, DoubleTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a double tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyDouble (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THIntTensor_copyDouble (this.handle, src.handle);
+        }
+        
     }
 
     public partial class LongTensor : IDisposable {
@@ -5408,18 +6473,63 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
-        extern static long THLongTensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static long THLongTensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            THLongTensor_randperm (handle, source.handle, n);
+            THLongTensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static long THLongTensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THLongTensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static long THLongTensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THLongTensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static long THLongTensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THLongTensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -5429,8 +6539,10 @@ namespace TorchSharp {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -6042,6 +7154,28 @@ namespace TorchSharp {
            
             return THLongTensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_match (HType result, HType m1, HType m2, long gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor Match (LongTensor m2, long gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new LongTensor ();
+            THLongTensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
                 
         [DllImport ("caffe2")]
         extern static void THLongTensor_cmul (HType result, HType t, HType src);
@@ -6223,6 +7357,183 @@ namespace TorchSharp {
         }
 
 
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_addcmul (HType result, HType t, long value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCMul of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor AddCMul (long value, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_addcmul (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_addcdiv (HType result, HType t, long value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCDiv of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor AddCDiv (long value, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_addcdiv (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_addmv (HType result, long beta, HType t, long alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMV of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor AddMV (long beta, long alpha, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_addmv (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_addmm (HType result, long beta, HType t, long alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor AddMM (long beta, long alpha, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_addmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_addr (HType result, long beta, HType t, long alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddR of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor AddR (long beta, long alpha, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_addr (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_addbmm (HType result, long beta, HType t, long alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor AddBMM (long beta, long alpha, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_addbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_baddbmm (HType result, long beta, HType t, long alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs BAddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public LongTensor BAddBMM (long beta, long alpha, LongTensor src1, LongTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new LongTensor ();
+            THLongTensor_baddbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_minall (HType result);
@@ -6236,8 +7547,6 @@ namespace TorchSharp {
         {
             return THLongTensor_minall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_maxall (HType result);
@@ -6251,8 +7560,6 @@ namespace TorchSharp {
         {
             return THLongTensor_maxall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_medianall (HType result);
@@ -6266,8 +7573,6 @@ namespace TorchSharp {
         {
             return THLongTensor_medianall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_sumall (HType result);
@@ -6281,8 +7586,6 @@ namespace TorchSharp {
         {
             return THLongTensor_sumall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_prodall (HType result);
@@ -6296,8 +7599,6 @@ namespace TorchSharp {
         {
             return THLongTensor_prodall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static long THLongTensor_meanall (HType result);
@@ -6311,8 +7612,6 @@ namespace TorchSharp {
         {
             return THLongTensor_meanall (this.handle);
         }
-
-
 
 
         [DllImport ("caffe2")]
@@ -6356,6 +7655,127 @@ namespace TorchSharp {
             
             THLongTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copy (this.handle, src.handle);
+        }
+
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copyByte (HType tensor, ByteTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a byte tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyByte (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copyByte (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copyShort (HType tensor, ShortTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a short tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyShort (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copyShort (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copyInt (HType tensor, IntTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a int tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyInt (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copyInt (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copyLong (HType tensor, LongTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a long tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyLong (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copyLong (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copyFloat (HType tensor, FloatTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a float tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyFloat (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copyFloat (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THLongTensor_copyDouble (HType tensor, DoubleTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a double tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyDouble (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THLongTensor_copyDouble (this.handle, src.handle);
+        }
+        
     }
 
     public partial class DoubleTensor : IDisposable {
@@ -6995,18 +8415,63 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
-        extern static double THDoubleTensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static double THDoubleTensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            THDoubleTensor_randperm (handle, source.handle, n);
+            THDoubleTensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static double THDoubleTensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THDoubleTensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static double THDoubleTensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THDoubleTensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static double THDoubleTensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THDoubleTensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -7016,8 +8481,122 @@ namespace TorchSharp {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+
+#if false
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_bernoulli_DoubleTensor (HType self, IntPtr thgenerator, HType p);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void BernoulliTensor (RandomGenerator source, DoubleTensor p)
+        {
+            THDoubleTensor_bernoulli_DoubleTensor(this.handle, source.handle, p.handle);
+        }
+#endif
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_uniform (HType self, IntPtr thgenerator, double min, double max);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Uniform (RandomGenerator source, double min, double max)
+        {
+            THDoubleTensor_uniform(this.handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_exponential (HType self, IntPtr thgenerator, double lambda);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Exponential (RandomGenerator source, double lambda)
+        {
+            THDoubleTensor_exponential(this.handle, source.handle, lambda);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_cauchy (HType self, IntPtr thgenerator, double median, double sigma);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Cauchy (RandomGenerator source, double median, double sigma)
+        {
+            THDoubleTensor_cauchy(this.handle, source.handle, median, sigma);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_logNormal (HType self, IntPtr thgenerator, double mean, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void LogNormal (RandomGenerator source, double mean, double stdv)
+        {
+            THDoubleTensor_logNormal(this.handle, source.handle, mean, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_normal (HType self, IntPtr thgenerator, double mean, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Normal (RandomGenerator source, double mean, double stdv)
+        {
+            THDoubleTensor_normal(this.handle, source.handle, mean, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_normal_means (HType self, IntPtr thgenerator, HType means, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeans (RandomGenerator source, DoubleTensor means, double stdv)
+        {
+            THDoubleTensor_normal_means(this.handle, source.handle, means.handle, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_normal_stddevs (HType self, IntPtr thgenerator, double mean, HType stdvs);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalStdvs (RandomGenerator source, double mean, DoubleTensor stdvs)
+        {
+            THDoubleTensor_normal_stddevs(this.handle, source.handle, mean, stdvs.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_normal_means_stddevs (HType self, IntPtr thgenerator, HType means, HType stdvs);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeansStdvs (RandomGenerator source, DoubleTensor means, DoubleTensor stdvs)
+        {
+            THDoubleTensor_normal_means_stddevs(this.handle, source.handle, means.handle, stdvs.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_multinomial (HType self, IntPtr thgenerator, HType prob_dist, int n_sample, int with_replacement);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeansStdvs (RandomGenerator source, DoubleTensor prob_dist, int n_sample, int with_replacement)
+        {
+            THDoubleTensor_multinomial(this.handle, source.handle, prob_dist.handle, n_sample, with_replacement);
+        }
+
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -8218,6 +9797,28 @@ namespace TorchSharp {
            
             return THDoubleTensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_match (HType result, HType m1, HType m2, double gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor Match (DoubleTensor m2, double gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
                 
         [DllImport ("caffe2")]
         extern static void THDoubleTensor_cmul (HType result, HType t, HType src);
@@ -8399,6 +10000,183 @@ namespace TorchSharp {
         }
 
 
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_addcmul (HType result, HType t, double value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCMul of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor AddCMul (double value, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_addcmul (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_addcdiv (HType result, HType t, double value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCDiv of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor AddCDiv (double value, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_addcdiv (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_addmv (HType result, double beta, HType t, double alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMV of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor AddMV (double beta, double alpha, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_addmv (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_addmm (HType result, double beta, HType t, double alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor AddMM (double beta, double alpha, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_addmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_addr (HType result, double beta, HType t, double alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddR of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor AddR (double beta, double alpha, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_addr (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_addbmm (HType result, double beta, HType t, double alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor AddBMM (double beta, double alpha, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_addbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_baddbmm (HType result, double beta, HType t, double alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs BAddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public DoubleTensor BAddBMM (double beta, double alpha, DoubleTensor src1, DoubleTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new DoubleTensor ();
+            THDoubleTensor_baddbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_minall (HType result);
@@ -8412,8 +10190,6 @@ namespace TorchSharp {
         {
             return THDoubleTensor_minall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_maxall (HType result);
@@ -8427,8 +10203,6 @@ namespace TorchSharp {
         {
             return THDoubleTensor_maxall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_medianall (HType result);
@@ -8442,8 +10216,6 @@ namespace TorchSharp {
         {
             return THDoubleTensor_medianall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_sumall (HType result);
@@ -8457,8 +10229,6 @@ namespace TorchSharp {
         {
             return THDoubleTensor_sumall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_prodall (HType result);
@@ -8472,8 +10242,6 @@ namespace TorchSharp {
         {
             return THDoubleTensor_prodall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THDoubleTensor_meanall (HType result);
@@ -8487,8 +10255,6 @@ namespace TorchSharp {
         {
             return THDoubleTensor_meanall (this.handle);
         }
-
-
 
 
         [DllImport ("caffe2")]
@@ -8532,6 +10298,127 @@ namespace TorchSharp {
             
             THDoubleTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copy (this.handle, src.handle);
+        }
+
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copyByte (HType tensor, ByteTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a byte tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyByte (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copyByte (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copyShort (HType tensor, ShortTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a short tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyShort (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copyShort (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copyInt (HType tensor, IntTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a int tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyInt (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copyInt (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copyLong (HType tensor, LongTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a long tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyLong (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copyLong (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copyFloat (HType tensor, FloatTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a float tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyFloat (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copyFloat (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_copyDouble (HType tensor, DoubleTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a double tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyDouble (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THDoubleTensor_copyDouble (this.handle, src.handle);
+        }
+        
     }
 
     public partial class FloatTensor : IDisposable {
@@ -9171,18 +11058,63 @@ namespace TorchSharp {
         }
         
         [DllImport ("caffe2")]
-        extern static float THFloatTensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static float THFloatTensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            THFloatTensor_randperm (handle, source.handle, n);
+            THFloatTensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static float THFloatTensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THFloatTensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static float THFloatTensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THFloatTensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static float THFloatTensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            THFloatTensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -9192,8 +11124,122 @@ namespace TorchSharp {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+
+#if false
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_bernoulli_FloatTensor (HType self, IntPtr thgenerator, HType p);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void BernoulliTensor (RandomGenerator source, FloatTensor p)
+        {
+            THFloatTensor_bernoulli_FloatTensor(this.handle, source.handle, p.handle);
+        }
+#endif
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_uniform (HType self, IntPtr thgenerator, double min, double max);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Uniform (RandomGenerator source, double min, double max)
+        {
+            THFloatTensor_uniform(this.handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_exponential (HType self, IntPtr thgenerator, double lambda);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Exponential (RandomGenerator source, double lambda)
+        {
+            THFloatTensor_exponential(this.handle, source.handle, lambda);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_cauchy (HType self, IntPtr thgenerator, double median, double sigma);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Cauchy (RandomGenerator source, double median, double sigma)
+        {
+            THFloatTensor_cauchy(this.handle, source.handle, median, sigma);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_logNormal (HType self, IntPtr thgenerator, double mean, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void LogNormal (RandomGenerator source, double mean, double stdv)
+        {
+            THFloatTensor_logNormal(this.handle, source.handle, mean, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_normal (HType self, IntPtr thgenerator, double mean, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Normal (RandomGenerator source, double mean, double stdv)
+        {
+            THFloatTensor_normal(this.handle, source.handle, mean, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_normal_means (HType self, IntPtr thgenerator, HType means, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeans (RandomGenerator source, FloatTensor means, double stdv)
+        {
+            THFloatTensor_normal_means(this.handle, source.handle, means.handle, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_normal_stddevs (HType self, IntPtr thgenerator, double mean, HType stdvs);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalStdvs (RandomGenerator source, double mean, FloatTensor stdvs)
+        {
+            THFloatTensor_normal_stddevs(this.handle, source.handle, mean, stdvs.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_normal_means_stddevs (HType self, IntPtr thgenerator, HType means, HType stdvs);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeansStdvs (RandomGenerator source, FloatTensor means, FloatTensor stdvs)
+        {
+            THFloatTensor_normal_means_stddevs(this.handle, source.handle, means.handle, stdvs.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_multinomial (HType self, IntPtr thgenerator, HType prob_dist, int n_sample, int with_replacement);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeansStdvs (RandomGenerator source, FloatTensor prob_dist, int n_sample, int with_replacement)
+        {
+            THFloatTensor_multinomial(this.handle, source.handle, prob_dist.handle, n_sample, with_replacement);
+        }
+
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -10394,6 +12440,28 @@ namespace TorchSharp {
            
             return THFloatTensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_match (HType result, HType m1, HType m2, float gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor Match (FloatTensor m2, float gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new FloatTensor ();
+            THFloatTensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
                 
         [DllImport ("caffe2")]
         extern static void THFloatTensor_cmul (HType result, HType t, HType src);
@@ -10575,6 +12643,183 @@ namespace TorchSharp {
         }
 
 
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_addcmul (HType result, HType t, float value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCMul of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor AddCMul (float value, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_addcmul (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_addcdiv (HType result, HType t, float value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddCDiv of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor AddCDiv (float value, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_addcdiv (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_addmv (HType result, float beta, HType t, float alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMV of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor AddMV (float beta, float alpha, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_addmv (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_addmm (HType result, float beta, HType t, float alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor AddMM (float beta, float alpha, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_addmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_addr (HType result, float beta, HType t, float alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddR of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor AddR (float beta, float alpha, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_addr (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_addbmm (HType result, float beta, HType t, float alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs AddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor AddBMM (float beta, float alpha, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_addbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+                
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_baddbmm (HType result, float beta, HType t, float alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs BAddBMM of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public FloatTensor BAddBMM (float beta, float alpha, FloatTensor src1, FloatTensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new FloatTensor ();
+            THFloatTensor_baddbmm (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+
  
         [DllImport ("caffe2")]
         extern static float THFloatTensor_minall (HType result);
@@ -10588,8 +12833,6 @@ namespace TorchSharp {
         {
             return THFloatTensor_minall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static float THFloatTensor_maxall (HType result);
@@ -10603,8 +12846,6 @@ namespace TorchSharp {
         {
             return THFloatTensor_maxall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static float THFloatTensor_medianall (HType result);
@@ -10618,8 +12859,6 @@ namespace TorchSharp {
         {
             return THFloatTensor_medianall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THFloatTensor_sumall (HType result);
@@ -10633,8 +12872,6 @@ namespace TorchSharp {
         {
             return THFloatTensor_sumall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THFloatTensor_prodall (HType result);
@@ -10648,8 +12885,6 @@ namespace TorchSharp {
         {
             return THFloatTensor_prodall (this.handle);
         }
-
-
  
         [DllImport ("caffe2")]
         extern static double THFloatTensor_meanall (HType result);
@@ -10663,8 +12898,6 @@ namespace TorchSharp {
         {
             return THFloatTensor_meanall (this.handle);
         }
-
-
 
 
         [DllImport ("caffe2")]
@@ -10708,6 +12941,127 @@ namespace TorchSharp {
             
             THFloatTensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copy (this.handle, src.handle);
+        }
+
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copyByte (HType tensor, ByteTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a byte tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyByte (ByteTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copyByte (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copyShort (HType tensor, ShortTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a short tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyShort (ShortTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copyShort (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copyInt (HType tensor, IntTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a int tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyInt (IntTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copyInt (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copyLong (HType tensor, LongTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a long tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyLong (LongTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copyLong (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copyFloat (HType tensor, FloatTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a float tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyFloat (FloatTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copyFloat (this.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_copyDouble (HType tensor, DoubleTensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a double tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void CopyDouble (DoubleTensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            THFloatTensor_copyDouble (this.handle, src.handle);
+        }
+        
     }
 
 }

--- a/TorchSharp/TypeGeneration.cs
+++ b/TorchSharp/TypeGeneration.cs
@@ -1263,7 +1263,9 @@ namespace TorchSharp {
 
 
 
-        [DllImport ("caffe2")]
+
+
+		[DllImport ("caffe2")]
         extern static long THByteTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -2848,7 +2850,9 @@ namespace TorchSharp {
 
 
 
-        [DllImport ("caffe2")]
+
+
+		[DllImport ("caffe2")]
         extern static long THShortTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -4433,7 +4437,9 @@ namespace TorchSharp {
 
 
 
-        [DllImport ("caffe2")]
+
+
+		[DllImport ("caffe2")]
         extern static long THIntTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -6018,7 +6024,9 @@ namespace TorchSharp {
 
 
 
-        [DllImport ("caffe2")]
+
+
+		[DllImport ("caffe2")]
         extern static long THLongTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -8161,7 +8169,40 @@ namespace TorchSharp {
 
 
 
+                
         [DllImport ("caffe2")]
+        extern static void THDoubleTensor_pow (HType result, HType x, double y);
+
+        /// <summary>
+        ///   Returns a new tensor with <see paramref="this"/> raised to the power of <see paramref="y"/>.
+        /// </summary>
+		/// <param 
+        /// <param name="y">The exponent.</param>
+        public DoubleTensor Pow (double y)
+        {
+            var result = new DoubleTensor ();
+            THDoubleTensor_pow (result.handle, this.handle, y);
+            return result;
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THDoubleTensor_tpow (HType result, double x, HType y);
+
+        /// <summary>
+        ///   Returns a new tensor with <see paramref="x"/> raised to the power of <see paramref="this"/>.
+        /// </summary>
+		/// <param 
+        /// <param name="x">The base.</param>
+        public DoubleTensor TPow (double x)
+        {
+            var result = new DoubleTensor ();
+            THDoubleTensor_tpow (result.handle, x, this.handle);
+            return result;
+        }
+
+
+
+		[DllImport ("caffe2")]
         extern static double THDoubleTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -10304,7 +10345,40 @@ namespace TorchSharp {
 
 
 
+                
         [DllImport ("caffe2")]
+        extern static void THFloatTensor_pow (HType result, HType x, float y);
+
+        /// <summary>
+        ///   Returns a new tensor with <see paramref="this"/> raised to the power of <see paramref="y"/>.
+        /// </summary>
+		/// <param 
+        /// <param name="y">The exponent.</param>
+        public FloatTensor Pow (float y)
+        {
+            var result = new FloatTensor ();
+            THFloatTensor_pow (result.handle, this.handle, y);
+            return result;
+        }
+
+        [DllImport ("caffe2")]
+        extern static void THFloatTensor_tpow (HType result, float x, HType y);
+
+        /// <summary>
+        ///   Returns a new tensor with <see paramref="x"/> raised to the power of <see paramref="this"/>.
+        /// </summary>
+		/// <param 
+        /// <param name="x">The base.</param>
+        public FloatTensor TPow (float x)
+        {
+            var result = new FloatTensor ();
+            THFloatTensor_tpow (result.handle, x, this.handle);
+            return result;
+        }
+
+
+
+		[DllImport ("caffe2")]
         extern static double THFloatTensor_dot (HType self, HType other);
         
         /// <summary>

--- a/TorchSharp/TypeGeneration.cs
+++ b/TorchSharp/TypeGeneration.cs
@@ -1312,7 +1312,7 @@ namespace TorchSharp {
 
 
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static long THByteTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -3254,7 +3254,7 @@ namespace TorchSharp {
 
 
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static long THShortTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -5196,7 +5196,7 @@ namespace TorchSharp {
 
 
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static long THIntTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -7138,7 +7138,7 @@ namespace TorchSharp {
 
 
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static long THLongTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -9755,7 +9755,7 @@ namespace TorchSharp {
         /// <summary>
         ///   Returns a new tensor with <see paramref="this"/> raised to the power of <see paramref="y"/>.
         /// </summary>
-		/// <param 
+        /// <param 
         /// <param name="y">The exponent.</param>
         public DoubleTensor Pow (double y)
         {
@@ -9770,7 +9770,7 @@ namespace TorchSharp {
         /// <summary>
         ///   Returns a new tensor with <see paramref="x"/> raised to the power of <see paramref="this"/>.
         /// </summary>
-		/// <param 
+        /// <param 
         /// <param name="x">The base.</param>
         public DoubleTensor TPow (double x)
         {
@@ -9781,7 +9781,7 @@ namespace TorchSharp {
 
 
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static double THDoubleTensor_dot (HType self, HType other);
         
         /// <summary>
@@ -12398,7 +12398,7 @@ namespace TorchSharp {
         /// <summary>
         ///   Returns a new tensor with <see paramref="this"/> raised to the power of <see paramref="y"/>.
         /// </summary>
-		/// <param 
+        /// <param 
         /// <param name="y">The exponent.</param>
         public FloatTensor Pow (float y)
         {
@@ -12413,7 +12413,7 @@ namespace TorchSharp {
         /// <summary>
         ///   Returns a new tensor with <see paramref="x"/> raised to the power of <see paramref="this"/>.
         /// </summary>
-		/// <param 
+        /// <param 
         /// <param name="x">The base.</param>
         public FloatTensor TPow (float x)
         {
@@ -12424,7 +12424,7 @@ namespace TorchSharp {
 
 
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static double THFloatTensor_dot (HType self, HType other);
         
         /// <summary>

--- a/TorchSharp/TypeGeneration.cs
+++ b/TorchSharp/TypeGeneration.cs
@@ -311,10 +311,10 @@ namespace TorchSharp {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, ByteTensor src)
         {
@@ -325,12 +325,13 @@ namespace TorchSharp {
         extern static void THByteTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, ByteTensor src)
         {
@@ -1895,10 +1896,10 @@ namespace TorchSharp {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, ShortTensor src)
         {
@@ -1909,12 +1910,13 @@ namespace TorchSharp {
         extern static void THShortTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, ShortTensor src)
         {
@@ -3479,10 +3481,10 @@ namespace TorchSharp {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, IntTensor src)
         {
@@ -3493,12 +3495,13 @@ namespace TorchSharp {
         extern static void THIntTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, IntTensor src)
         {
@@ -5063,10 +5066,10 @@ namespace TorchSharp {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, LongTensor src)
         {
@@ -5077,12 +5080,13 @@ namespace TorchSharp {
         extern static void THLongTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, LongTensor src)
         {
@@ -6647,10 +6651,10 @@ namespace TorchSharp {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, DoubleTensor src)
         {
@@ -6661,12 +6665,13 @@ namespace TorchSharp {
         extern static void THDoubleTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, DoubleTensor src)
         {
@@ -8789,10 +8794,10 @@ namespace TorchSharp {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, FloatTensor src)
         {
@@ -8803,12 +8808,13 @@ namespace TorchSharp {
         extern static void THFloatTensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, FloatTensor src)
         {

--- a/TorchSharp/TypeGeneration.tt
+++ b/TorchSharp/TypeGeneration.tt
@@ -851,7 +851,43 @@ foreach (var type in new [] {
 
 <#          } /* foreach */ } #>
 
+<#
+        // Idiom Op (Result, T, Scalar, Source2)
+            if (isFloat){
+#>                
         [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_pow (HType result, HType x, <#=ttype#> y);
+
+        /// <summary>
+        ///   Returns a new tensor with <see paramref="this"/> raised to the power of <see paramref="y"/>.
+        /// </summary>
+		/// <param 
+        /// <param name="y">The exponent.</param>
+        public <#=tname#>Tensor Pow (<#=ttype#> y)
+        {
+            var result = new <#=tname#>Tensor ();
+            TH<#=tname#>Tensor_pow (result.handle, this.handle, y);
+            return result;
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_tpow (HType result, <#=ttype#> x, HType y);
+
+        /// <summary>
+        ///   Returns a new tensor with <see paramref="x"/> raised to the power of <see paramref="this"/>.
+        /// </summary>
+		/// <param 
+        /// <param name="x">The base.</param>
+        public <#=tname#>Tensor TPow (<#=ttype#> x)
+        {
+            var result = new <#=tname#>Tensor ();
+            TH<#=tname#>Tensor_tpow (result.handle, x, this.handle);
+            return result;
+        }
+
+<#          } /* if */ #>
+
+		[DllImport ("caffe2")]
         extern static <#=accreal#> TH<#=tname#>Tensor_dot (HType self, HType other);
         
         /// <summary>

--- a/TorchSharp/TypeGeneration.tt
+++ b/TorchSharp/TypeGeneration.tt
@@ -308,6 +308,51 @@ foreach (var type in new [] {
         }
         
         [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_maskedFill (HType handle1, ByteTensor.HType handle2, <#=ttype#> value);
+        
+        /// <summary>
+        ///  Fills the tensor with the specified value at the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="value">The value to write at the indicated locations.</param>
+        public void MaskedFill (ByteTensor mask, <#=ttype#> value)
+        {
+            TH<#=tname#>Tensor_maskedFill (handle, mask.handle, value);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_maskedCopy (HType handle1, ByteTensor.HType handle2, HType src);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedCopy (ByteTensor mask, <#=tname#>Tensor src)
+        {
+            TH<#=tname#>Tensor_maskedCopy (handle, mask.handle, src.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
+        
+        /// <summary>
+        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        /// </summary>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="src">The source tensor.</param>
+        /// <remarks>
+        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        /// </remarks>
+        public void MaskedSelect (ByteTensor mask, <#=tname#>Tensor src)
+        {
+            TH<#=tname#>Tensor_maskedSelect (handle, src.handle, mask.handle);
+        }
+
+        [DllImport ("caffe2")]
         extern static <#=tname#>Storage.HType TH<#=tname#>Tensor_storage (HType handle);
 
         /// <summary>
@@ -426,6 +471,42 @@ foreach (var type in new [] {
         /// <param name="step"></param>
         public <#=tname#>Tensor Unfold (int dim, long size, long step) => new <#=tname#>Tensor (TH<#=tname#>Tensor_newUnfold (handle, dim, size, step));
         
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_squeeze (HType handle, HType src);
+        
+        /// <summary>
+        ///   Squeeze the tensor, i.e. remove all 1-sized dimensions.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze ()
+        {
+            TH<#=tname#>Tensor_squeeze (handle, handle);
+        }
+        
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_squeeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Squeeze the tensor, by removing the specified dimension.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Squeeze1d (<#=tname#>Tensor src, int dimension)
+        {
+            TH<#=tname#>Tensor_squeeze1d (handle, src.handle, dimension);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_unsqueeze1d (HType handle, HType src, int dimension);
+        
+        /// <summary>
+        ///   Unsqueeze the tensor, by inserting the specified dimension of size 1.   
+        /// </summary>
+        /// <param name="src">The source tensor which contains the data..</param>
+        public void Unsqueeze1d (<#=tname#>Tensor src, int dimension)
+        {
+            TH<#=tname#>Tensor_unsqueeze1d (handle, src.handle, dimension);
+        }
+
         [DllImport ("caffe2")]
         extern static void TH<#=tname#>Tensor_resize1d (HType handle, long size);
         

--- a/TorchSharp/TypeGeneration.tt
+++ b/TorchSharp/TypeGeneration.tt
@@ -326,10 +326,10 @@ foreach (var type in new [] {
         /// <summary>
         ///  Copies elements from the source tensor to the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the destination the value should be filled.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedCopy (ByteTensor mask, <#=tname#>Tensor src)
         {
@@ -340,12 +340,13 @@ foreach (var type in new [] {
         extern static void TH<#=tname#>Tensor_maskedSelect (HType handle1, HType src, ByteTensor.HType handle2);
         
         /// <summary>
-        ///  Copies elements from the source tensor to the locations indicated by the mask.
+        ///  Copies elements from the source tensor at the locations indicated by the mask.
         /// </summary>
-        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where the value should be filled.</param>
+        /// <param name="mask">A byte tensor with values 0 or 1 indicating the locations where in the source the value should be fetched.</param>
         /// <param name="src">The source tensor.</param>
         /// <remarks>
-        ///  There must be at least as many elements in the source tensors as there are 1s in the mask.
+        ///  There will be as many elements in the tensor as there are 1s in the mask.
+        ///  There must be at least as many elements in the source tensor as there are 1s in the mask.
         /// </remarks>
         public void MaskedSelect (ByteTensor mask, <#=tname#>Tensor src)
         {

--- a/TorchSharp/TypeGeneration.tt
+++ b/TorchSharp/TypeGeneration.tt
@@ -733,7 +733,7 @@ foreach (var type in new [] {
 
 <#
         // Float-specific random distributions.
-            if (isFloat){                    
+            if (isFloat) {                    
 #>
 #if false
         [DllImport ("caffe2")]
@@ -1023,7 +1023,7 @@ foreach (var type in new [] {
         /// <summary>
         ///   Returns a new tensor with <see paramref="this"/> raised to the power of <see paramref="y"/>.
         /// </summary>
-		/// <param 
+        /// <param 
         /// <param name="y">The exponent.</param>
         public <#=tname#>Tensor Pow (<#=ttype#> y)
         {
@@ -1038,7 +1038,7 @@ foreach (var type in new [] {
         /// <summary>
         ///   Returns a new tensor with <see paramref="x"/> raised to the power of <see paramref="this"/>.
         /// </summary>
-		/// <param 
+        /// <param 
         /// <param name="x">The base.</param>
         public <#=tname#>Tensor TPow (<#=ttype#> x)
         {
@@ -1049,7 +1049,7 @@ foreach (var type in new [] {
 
 <#          } /* if */ #>
 
-		[DllImport ("caffe2")]
+        [DllImport ("caffe2")]
         extern static <#=accreal#> TH<#=tname#>Tensor_dot (HType self, HType other);
         
         /// <summary>

--- a/TorchSharp/TypeGeneration.tt
+++ b/TorchSharp/TypeGeneration.tt
@@ -662,18 +662,63 @@ foreach (var type in new [] {
         }
         
         [DllImport ("caffe2")]
-        extern static <#=ttype#> TH<#=tname#>Tensor_randperm (HType handle, IntPtr thgenerator, long n);
+        extern static <#=ttype#> TH<#=tname#>Tensor_random (HType handle, IntPtr thgenerator);
         
         /// <summary>
         ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
         /// </summary>
         /// <param name="source">The random generator source</param>
         /// <param name="n">The upper limit for the values to be generated</param>
-        public void Random (RandomGenerator source, long n)
+        public void Random (RandomGenerator source)
         {
             if (source == null)
                 throw new ArgumentNullException (nameof (source));
-            TH<#=tname#>Tensor_randperm (handle, source.handle, n);
+            TH<#=tname#>Tensor_random (handle, source.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static <#=ttype#> TH<#=tname#>Tensor_clampedRandom (HType handle, IntPtr thgenerator, long min, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void ClampedRandom (RandomGenerator source, long min, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            TH<#=tname#>Tensor_clampedRandom (handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static <#=ttype#> TH<#=tname#>Tensor_cappedRandom (HType handle, IntPtr thgenerator, long max);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void CappedRandom (RandomGenerator source, long max)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            TH<#=tname#>Tensor_cappedRandom (handle, source.handle, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static <#=ttype#> TH<#=tname#>Tensor_geometric (HType handle, IntPtr thgenerator, double p);
+        
+        /// <summary>
+        ///  Populates the tensor with random values from 0 to n, using the provided random source generator.
+        /// </summary>
+        /// <param name="source">The random generator source</param>
+        /// <param name="n">The upper limit for the values to be generated</param>
+        public void Geometric (RandomGenerator source, double p)
+        {
+            if (source == null)
+                throw new ArgumentNullException (nameof (source));
+            TH<#=tname#>Tensor_geometric (handle, source.handle, p);
         }
         
         /// <summary>
@@ -683,8 +728,125 @@ foreach (var type in new [] {
         public void Random (long n)
         {
             using (var r = new RandomGenerator ())
-                Random (r, n);
+                CappedRandom (r, n);
         }
+
+<#
+        // Float-specific random distributions.
+            if (isFloat){                    
+#>
+#if false
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_bernoulli_<#=tname#>Tensor (HType self, IntPtr thgenerator, HType p);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void BernoulliTensor (RandomGenerator source, <#=tname#>Tensor p)
+        {
+            TH<#=tname#>Tensor_bernoulli_<#=tname#>Tensor(this.handle, source.handle, p.handle);
+        }
+#endif
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_uniform (HType self, IntPtr thgenerator, double min, double max);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Uniform (RandomGenerator source, double min, double max)
+        {
+            TH<#=tname#>Tensor_uniform(this.handle, source.handle, min, max);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_exponential (HType self, IntPtr thgenerator, double lambda);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Exponential (RandomGenerator source, double lambda)
+        {
+            TH<#=tname#>Tensor_exponential(this.handle, source.handle, lambda);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_cauchy (HType self, IntPtr thgenerator, double median, double sigma);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Cauchy (RandomGenerator source, double median, double sigma)
+        {
+            TH<#=tname#>Tensor_cauchy(this.handle, source.handle, median, sigma);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_logNormal (HType self, IntPtr thgenerator, double mean, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void LogNormal (RandomGenerator source, double mean, double stdv)
+        {
+            TH<#=tname#>Tensor_logNormal(this.handle, source.handle, mean, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_normal (HType self, IntPtr thgenerator, double mean, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void Normal (RandomGenerator source, double mean, double stdv)
+        {
+            TH<#=tname#>Tensor_normal(this.handle, source.handle, mean, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_normal_means (HType self, IntPtr thgenerator, HType means, double stdv);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeans (RandomGenerator source, <#=tname#>Tensor means, double stdv)
+        {
+            TH<#=tname#>Tensor_normal_means(this.handle, source.handle, means.handle, stdv);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_normal_stddevs (HType self, IntPtr thgenerator, double mean, HType stdvs);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalStdvs (RandomGenerator source, double mean, <#=tname#>Tensor stdvs)
+        {
+            TH<#=tname#>Tensor_normal_stddevs(this.handle, source.handle, mean, stdvs.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_normal_means_stddevs (HType self, IntPtr thgenerator, HType means, HType stdvs);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeansStdvs (RandomGenerator source, <#=tname#>Tensor means, <#=tname#>Tensor stdvs)
+        {
+            TH<#=tname#>Tensor_normal_means_stddevs(this.handle, source.handle, means.handle, stdvs.handle);
+        }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_multinomial (HType self, IntPtr thgenerator, HType prob_dist, int n_sample, int with_replacement);
+
+        /// <summary>
+        ///   Returns a debuggable version of the tensor, in this case the tensor shape
+        /// </summary>
+        public void NormalMeansStdvs (RandomGenerator source, <#=tname#>Tensor prob_dist, int n_sample, int with_replacement)
+        {
+            TH<#=tname#>Tensor_multinomial(this.handle, source.handle, prob_dist.handle, n_sample, with_replacement);
+        }
+<#          } /* if */ #>
         
         /// <summary>
         ///   Returns a debuggable version of the tensor, in this case the tensor shape
@@ -903,6 +1065,28 @@ foreach (var type in new [] {
            
             return TH<#=tname#>Tensor_dot (this.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_match (HType result, HType m1, HType m2, <#=ttype#> gain);
+        
+        /// <summary>
+        ///   
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public <#=tname#>Tensor Match (<#=tname#>Tensor m2, <#=ttype#> gain)
+        {
+            if (m2 == null)
+                throw new ArgumentNullException (nameof (m2));
+            var result = new <#=tname#>Tensor ();
+            TH<#=tname#>Tensor_match (result.handle, this.handle, m2.handle, gain);
+            return result;
+        }
+
 <#
         // Idiom Op (Result, Tensor, Tensor 
         
@@ -942,6 +1126,81 @@ foreach (var type in new [] {
 
 <#          } /* foreach */ #>
 <#
+        // Idiom Op (Result, Tensor, Scalar, Tensor, Tensor)
+        
+            foreach (var opdoc in new [] { 
+                new { Name="AddCMul", Doc="" },
+                new { Name="AddCDiv", Doc="" },
+                }){
+                var op = opdoc.Name;
+                var doc = opdoc.Doc;
+            
+#>                
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_<#=op.ToLower()#> (HType result, HType t, <#=ttype#> value, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs <#=op#> of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public <#=tname#>Tensor <#=op#> (<#=ttype#> value, <#=tname#>Tensor src1, <#=tname#>Tensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new <#=tname#>Tensor ();
+            TH<#=tname#>Tensor_<#=op.ToLower()#> (result.handle, this.handle, value, src1.handle, src2.handle);
+            return result;
+        }
+
+<#          } /* foreach */ #>
+<#
+        // Idiom Op (Result, Scalar, Tensor, Scalar, Tensor, Tensor)
+        
+            foreach (var opdoc in new [] { 
+                new { Name="AddMV", Doc="" },
+                new { Name="AddMM", Doc="" },
+                new { Name="AddR", Doc="" },
+                new { Name="AddBMM", Doc="" },
+                new { Name="BAddBMM", Doc="" },
+                }){
+                var op = opdoc.Name;
+                var doc = opdoc.Doc;
+            
+#>                
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_<#=op.ToLower()#> (HType result, <#=ttype#> beta, HType t, <#=ttype#> alpha, HType src1, HType src2);
+        
+        /// <summary>
+        ///   Performs <#=op#> of the tensor with the provided 
+        ///   <see paramref="src1"/> and <see paramref="src1"/> tensors and returns a new tensor with the result.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="src1"></param>
+        /// <param name="src2"></param>
+        /// <returns>
+        ///   This returns a new tensor with the same shape as the tensor this operates on.
+        /// </returns>
+        public <#=tname#>Tensor <#=op#> (<#=ttype#> beta, <#=ttype#> alpha, <#=tname#>Tensor src1, <#=tname#>Tensor src2)
+        {
+            if (src1 == null)
+                throw new ArgumentNullException (nameof (src1));
+            if (src2 == null)
+                throw new ArgumentNullException (nameof (src2));
+            var result = new <#=tname#>Tensor ();
+            TH<#=tname#>Tensor_<#=op.ToLower()#> (result.handle, beta, this.handle, alpha, src1.handle, src2.handle);
+            return result;
+        }
+
+<#          } /* foreach */ #>
+<#
         // Idiom Op (Result, Tensor, Tensor 
         
             foreach (var opdoc in new [] { 
@@ -968,8 +1227,6 @@ foreach (var type in new [] {
         {
             return TH<#=tname#>Tensor_<#=op.ToLower()#> (this.handle);
         }
-
-
 <#          } /* foreach */ #>
 
         [DllImport ("caffe2")]
@@ -1013,6 +1270,44 @@ foreach (var type in new [] {
             
             TH<#=tname#>Tensor_indexCopy (handle, dim, index.handle, src.handle);
         }
+
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_copy (HType tensor, HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy (<#=tname#>Tensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            TH<#=tname#>Tensor_copy (this.handle, src.handle);
+        }
+
+<#
+        foreach (var srcType in new string [] { "Byte", "Short", "Int", "Long", "Float", "Double" }) {
+#>
+        [DllImport ("caffe2")]
+        extern static void TH<#=tname#>Tensor_copy<#=srcType#> (HType tensor, <#=srcType#>Tensor.HType src);
+        
+        /// <summary>
+        ///   Copies the elements of a <#=srcType.ToLower()#> tensor into the original tensor. 
+        ///   The shape of the tensors must exactly match or an error will be thrown.
+        /// </summary>
+        /// <param name="dim">Dimension to select for the copy</param>
+        /// <param name="index">Entries to copy</param>
+        /// <param name="src">Tensor to copy the data from.</param>
+        public void Copy<#=srcType#> (<#=srcType#>Tensor src)
+        {
+            if (src == null)
+                throw new ArgumentNullException (nameof (src));
+            TH<#=tname#>Tensor_copy<#=srcType#> (this.handle, src.handle);
+        }
+<#          } /* foreach */ #>        
     }
 <#
 }


### PR DESCRIPTION
Here's a question of mine: should the 'Masked' prefix be there for MaskedFill/Copy/Select, or is a shorter name better and let overloading take care of the disambiguation? If this is meant as a low-level API with high fidelity to the C interface, then I think they should be present, otherwise I would argue for letting overloading take care of it.

