### PR TITLE
bugfix: FloatTensor.Random() takes only one parameter

### DIFF
--- a/Tester/Program.cs
+++ b/Tester/Program.cs
@@ -15,7 +15,7 @@ class MainClass {
 		var b = new FloatTensor (10);
 		b.Fill (30);
 		Dump (b);
-		x.Random (new RandomGenerator (), 10);
+		x.Random (new RandomGenerator ());
 		FloatTensor.Add (x, 100, b);
 		Dump (x);
 		Dump (b);


### PR DESCRIPTION
Fix `Tester/Program.cs`: `FloatTensor.Random()` method takes only one parameter

Closes #36 
