### PR TITLE
Fix Torch 1.5.0 Bool/Byte tensor support and add other functionality

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,7 +70,7 @@
   <PropertyGroup>
      
     <VersionPrefix >$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>local-$(Configuration)-$([System.DateTime]::Now.ToString(yyyyMMdd))</VersionSuffix>
 
     <VersionSuffix Condition="'$(TF_BUILD)' != ''">$([System.String]::Copy('$(BUILD_BUILDNUMBER)').Replace('.',''))</VersionSuffix>
     <VersionSuffix Condition="'$(TF_BUILD)' != '' AND '$(BUILD_SOURCEBRANCHNAME)' != 'master'">preview-$(VersionSuffix)-$(BUILD_SOURCEBRANCHNAME)</VersionSuffix>

--- a/README.md
+++ b/README.md
@@ -101,7 +101,21 @@ Commands:
 Building packages
 ------------------------
 
-The managed package can be built with `dotnet pack`
+The managed package can be built with `dotnet pack`, e.g.
+
+    dotnet pack /p:SkipCuda=true
+
+Locally built packages have names like this, names update every day.  If repeatedly rebuilding them locally you may have to remove them
+from your local `.nuget` package cache.
+
+    bin/packages/Debug/LibTorch.Cuda.10.2.Redist.0.3.0-local-Debug-20200520.nupkg
+    bin/packages/Debug/LibTorch.Redist.0.3.0-local-Debug-20200520.nupkg
+    bin/packages/Debug/TorchSharp.Redist.0.3.0-local-Debug-20200520.nupkg
+
+    bin/packages/Release/LibTorch.Cuda.10.2.Redist.0.3.0-local-Release-20200520.nupkg
+    bin/packages/Release/LibTorch.Redist.0.3.0-local-Release-20200520.nupkg
+    bin/packages/Release/TorchSharp.Redist.0.3.0-local-Release-20200520.nupkg
+
 
 Complete LibTorch.Redist packages can't be built using your local machine alone, since they won't contain the
 full range of native bits. Instead they are built using Azure Pipelines.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ jobs:
     displayName: 'NuGet push'
     inputs:
       command: push
-      publishVstsFeed: 'TorchSharp/packages'
+      publishVstsFeed: 'TorchSharp/packages2'
       allowPackageConflicts: true
 
   # Terminate all dotnet build processes.

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -1355,3 +1355,19 @@ Tensor THSTensor_conv3d(
             groups));
 }
 
+Tensor THSTensor_gather(
+    const Tensor tensor,
+    const int64_t dimension,
+    const Tensor index)
+{
+    CATCH_TENSOR(torch::gather(*tensor, dimension, *index));
+}
+
+Tensor THSTensor_scatter(
+    const Tensor tensor,
+    const int64_t dimension,
+    const Tensor index,
+    const Tensor source)
+{
+    CATCH_TENSOR(torch::scatter(*tensor, dimension, *index, *source));
+}

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -109,6 +109,22 @@ Tensor THSTensor_newByteScalar(char data, bool requires_grad)
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
+Tensor THSTensor_newBoolScalar(bool  data, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Bool))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
+Tensor THSTensor_newHalfScalar(c10::Half data, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Half))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
 Tensor THSTensor_newShortScalar(short data, bool requires_grad)
 {
     auto options = at::TensorOptions()
@@ -1114,6 +1130,30 @@ Tensor THSTensor_maxpool1d(
         ceil_mode));
 }
 
+void THSTensor_maxpool1d_with_indices(
+    const Tensor tensor,
+    Tensor* (*allocator)(size_t length),
+    const int64_t* kernelSize, const int kernelSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength,
+    const int64_t* dilation, const int dilationLength,
+    bool ceil_mode)
+{
+    CATCH (
+        auto res = torch::max_pool1d_with_indices(
+            *tensor,
+            at::ArrayRef<int64_t>(kernelSize, kernelSizeLength),
+            at::ArrayRef<int64_t>(stride, strideLength),
+            at::ArrayRef<int64_t>(padding, paddingLength),
+            at::ArrayRef<int64_t>(dilation, dilationLength),
+            ceil_mode);
+    
+        Tensor* result = allocator(2);
+        result[0] = new torch::Tensor(std::get<0>(res));
+        result[1] = new torch::Tensor(std::get<1>(res));
+    )
+}
+
 Tensor THSTensor_maxpool2d(
     const Tensor tensor,
     const int64_t* kernelSize, const int kernelSizeLength,
@@ -1125,7 +1165,32 @@ Tensor THSTensor_maxpool2d(
     CATCH_TENSOR(torch::max_pool2d(
         *tensor, 
         at::ArrayRef<int64_t>(kernelSize, kernelSizeLength),
-        at::ArrayRef<int64_t>(stride, strideLength)));
+        at::ArrayRef<int64_t>(stride, strideLength),
+        at::ArrayRef<int64_t>(padding, paddingLength),
+        at::ArrayRef<int64_t>(dilation, dilationLength)));
+}
+
+void THSTensor_maxpool2d_with_indices(
+    const Tensor tensor,
+    Tensor* (*allocator)(size_t length),
+    const int64_t* kernelSize, const int kernelSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength,
+    const int64_t* dilation, const int dilationLength,
+    bool ceil_mode)
+{
+    CATCH(
+        auto res = torch::max_pool2d_with_indices(
+            *tensor,
+            at::ArrayRef<int64_t>(kernelSize, kernelSizeLength),
+            at::ArrayRef<int64_t>(stride, strideLength),
+            at::ArrayRef<int64_t>(padding, paddingLength),
+            at::ArrayRef<int64_t>(dilation, dilationLength),
+            ceil_mode);
+        Tensor* result = allocator(2);
+        result[0] = new torch::Tensor(std::get<0>(res));
+        result[1] = new torch::Tensor(std::get<1>(res));
+    )
 }
 
 Tensor THSTensor_maxpool3d(
@@ -1145,6 +1210,54 @@ Tensor THSTensor_maxpool3d(
             ceil_mode));
 }
 
+void THSTensor_maxpool3d_with_indices(
+    const Tensor tensor,
+    Tensor* (*allocator)(size_t length),
+    const int64_t* kernelSize, const int kernelSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength,
+    const int64_t* dilation, const int dilationLength,
+    bool ceil_mode)
+{
+    CATCH(
+        auto res = torch::max_pool3d_with_indices(
+            *tensor,
+            at::ArrayRef<int64_t>(kernelSize, kernelSizeLength),
+            at::ArrayRef<int64_t>(stride, strideLength),
+            at::ArrayRef<int64_t>(padding, paddingLength),
+            at::ArrayRef<int64_t>(dilation, dilationLength),
+            ceil_mode);
+        Tensor* result = allocator(2);
+        result[0] = new torch::Tensor(std::get<0>(res));
+        result[1] = new torch::Tensor(std::get<1>(res));
+    )
+}
+
+Tensor THSTensor_maxunpool2d(
+    const Tensor tensor,
+    const Tensor indices,
+    const int64_t* outputSize, const int outputSizeLength)
+{
+    CATCH_TENSOR(torch::max_unpool2d(
+        *tensor,
+        *indices,
+        at::ArrayRef<int64_t>(outputSize, outputSizeLength)));
+}
+
+Tensor THSTensor_maxunpool3d(
+    const Tensor tensor,
+    const Tensor indices,
+    const int64_t* outputSize, const int outputSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength)
+{
+    CATCH_TENSOR(torch::max_unpool3d(
+        *tensor,
+        *indices,
+        at::ArrayRef<int64_t>(outputSize, outputSizeLength),
+        at::ArrayRef<int64_t>(stride, strideLength),
+        at::ArrayRef<int64_t>(padding, paddingLength)));
+}
 
 Tensor THSTensor_conv_transpose1d(
     const Tensor input, const Tensor weight, const Tensor bias,

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -707,4 +707,13 @@ EXPORT_API(Tensor) THSTensor_maxunpool3d(
     const int64_t* stride, const int strideLength,
     const int64_t* padding, const int paddingLength);
 
+EXPORT_API(Tensor) THSTensor_gather(
+    const Tensor tensor,
+    const int64_t dimension,
+    const Tensor index);
 
+EXPORT_API(Tensor) THSTensor_scatter(
+    const Tensor tensor,
+    const int64_t dimension,
+    const Tensor index,
+    const Tensor source);

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -67,6 +67,12 @@ EXPORT_API(Tensor) THSTensor_newSByteScalar(int8_t data, bool requires_grad);
 EXPORT_API(Tensor) THSTensor_newByteScalar(char data, bool requires_grad);
 
 //  Creates  a variable tensor wrapping the input scalar.
+EXPORT_API(Tensor) THSTensor_newBoolScalar(bool data, bool requires_grad);
+
+//  Creates  a variable tensor wrapping the input scalar.
+EXPORT_API(Tensor) THSTensor_newHalfScalar(c10::Half data, bool requires_grad);
+
+//  Creates  a variable tensor wrapping the input scalar.
 EXPORT_API(Tensor) THSTensor_newShortScalar(short data, bool requires_grad);
 
 //  Creates  a variable tensor wrapping the input scalar.
@@ -660,7 +666,45 @@ EXPORT_API(Tensor) THSTensor_maxpool3d(
     const int64_t* dilation, const int dilationLength,
     bool ceil_mode);
 
+EXPORT_API(void) THSTensor_maxpool1d_with_indices(
+    const Tensor tensor,
+    Tensor* (*allocator)(size_t length),
+    const int64_t* kernelSize, const int kernelSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength,
+    const int64_t* dilation, const int dilationLength,
+    bool ceil_mode);
+
+EXPORT_API(void) THSTensor_maxpool2d_with_indices(
+    const Tensor tensor,
+    Tensor* (*allocator)(size_t length),
+    const int64_t* kernelSize, const int kernelSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength,
+    const int64_t* dilation, const int dilationLength,
+    bool ceil_mode);
+
+EXPORT_API(void) THSTensor_maxpool3d_with_indices(
+    const Tensor tensor,
+    Tensor* (*allocator)(size_t length),
+    const int64_t* kernelSize, const int kernelSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength,
+    const int64_t* dilation, const int dilationLength,
+    bool ceil_mode);
 
 
+EXPORT_API(Tensor) THSTensor_maxunpool2d(
+    const Tensor tensor,
+    const Tensor indices,
+    const int64_t* outputSize, const int outputSizeLength);
+
+
+EXPORT_API(Tensor) THSTensor_maxunpool3d(
+    const Tensor tensor,
+    const Tensor indices,
+    const int64_t* outputSize, const int outputSizeLength,
+    const int64_t* stride, const int strideLength,
+    const int64_t* padding, const int paddingLength);
 
 

--- a/src/Native/LibTorchSharp/THSTorch.cpp
+++ b/src/Native/LibTorchSharp/THSTorch.cpp
@@ -20,40 +20,60 @@ const char * THSTorch_get_and_reset_last_err()
     return tmp;
 }
 
-Scalar THSTorch_sbtos(int8_t value)
+Scalar THSTorch_int8_to_scalar(int8_t value)
 {
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_btos(uint8_t value)
+Scalar THSTorch_uint8_to_scalar(uint8_t value)
 {
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_stos(short value)
+Scalar THSTorch_short_to_scalar(short value)
 {
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_itos(int value)
+Scalar THSTorch_int32_to_scalar(int value)
 {
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_ltos(long value)
+Scalar THSTorch_long_to_scalar(long value)
 {
     return new torch::Scalar(int64_t(value));
 }
 
-Scalar THSTorch_ftos(float value)
+Scalar THSTorch_float32_to_scalar(float value)
 {
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_dtos(double value)
+Scalar THSTorch_float64_to_scalar(double value)
 {
     return new torch::Scalar(value);
 }
+
+Scalar THSTorch_half_to_scalar(c10::Half value)
+{
+    return new torch::Scalar(value);
+}
+
+Scalar THSTorch_bool_to_scalar(bool value)
+{
+    return new torch::Scalar(value);
+}
+
+//Scalar THSTorch_complex32_to_scalar(std::complex<float> value)
+//{
+//    return new torch::Scalar(value);
+//}
+//
+//Scalar THSTorch_complex64_to_scalar(std::complex<double> value)
+//{
+//    return new torch::Scalar(value);
+//}
 
 void THSThorch_dispose_scalar(Scalar scalar)
 {

--- a/src/Native/LibTorchSharp/THSTorch.h
+++ b/src/Native/LibTorchSharp/THSTorch.h
@@ -16,26 +16,17 @@ EXPORT_API(int) THSTorch_isCudaAvailable();
 // Returns the latest error. This is thread-local.
 EXPORT_API(const char *) THSTorch_get_and_reset_last_err();
 
-// Returns a Scalar object from a char value.
-EXPORT_API(Scalar) THSTorch_sbtos(int8_t value);
-
-// Returns a Scalar object from a byte value.
-EXPORT_API(Scalar) THSTorch_btos(uint8_t value);
-
-// Returns a Scalar object from a short value.
-EXPORT_API(Scalar) THSTorch_stos(short value);
-
-// Returns a Scalar object from an int value.
-EXPORT_API(Scalar) THSTorch_itos(int value);
-
-// Returns a Scalar object from a long value.
-EXPORT_API(Scalar) THSTorch_ltos(long value);
-
-// Returns a Scalar object from a float value.
-EXPORT_API(Scalar) THSTorch_ftos(float value);
-
-// Returns a Scalar object from a double value.
-EXPORT_API(Scalar) THSTorch_dtos(double value);
+EXPORT_API(Scalar) THSTorch_int8_to_scalar(int8_t value);
+EXPORT_API(Scalar) THSTorch_uint8_to_scalar(uint8_t value);
+EXPORT_API(Scalar) THSTorch_short_to_scalar(short value);
+EXPORT_API(Scalar) THSTorch_int32_to_scalar(int value);
+EXPORT_API(Scalar) THSTorch_long_to_scalar(long value);
+EXPORT_API(Scalar) THSTorch_float32_to_scalar(float value);
+EXPORT_API(Scalar) THSTorch_float64_to_scalar(double value);
+EXPORT_API(Scalar) THSTorch_bool_to_scalar(bool value);
+EXPORT_API(Scalar) THSTorch_half_to_scalar(c10::Half value);
+//EXPORT_API(Scalar) THSTorch_complex32_to_scalar(std::complex<float> value);
+//EXPORT_API(Scalar) THSTorch_complex64_to_scalar(std::complex<double> value);
 
 // Dispose the scalar.
 EXPORT_API(void) THSThorch_dispose_scalar(Scalar scalar);

--- a/src/TorchSharp/JIT/Type/TensorType.cs
+++ b/src/TorchSharp/JIT/Type/TensorType.cs
@@ -21,9 +21,9 @@
 //        [DllImport("LibTorchSharp")]
 //        private static extern short THSJIT_getScalarFromDimensionedTensorType(HType handle);
 
-//        public Tensor.ATenScalarMapping GetScalarType()
+//        public Tensor.ScalarType GetScalarType()
 //        {
-//            return (Tensor.ATenScalarMapping)THSJIT_getScalarFromDimensionedTensorType(handle);
+//            return (Tensor.ScalarType)THSJIT_getScalarFromDimensionedTensorType(handle);
 //        }
 
 //        [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/PinnedArray.cs
+++ b/src/TorchSharp/PinnedArray.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
 
@@ -56,9 +56,12 @@ internal sealed class PinnedArray<T> : IDisposable where T : struct
 
     public void Dispose()
     {
-        foreach (var val in Array)
+        if (Array != null)
         {
-            (val as IDisposable)?.Dispose();
+            foreach (var val in Array)
+            {
+                (val as IDisposable)?.Dispose();
+            }
         }
         FreeHandle();
     }

--- a/src/TorchSharp/Scalar.cs
+++ b/src/TorchSharp/Scalar.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
 
@@ -48,6 +48,20 @@ namespace TorchSharp
             return value.ToScalar();
         }
 
+        public static implicit operator Scalar(Half value)
+        {
+            return value.ToScalar();
+        }
+
+        public static implicit operator Scalar(System.Numerics.Complex value)
+        {
+            return value.ToScalar();
+        }
+
+        public static implicit operator Scalar(bool value)
+        {
+            return value.ToScalar();
+        }
         /// <summary>
         ///   Releases the storage.
         /// </summary>
@@ -76,59 +90,88 @@ namespace TorchSharp
     public static class ScalarExtensionMethods
     {
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_btos(byte hanvaluedle);
+        extern static IntPtr THSTorch_uint8_to_scalar(byte value);
 
         public static Scalar ToScalar(this byte value)
         {
-            return new Scalar(THSTorch_btos(value));
+            return new Scalar(THSTorch_uint8_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_sbtos(sbyte hanvaluedle);
+        extern static IntPtr THSTorch_int8_to_scalar(sbyte value);
 
         public static Scalar ToScalar(this sbyte value)
         {
-            return new Scalar(THSTorch_sbtos(value));
+            return new Scalar(THSTorch_int8_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_stos(short hanvaluedle);
+        extern static IntPtr THSTorch_short_to_scalar(short value);
 
         public static Scalar ToScalar(this short value)
         {
-            return new Scalar(THSTorch_stos(value));
+            return new Scalar(THSTorch_short_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_itos(int hanvaluedle);
+        extern static IntPtr THSTorch_int32_to_scalar(int value);
 
         public static Scalar ToScalar(this int value)
         {
-            return new Scalar(THSTorch_itos(value));
+            return new Scalar(THSTorch_int32_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_ltos(long hanvaluedle);
+        extern static IntPtr THSTorch_long_to_scalar(long value);
 
         public static Scalar ToScalar(this long value)
         {
-            return new Scalar(THSTorch_ltos(value));
+            return new Scalar(THSTorch_long_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_ftos(float hanvaluedle);
+        extern static IntPtr THSTorch_float32_to_scalar(float value);
 
         public static Scalar ToScalar(this float value)
         {
-            return new Scalar(THSTorch_ftos(value));
+            return new Scalar(THSTorch_float32_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_dtos(double hanvaluedle);
+        extern static IntPtr THSTorch_float64_to_scalar(double value);
 
         public static Scalar ToScalar(this double value)
         {
-            return new Scalar(THSTorch_dtos(value));
+            return new Scalar(THSTorch_float64_to_scalar(value));
+        }
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTorch_bool_to_scalar(bool value);
+
+        public static Scalar ToScalar(this bool value)
+        {
+            return new Scalar(THSTorch_bool_to_scalar(value));
+        }
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTorch_half_to_scalar(Half value);
+
+        public static Scalar ToScalar(this Half value)
+        {
+            return new Scalar(THSTorch_half_to_scalar(value));
+        }
+        //[DllImport("LibTorchSharp")]
+        //extern static IntPtr THSTorch_complex32_to_scalar(System.Numerics.Complex value);
+
+        //public static Scalar ToScalar(this System.Numerics.Complex value)
+        //{
+        //    return new Scalar(THSTorch_complex32_to_scalar(value));
+        //}
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTorch_complex64_to_scalar(System.Numerics.Complex value);
+
+        public static Scalar ToScalar(this System.Numerics.Complex value)
+        {
+            return new Scalar(THSTorch_complex64_to_scalar(value));
         }
     }
 }

--- a/src/TorchSharp/Tensor/Half.cs
+++ b/src/TorchSharp/Tensor/Half.cs
@@ -1,0 +1,1031 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace TorchSharp
+{
+    /// <summary>
+    /// Represents a half-precision floating point number. 
+    /// </summary>
+    /// <remarks>
+    /// Note:
+    ///     Half is not fast enought and precision is also very bad, 
+    ///     so is should not be used for mathematical computation (use Single instead).
+    ///     The main advantage of Half type is lower memory cost: two bytes per number. 
+    ///     Half is typically used in graphical applications.
+    ///     
+    /// Note: 
+    ///     All functions, where is used conversion half->float/float->half, 
+    ///     are approx. ten times slower than float->double/double->float, i.e. ~3ns on 2GHz CPU.
+    ///
+    /// References:
+    ///     - Code retrieved from http://sourceforge.net/p/csharp-half/code/HEAD/tree/ on 2015-12-04
+    ///     - Fast Half Float Conversions, Jeroen van der Zijp, link: http://www.fox-toolkit.org/ftp/fasthalffloatconversion.pdf
+    ///     - IEEE 754 revision, link: http://grouper.ieee.org/groups/754/
+    /// </remarks>
+    [Serializable]
+    public struct Half : IComparable, IFormattable, IConvertible, IComparable<Half>, IEquatable<Half>
+    {
+        /// <summary>
+        /// Internal representation of the half-precision floating-point number.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal ushort Value;
+
+        #region Constants
+        /// <summary>
+        /// Represents the smallest positive System.Half value greater than zero. This field is constant.
+        /// </summary>
+        public static readonly Half Epsilon = ToHalf(0x0001);
+        /// <summary>
+        /// Represents the largest possible value of System.Half. This field is constant.
+        /// </summary>
+        public static readonly Half MaxValue = ToHalf(0x7bff);
+        /// <summary>
+        /// Represents the smallest possible value of System.Half. This field is constant.
+        /// </summary>
+        public static readonly Half MinValue = ToHalf(0xfbff);
+        /// <summary>
+        /// Represents not a number (NaN). This field is constant.
+        /// </summary>
+        public static readonly Half NaN = ToHalf(0xfe00);
+        /// <summary>
+        /// Represents negative infinity. This field is constant.
+        /// </summary>
+        public static readonly Half NegativeInfinity = ToHalf(0xfc00);
+        /// <summary>
+        /// Represents positive infinity. This field is constant.
+        /// </summary>
+        public static readonly Half PositiveInfinity = ToHalf(0x7c00);
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified single-precision floating-point number.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(float value) { this = HalfHelper.SingleToHalf(value); }
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified 32-bit signed integer.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(int value) : this((float)value) { }
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified 64-bit signed integer.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(long value) : this((float)value) { }
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified double-precision floating-point number.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(double value) : this((float)value) { }
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified decimal number.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(decimal value) : this((float)value) { }
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified 32-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(uint value) : this((float)value) { }
+        /// <summary>
+        /// Initializes a new instance of System.Half to the value of the specified 64-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">The value to represent as a System.Half.</param>
+        public Half(ulong value) : this((float)value) { }
+        #endregion
+
+        #region Numeric operators
+
+        /// <summary>
+        /// Returns the result of multiplying the specified System.Half value by negative one.
+        /// </summary>
+        /// <param name="half">A System.Half.</param>
+        /// <returns>A System.Half with the value of half, but the opposite sign. -or- Zero, if half is zero.</returns>
+        public static Half Negate(Half half) { return -half; }
+        /// <summary>
+        /// Adds two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>A System.Half value that is the sum of half1 and half2.</returns>
+        public static Half Add(Half half1, Half half2) { return half1 + half2; }
+        /// <summary>
+        /// Subtracts one specified System.Half value from another.
+        /// </summary>
+        /// <param name="half1">A System.Half (the minuend).</param>
+        /// <param name="half2">A System.Half (the subtrahend).</param>
+        /// <returns>The System.Half result of subtracting half2 from half1.</returns>
+        public static Half Subtract(Half half1, Half half2) { return half1 - half2; }
+        /// <summary>
+        /// Multiplies two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half (the multiplicand).</param>
+        /// <param name="half2">A System.Half (the multiplier).</param>
+        /// <returns>A System.Half that is the result of multiplying half1 and half2.</returns>
+        public static Half Multiply(Half half1, Half half2) { return half1 * half2; }
+        /// <summary>
+        /// Divides two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half (the dividend).</param>
+        /// <param name="half2">A System.Half (the divisor).</param>
+        /// <returns>The System.Half that is the result of dividing half1 by half2.</returns>
+        /// <exception cref="System.DivideByZeroException">half2 is zero.</exception>
+        public static Half Divide(Half half1, Half half2) { return half1 / half2; }
+
+        /// <summary>
+        /// Returns the value of the System.Half operand (the sign of the operand is unchanged).
+        /// </summary>
+        /// <param name="half">The System.Half operand.</param>
+        /// <returns>The value of the operand, half.</returns>
+        public static Half operator +(Half half) { return half; }
+        /// <summary>
+        /// Negates the value of the specified System.Half operand.
+        /// </summary>
+        /// <param name="half">The System.Half operand.</param>
+        /// <returns>The result of half multiplied by negative one (-1).</returns>
+        public static Half operator -(Half half) { return HalfHelper.Negate(half); }
+        /// <summary>
+        /// Increments the System.Half operand by 1.
+        /// </summary>
+        /// <param name="half">The System.Half operand.</param>
+        /// <returns>The value of half incremented by 1.</returns>
+        public static Half operator ++(Half half) { return (Half)(half + 1f); }
+        /// <summary>
+        /// Decrements the System.Half operand by one.
+        /// </summary>
+        /// <param name="half">The System.Half operand.</param>
+        /// <returns>The value of half decremented by 1.</returns>
+        public static Half operator --(Half half) { return (Half)(half - 1f); }
+        /// <summary>
+        /// Adds two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>The System.Half result of adding half1 and half2.</returns>
+        public static Half operator +(Half half1, Half half2) { return (Half)(half1 + (float)half2); }
+        /// <summary>
+        /// Subtracts two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>The System.Half result of subtracting half1 and half2.</returns>        
+        public static Half operator -(Half half1, Half half2) { return (Half)(half1 - (float)half2); }
+        /// <summary>
+        /// Multiplies two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>The System.Half result of multiplying half1 by half2.</returns>
+        public static Half operator *(Half half1, Half half2) { return (Half)(half1 * (float)half2); }
+        /// <summary>
+        /// Divides two specified System.Half values.
+        /// </summary>
+        /// <param name="half1">A System.Half (the dividend).</param>
+        /// <param name="half2">A System.Half (the divisor).</param>
+        /// <returns>The System.Half result of half1 by half2.</returns>
+        public static Half operator /(Half half1, Half half2) { return (Half)(half1 / (float)half2); }
+        /// <summary>
+        /// Returns a value indicating whether two instances of System.Half are equal.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>true if half1 and half2 are equal; otherwise, false.</returns>
+        public static bool operator ==(Half half1, Half half2) { return (!IsNaN(half1) && (half1.Value == half2.Value)); }
+        /// <summary>
+        /// Returns a value indicating whether two instances of System.Half are not equal.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>true if half1 and half2 are not equal; otherwise, false.</returns>
+        public static bool operator !=(Half half1, Half half2) { return half1.Value != half2.Value; }
+        /// <summary>
+        /// Returns a value indicating whether a specified System.Half is less than another specified System.Half.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>true if half1 is less than half1; otherwise, false.</returns>
+        public static bool operator <(Half half1, Half half2) { return half1 < (float)half2; }
+        /// <summary>
+        /// Returns a value indicating whether a specified System.Half is greater than another specified System.Half.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>true if half1 is greater than half2; otherwise, false.</returns>
+        public static bool operator >(Half half1, Half half2) { return half1 > (float)half2; }
+        /// <summary>
+        /// Returns a value indicating whether a specified System.Half is less than or equal to another specified System.Half.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>true if half1 is less than or equal to half2; otherwise, false.</returns>
+        public static bool operator <=(Half half1, Half half2) { return (half1 == half2) || (half1 < half2); }
+        /// <summary>
+        /// Returns a value indicating whether a specified System.Half is greater than or equal to another specified System.Half.
+        /// </summary>
+        /// <param name="half1">A System.Half.</param>
+        /// <param name="half2">A System.Half.</param>
+        /// <returns>true if half1 is greater than or equal to half2; otherwise, false.</returns>
+        public static bool operator >=(Half half1, Half half2) { return (half1 == half2) || (half1 > half2); }
+        #endregion
+
+        #region Type casting operators
+        /// <summary>
+        /// Converts an 8-bit unsigned integer to a System.Half.
+        /// </summary>
+        /// <param name="value">An 8-bit unsigned integer.</param>
+        /// <returns>A System.Half that represents the converted 8-bit unsigned integer.</returns>
+        public static implicit operator Half(byte value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a 16-bit signed integer to a System.Half.
+        /// </summary>
+        /// <param name="value">A 16-bit signed integer.</param>
+        /// <returns>A System.Half that represents the converted 16-bit signed integer.</returns>
+        public static implicit operator Half(short value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a Unicode character to a System.Half.
+        /// </summary>
+        /// <param name="value">A Unicode character.</param>
+        /// <returns>A System.Half that represents the converted Unicode character.</returns>
+        public static implicit operator Half(char value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a 32-bit signed integer to a System.Half.
+        /// </summary>
+        /// <param name="value">A 32-bit signed integer.</param>
+        /// <returns>A System.Half that represents the converted 32-bit signed integer.</returns>
+        public static implicit operator Half(int value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a 64-bit signed integer to a System.Half.
+        /// </summary>
+        /// <param name="value">A 64-bit signed integer.</param>
+        /// <returns>A System.Half that represents the converted 64-bit signed integer.</returns>
+        public static implicit operator Half(long value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a single-precision floating-point number to a System.Half.
+        /// </summary>
+        /// <param name="value">A single-precision floating-point number.</param>
+        /// <returns>A System.Half that represents the converted single-precision floating point number.</returns>
+        public static explicit operator Half(float value) { return new Half(value); }
+        /// <summary>
+        /// Converts a double-precision floating-point number to a System.Half.
+        /// </summary>
+        /// <param name="value">A double-precision floating-point number.</param>
+        /// <returns>A System.Half that represents the converted double-precision floating point number.</returns>
+        public static explicit operator Half(double value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a decimal number to a System.Half.
+        /// </summary>
+        /// <param name="value">decimal number</param>
+        /// <returns>A System.Half that represents the converted decimal number.</returns>
+        public static explicit operator Half(decimal value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a System.Half to an 8-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>An 8-bit unsigned integer that represents the converted System.Half.</returns>
+        public static explicit operator byte(Half value) { return (byte)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a Unicode character.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A Unicode character that represents the converted System.Half.</returns>
+        public static explicit operator char(Half value) { return (char)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a 16-bit signed integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A 16-bit signed integer that represents the converted System.Half.</returns>
+        public static explicit operator short(Half value) { return (short)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a 32-bit signed integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A 32-bit signed integer that represents the converted System.Half.</returns>
+        public static explicit operator int(Half value) { return (int)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a 64-bit signed integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A 64-bit signed integer that represents the converted System.Half.</returns>
+        public static explicit operator long(Half value) { return (long)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a single-precision floating-point number.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A single-precision floating-point number that represents the converted System.Half.</returns>
+        public static implicit operator float(Half value) { return HalfHelper.HalfToSingle(value); }
+        /// <summary>
+        /// Converts a System.Half to a double-precision floating-point number.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A double-precision floating-point number that represents the converted System.Half.</returns>
+        public static implicit operator double(Half value) { return (float)value; }
+        /// <summary>
+        /// Converts a System.Half to a decimal number.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A decimal number that represents the converted System.Half.</returns>
+        public static explicit operator decimal(Half value) { return (decimal)(float)value; }
+        /// <summary>
+        /// Converts an 8-bit signed integer to a System.Half.
+        /// </summary>
+        /// <param name="value">An 8-bit signed integer.</param>
+        /// <returns>A System.Half that represents the converted 8-bit signed integer.</returns>
+        public static implicit operator Half(sbyte value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a 16-bit unsigned integer to a System.Half.
+        /// </summary>
+        /// <param name="value">A 16-bit unsigned integer.</param>
+        /// <returns>A System.Half that represents the converted 16-bit unsigned integer.</returns>
+        public static implicit operator Half(ushort value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a 32-bit unsigned integer to a System.Half.
+        /// </summary>
+        /// <param name="value">A 32-bit unsigned integer.</param>
+        /// <returns>A System.Half that represents the converted 32-bit unsigned integer.</returns>
+        public static implicit operator Half(uint value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a 64-bit unsigned integer to a System.Half.
+        /// </summary>
+        /// <param name="value">A 64-bit unsigned integer.</param>
+        /// <returns>A System.Half that represents the converted 64-bit unsigned integer.</returns>
+        public static implicit operator Half(ulong value) { return new Half((float)value); }
+        /// <summary>
+        /// Converts a System.Half to an 8-bit signed integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>An 8-bit signed integer that represents the converted System.Half.</returns>
+        public static explicit operator sbyte(Half value) { return (sbyte)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a 16-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A 16-bit unsigned integer that represents the converted System.Half.</returns>
+        public static explicit operator ushort(Half value) { return (ushort)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a 32-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A 32-bit unsigned integer that represents the converted System.Half.</returns>
+        public static explicit operator uint(Half value) { return (uint)(float)value; }
+        /// <summary>
+        /// Converts a System.Half to a 64-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">A System.Half to convert.</param>
+        /// <returns>A 64-bit unsigned integer that represents the converted System.Half.</returns>
+        public static explicit operator ulong(Half value) { return (ulong)(float)value; }
+        #endregion
+
+        /// <summary>
+        /// Compares this instance to a specified System.Half object.
+        /// </summary>
+        /// <param name="other">A System.Half object.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and value.
+        /// Return Value Meaning Less than zero This instance is less than value. Zero
+        /// This instance is equal to value. Greater than zero This instance is greater than value.
+        /// </returns>
+        public int CompareTo(Half other)
+        {
+            int result = 0;
+            if (this < other) {
+                result = -1;
+            } else if (this > other) {
+                result = 1;
+            } else if (this != other) {
+                if (!IsNaN(this)) {
+                    result = 1;
+                } else if (!IsNaN(other)) {
+                    result = -1;
+                }
+            }
+
+            return result;
+        }
+        /// <summary>
+        /// Compares this instance to a specified System.Object.
+        /// </summary>
+        /// <param name="obj">An System.Object or null.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and value.
+        /// Return Value Meaning Less than zero This instance is less than value. Zero
+        /// This instance is equal to value. Greater than zero This instance is greater
+        /// than value. -or- value is null.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">value is not a System.Half</exception>
+        public int CompareTo(object obj)
+        {
+            int result = 0;
+            if (obj == null) {
+                result = 1;
+            } else {
+                if (obj is Half) {
+                    result = CompareTo((Half)obj);
+                } else {
+                    throw new ArgumentException("Object must be of type Half.");
+                }
+            }
+
+            return result;
+        }
+        /// <summary>
+        /// Returns a value indicating whether this instance and a specified System.Half object represent the same value.
+        /// </summary>
+        /// <param name="other">A System.Half object to compare to this instance.</param>
+        /// <returns>true if value is equal to this instance; otherwise, false.</returns>
+        public bool Equals(Half other)
+        {
+            return ((other == this) || (IsNaN(other) && IsNaN(this)));
+        }
+        /// <summary>
+        /// Returns a value indicating whether this instance and a specified System.Object
+        /// represent the same type and value.
+        /// </summary>
+        /// <param name="obj">An System.Object.</param>
+        /// <returns>true if value is a System.Half and equal to this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            bool result = false;
+            if (obj is Half) {
+                Half half = (Half)obj;
+                if ((half == this) || (IsNaN(half) && IsNaN(this))) {
+                    result = true;
+                }
+            }
+
+            return result;
+        }
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+        /// <summary>
+        /// Returns the System.TypeCode for value type System.Half.
+        /// </summary>
+        /// <returns>The enumerated constant (TypeCode)255.</returns>
+        public TypeCode GetTypeCode()
+        {
+            return (TypeCode)255;
+        }
+
+        #region BitConverter & Math methods for Half
+        /// <summary>
+        /// Returns the specified half-precision floating point value as an array of bytes.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>An array of bytes with length 2.</returns>
+        public static byte[] GetBytes(Half value)
+        {
+            return BitConverter.GetBytes(value.Value);
+        }
+        /// <summary>
+        /// Converts the value of a specified instance of System.Half to its equivalent binary representation.
+        /// </summary>
+        /// <param name="value">A System.Half value.</param>
+        /// <returns>A 16-bit unsigned integer that contain the binary representation of value.</returns>        
+        public static ushort GetBits(Half value)
+        {
+            return value.Value;
+        }
+        /// <summary>
+        /// Returns a half-precision floating point number converted from two bytes
+        /// at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes.</param>
+        /// <param name="startIndex">The starting position within value.</param>
+        /// <returns>A half-precision floating point number formed by two bytes beginning at startIndex.</returns>
+        /// <exception cref="System.ArgumentException">
+        /// startIndex is greater than or equal to the length of value minus 1, and is
+        /// less than or equal to the length of value minus 1.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">value is null.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">startIndex is less than zero or greater than the length of value minus 1.</exception>
+        public static Half ToHalf(byte[] value, int startIndex)
+        {
+            return ToHalf((ushort)BitConverter.ToInt16(value, startIndex));
+        }
+        /// <summary>
+        /// Returns a half-precision floating point number converted from its binary representation.
+        /// </summary>
+        /// <param name="bits">Binary representation of System.Half value</param>
+        /// <returns>A half-precision floating point number formed by its binary representation.</returns>
+        public static Half ToHalf(ushort bits)
+        {
+            return new Half { Value = bits };
+        }
+
+        /// <summary>
+        /// Returns a value indicating the sign of a half-precision floating-point number.
+        /// </summary>
+        /// <param name="value">A signed number.</param>
+        /// <returns>
+        /// A number indicating the sign of value. Number Description -1 value is less
+        /// than zero. 0 value is equal to zero. 1 value is greater than zero.
+        /// </returns>
+        /// <exception cref="System.ArithmeticException">value is equal to System.Half.NaN.</exception>
+        public static int Sign(Half value)
+        {
+            if (value < 0) {
+                return -1;
+            } else if (value > 0) {
+                return 1;
+            } else {
+                if (value != 0) {
+                    throw new ArithmeticException("Function does not accept floating point Not-a-Number values.");
+                }
+            }
+
+            return 0;
+        }
+        /// <summary>
+        /// Returns the absolute value of a half-precision floating-point number.
+        /// </summary>
+        /// <param name="value">A number in the range System.Half.MinValue ≤ value ≤ System.Half.MaxValue.</param>
+        /// <returns>A half-precision floating-point number, x, such that 0 ≤ x ≤System.Half.MaxValue.</returns>
+        public static Half Abs(Half value)
+        {
+            return HalfHelper.Abs(value);
+        }
+        /// <summary>
+        /// Returns the larger of two half-precision floating-point numbers.
+        /// </summary>
+        /// <param name="value1">The first of two half-precision floating-point numbers to compare.</param>
+        /// <param name="value2">The second of two half-precision floating-point numbers to compare.</param>
+        /// <returns>
+        /// Parameter value1 or value2, whichever is larger. If value1, or value2, or both val1
+        /// and value2 are equal to System.Half.NaN, System.Half.NaN is returned.
+        /// </returns>
+        public static Half Max(Half value1, Half value2)
+        {
+            return (value1 < value2) ? value2 : value1;
+        }
+        /// <summary>
+        /// Returns the smaller of two half-precision floating-point numbers.
+        /// </summary>
+        /// <param name="value1">The first of two half-precision floating-point numbers to compare.</param>
+        /// <param name="value2">The second of two half-precision floating-point numbers to compare.</param>
+        /// <returns>
+        /// Parameter value1 or value2, whichever is smaller. If value1, or value2, or both val1
+        /// and value2 are equal to System.Half.NaN, System.Half.NaN is returned.
+        /// </returns>
+        public static Half Min(Half value1, Half value2)
+        {
+            return (value1 < value2) ? value1 : value2;
+        }
+        #endregion
+
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to not a number (System.Half.NaN).
+        /// </summary>
+        /// <param name="half">A half-precision floating-point number.</param>
+        /// <returns>true if value evaluates to not a number (System.Half.NaN); otherwise, false.</returns>
+        public static bool IsNaN(Half half)
+        {
+            return HalfHelper.IsNaN(half);
+        }
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to negative or positive infinity.
+        /// </summary>
+        /// <param name="half">A half-precision floating-point number.</param>
+        /// <returns>true if half evaluates to System.Half.PositiveInfinity or System.Half.NegativeInfinity; otherwise, false.</returns>
+        public static bool IsInfinity(Half half)
+        {
+            return HalfHelper.IsInfinity(half);
+        }
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to negative infinity.
+        /// </summary>
+        /// <param name="half">A half-precision floating-point number.</param>
+        /// <returns>true if half evaluates to System.Half.NegativeInfinity; otherwise, false.</returns>
+        public static bool IsNegativeInfinity(Half half)
+        {
+            return HalfHelper.IsNegativeInfinity(half);
+        }
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to positive infinity.
+        /// </summary>
+        /// <param name="half">A half-precision floating-point number.</param>
+        /// <returns>true if half evaluates to System.Half.PositiveInfinity; otherwise, false.</returns>
+        public static bool IsPositiveInfinity(Half half)
+        {
+            return HalfHelper.IsPositiveInfinity(half);
+        }
+
+        #region String operations (Parse and ToString)
+        /// <summary>
+        /// Converts the string representation of a number to its System.Half equivalent.
+        /// </summary>
+        /// <param name="value">The string representation of the number to convert.</param>
+        /// <returns>The System.Half number equivalent to the number contained in value.</returns>
+        /// <exception cref="System.ArgumentNullException">value is null.</exception>
+        /// <exception cref="System.FormatException">value is not in the correct format.</exception>
+        /// <exception cref="System.OverflowException">value represents a number less than System.Half.MinValue or greater than System.Half.MaxValue.</exception>
+        public static Half Parse(string value)
+        {
+            return (Half)float.Parse(value, CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Converts the string representation of a number to its System.Half equivalent 
+        /// using the specified culture-specific format information.
+        /// </summary>
+        /// <param name="value">The string representation of the number to convert.</param>
+        /// <param name="provider">An System.IFormatProvider that supplies culture-specific parsing information about value.</param>
+        /// <returns>The System.Half number equivalent to the number contained in s as specified by provider.</returns>
+        /// <exception cref="System.ArgumentNullException">value is null.</exception>
+        /// <exception cref="System.FormatException">value is not in the correct format.</exception>
+        /// <exception cref="System.OverflowException">value represents a number less than System.Half.MinValue or greater than System.Half.MaxValue.</exception>
+        public static Half Parse(string value, IFormatProvider provider)
+        {
+            return (Half)float.Parse(value, provider);
+        }
+        /// <summary>
+        /// Converts the string representation of a number in a specified style to its System.Half equivalent.
+        /// </summary>
+        /// <param name="value">The string representation of the number to convert.</param>
+        /// <param name="style">
+        /// A bitwise combination of System.Globalization.NumberStyles values that indicates
+        /// the style elements that can be present in value. A typical value to specify is
+        /// System.Globalization.NumberStyles.Number.
+        /// </param>
+        /// <returns>The System.Half number equivalent to the number contained in s as specified by style.</returns>
+        /// <exception cref="System.ArgumentNullException">value is null.</exception>
+        /// <exception cref="System.ArgumentException">
+        /// style is not a System.Globalization.NumberStyles value. -or- style is the
+        /// System.Globalization.NumberStyles.AllowHexSpecifier value.
+        /// </exception>
+        /// <exception cref="System.FormatException">value is not in the correct format.</exception>
+        /// <exception cref="System.OverflowException">value represents a number less than System.Half.MinValue or greater than System.Half.MaxValue.</exception>
+        public static Half Parse(string value, NumberStyles style)
+        {
+            return (Half)float.Parse(value, style, CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Converts the string representation of a number to its System.Half equivalent 
+        /// using the specified style and culture-specific format.
+        /// </summary>
+        /// <param name="value">The string representation of the number to convert.</param>
+        /// <param name="style">
+        /// A bitwise combination of System.Globalization.NumberStyles values that indicates
+        /// the style elements that can be present in value. A typical value to specify is 
+        /// System.Globalization.NumberStyles.Number.
+        /// </param>
+        /// <param name="provider">An System.IFormatProvider object that supplies culture-specific information about the format of value.</param>
+        /// <returns>The System.Half number equivalent to the number contained in s as specified by style and provider.</returns>
+        /// <exception cref="System.ArgumentNullException">value is null.</exception>
+        /// <exception cref="System.ArgumentException">
+        /// style is not a System.Globalization.NumberStyles value. -or- style is the
+        /// System.Globalization.NumberStyles.AllowHexSpecifier value.
+        /// </exception>
+        /// <exception cref="System.FormatException">value is not in the correct format.</exception>
+        /// <exception cref="System.OverflowException">value represents a number less than System.Half.MinValue or greater than System.Half.MaxValue.</exception>
+        public static Half Parse(string value, NumberStyles style, IFormatProvider provider)
+        {
+            return (Half)float.Parse(value, style, provider);
+        }
+        /// <summary>
+        /// Converts the string representation of a number to its System.Half equivalent.
+        /// A return value indicates whether the conversion succeeded or failed.
+        /// </summary>
+        /// <param name="value">The string representation of the number to convert.</param>
+        /// <param name="result">
+        /// When this method returns, contains the System.Half number that is equivalent
+        /// to the numeric value contained in value, if the conversion succeeded, or is zero
+        /// if the conversion failed. The conversion fails if the s parameter is null,
+        /// is not a number in a valid format, or represents a number less than System.Half.MinValue
+        /// or greater than System.Half.MaxValue. This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>true if s was converted successfully; otherwise, false.</returns>
+        public static bool TryParse(string value, out Half result)
+        {
+            float f;
+            if (float.TryParse(value, out f)) {
+                result = (Half)f;
+                return true;
+            }
+
+            result = new Half();
+            return false;
+        }
+        /// <summary>
+        /// Converts the string representation of a number to its System.Half equivalent
+        /// using the specified style and culture-specific format. A return value indicates
+        /// whether the conversion succeeded or failed.
+        /// </summary>
+        /// <param name="value">The string representation of the number to convert.</param>
+        /// <param name="style">
+        /// A bitwise combination of System.Globalization.NumberStyles values that indicates
+        /// the permitted format of value. A typical value to specify is System.Globalization.NumberStyles.Number.
+        /// </param>
+        /// <param name="provider">An System.IFormatProvider object that supplies culture-specific parsing information about value.</param>
+        /// <param name="result">
+        /// When this method returns, contains the System.Half number that is equivalent
+        /// to the numeric value contained in value, if the conversion succeeded, or is zero
+        /// if the conversion failed. The conversion fails if the s parameter is null,
+        /// is not in a format compliant with style, or represents a number less than
+        /// System.Half.MinValue or greater than System.Half.MaxValue. This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>true if s was converted successfully; otherwise, false.</returns>
+        /// <exception cref="System.ArgumentException">
+        /// style is not a System.Globalization.NumberStyles value. -or- style 
+        /// is the System.Globalization.NumberStyles.AllowHexSpecifier value.
+        /// </exception>
+        public static bool TryParse(string value, NumberStyles style, IFormatProvider provider, out Half result)
+        {
+            bool parseResult = false;
+            float f;
+            if (float.TryParse(value, style, provider, out f)) {
+                result = (Half)f;
+                parseResult = true;
+            } else {
+                result = new Half();
+            }
+
+            return parseResult;
+        }
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation.
+        /// </summary>
+        /// <returns>A string that represents the value of this instance.</returns>
+        public override string ToString()
+        {
+            return ((float)this).ToString(CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation
+        /// using the specified culture-specific format information.
+        /// </summary>
+        /// <param name="formatProvider">An System.IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <returns>The string representation of the value of this instance as specified by provider.</returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ((float)this).ToString(formatProvider);
+        }
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation, using the specified format.
+        /// </summary>
+        /// <param name="format">A numeric format string.</param>
+        /// <returns>The string representation of the value of this instance as specified by format.</returns>
+        public string ToString(string format)
+        {
+            return ((float)this).ToString(format, CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation 
+        /// using the specified format and culture-specific format information.
+        /// </summary>
+        /// <param name="format">A numeric format string.</param>
+        /// <param name="formatProvider">An System.IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <returns>The string representation of the value of this instance as specified by format and provider.</returns>
+        /// <exception cref="System.FormatException">format is invalid.</exception>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return ((float)this).ToString(format, formatProvider);
+        }
+        #endregion
+
+        #region IConvertible Members
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            return this;
+        }
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return GetTypeCode();
+        }
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            return Convert.ToBoolean(this);
+        }
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            return Convert.ToByte(this);
+        }
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException(string.Format(CultureInfo.CurrentCulture, "Invalid cast from '{0}' to '{1}'.", "Half", "Char"));
+        }
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            throw new InvalidCastException(string.Format(CultureInfo.CurrentCulture, "Invalid cast from '{0}' to '{1}'.", "Half", "DateTime"));
+        }
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            return Convert.ToDecimal(this);
+        }
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            return Convert.ToDouble(this);
+        }
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16(this);
+        }
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32(this);
+        }
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64(this);
+        }
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            return Convert.ToSByte(this);
+        }
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return Convert.ToString(this, CultureInfo.InvariantCulture);
+        }
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            return (((float)this) as IConvertible).ToType(conversionType, provider);
+        }
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            return Convert.ToUInt16(this);
+        }
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            return Convert.ToUInt32(this);
+        }
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            return Convert.ToUInt64(this);
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Helper class for Half conversions and some low level operations.
+    /// This class is internally used in the Half class.
+    /// </summary>
+    /// <remarks>
+    /// References:
+    ///     - Code retrieved from http://sourceforge.net/p/csharp-half/code/HEAD/tree/ on 2015-12-04
+    ///     - Fast Half Float Conversions, Jeroen van der Zijp, link: http://www.fox-toolkit.org/ftp/fasthalffloatconversion.pdf
+    /// </remarks>
+    internal static class HalfHelper
+    {
+        private static readonly uint[] MantissaTable = GenerateMantissaTable();
+        private static readonly uint[] ExponentTable = GenerateExponentTable();
+        private static readonly ushort[] OffsetTable = GenerateOffsetTable();
+        private static readonly ushort[] BaseTable = GenerateBaseTable();
+        private static readonly sbyte[] ShiftTable = GenerateShiftTable();
+
+        // Transforms the subnormal representation to a normalized one. 
+        private static uint ConvertMantissa(int i)
+        {
+            uint m = (uint)(i << 13); // Zero pad mantissa bits
+            uint e = 0; // Zero exponent
+
+            // While not normalized
+            while ((m & 0x00800000) == 0) {
+                e -= 0x00800000; // Decrement exponent (1<<23)
+                m <<= 1; // Shift mantissa                
+            }
+            m &= unchecked((uint)~0x00800000); // Clear leading 1 bit
+            e += 0x38800000; // Adjust bias ((127-14)<<23)
+            return m | e; // Return combined number
+        }
+
+        private static uint[] GenerateMantissaTable()
+        {
+            uint[] mantissaTable = new uint[2048];
+            mantissaTable[0] = 0;
+            for (int i = 1; i < 1024; i++) {
+                mantissaTable[i] = ConvertMantissa(i);
+            }
+            for (int i = 1024; i < 2048; i++) {
+                mantissaTable[i] = (uint)(0x38000000 + ((i - 1024) << 13));
+            }
+
+            return mantissaTable;
+        }
+        private static uint[] GenerateExponentTable()
+        {
+            uint[] exponentTable = new uint[64];
+            exponentTable[0] = 0;
+            for (int i = 1; i < 31; i++) {
+                exponentTable[i] = (uint)(i << 23);
+            }
+            exponentTable[31] = 0x47800000;
+            exponentTable[32] = 0x80000000;
+            for (int i = 33; i < 63; i++) {
+                exponentTable[i] = (uint)(0x80000000 + ((i - 32) << 23));
+            }
+            exponentTable[63] = 0xc7800000;
+
+            return exponentTable;
+        }
+        private static ushort[] GenerateOffsetTable()
+        {
+            ushort[] offsetTable = new ushort[64];
+            offsetTable[0] = 0;
+            for (int i = 1; i < 32; i++) {
+                offsetTable[i] = 1024;
+            }
+            offsetTable[32] = 0;
+            for (int i = 33; i < 64; i++) {
+                offsetTable[i] = 1024;
+            }
+
+            return offsetTable;
+        }
+        private static ushort[] GenerateBaseTable()
+        {
+            ushort[] baseTable = new ushort[512];
+            for (int i = 0; i < 256; ++i) {
+                sbyte e = (sbyte)(127 - i);
+                if (e > 24) { // Very small numbers map to zero
+                    baseTable[i | 0x000] = 0x0000;
+                    baseTable[i | 0x100] = 0x8000;
+                } else if (e > 14) { // Small numbers map to denorms
+                    baseTable[i | 0x000] = (ushort)(0x0400 >> (18 + e));
+                    baseTable[i | 0x100] = (ushort)((0x0400 >> (18 + e)) | 0x8000);
+                } else if (e >= -15) { // Normal numbers just lose precision
+                    baseTable[i | 0x000] = (ushort)((15 - e) << 10);
+                    baseTable[i | 0x100] = (ushort)(((15 - e) << 10) | 0x8000);
+                } else if (e > -128) { // Large numbers map to Infinity
+                    baseTable[i | 0x000] = 0x7c00;
+                    baseTable[i | 0x100] = 0xfc00;
+                } else { // Infinity and NaN's stay Infinity and NaN's
+                    baseTable[i | 0x000] = 0x7c00;
+                    baseTable[i | 0x100] = 0xfc00;
+                }
+            }
+
+            return baseTable;
+        }
+        private static sbyte[] GenerateShiftTable()
+        {
+            sbyte[] shiftTable = new sbyte[512];
+            for (int i = 0; i < 256; ++i) {
+                sbyte e = (sbyte)(127 - i);
+                if (e > 24) { // Very small numbers map to zero
+                    shiftTable[i | 0x000] = 24;
+                    shiftTable[i | 0x100] = 24;
+                } else if (e > 14) { // Small numbers map to denorms
+                    shiftTable[i | 0x000] = (sbyte)(e - 1);
+                    shiftTable[i | 0x100] = (sbyte)(e - 1);
+                } else if (e >= -15) { // Normal numbers just lose precision
+                    shiftTable[i | 0x000] = 13;
+                    shiftTable[i | 0x100] = 13;
+                } else if (e > -128) { // Large numbers map to Infinity
+                    shiftTable[i | 0x000] = 24;
+                    shiftTable[i | 0x100] = 24;
+                } else { // Infinity and NaN's stay Infinity and NaN's
+                    shiftTable[i | 0x000] = 13;
+                    shiftTable[i | 0x100] = 13;
+                }
+            }
+
+            return shiftTable;
+        }
+
+        public static unsafe float HalfToSingle(Half half)
+        {
+            uint result = MantissaTable[OffsetTable[half.Value >> 10] + (half.Value & 0x3ff)] + ExponentTable[half.Value >> 10];
+            return *(float*)&result;
+        }
+        public static unsafe Half SingleToHalf(float single)
+        {
+            uint value = *(uint*)&single;
+
+            ushort result = (ushort)(BaseTable[(value >> 23) & 0x1ff] + ((value & 0x007fffff) >> ShiftTable[value >> 23]));
+            return Half.ToHalf(result);
+        }
+
+        public static Half Negate(Half half)
+        {
+            return Half.ToHalf((ushort)(half.Value ^ 0x8000));
+        }
+        public static Half Abs(Half half)
+        {
+            return Half.ToHalf((ushort)(half.Value & 0x7fff));
+        }
+
+        public static bool IsNaN(Half half)
+        {
+            return (half.Value & 0x7fff) > 0x7c00;
+        }
+        public static bool IsInfinity(Half half)
+        {
+            return (half.Value & 0x7fff) == 0x7c00;
+        }
+        public static bool IsPositiveInfinity(Half half)
+        {
+            return half.Value == 0x7c00;
+        }
+        public static bool IsNegativeInfinity(Half half)
+        {
+            return half.Value == 0xfc00;
+        }
+    }
+}
+

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -1706,6 +1706,34 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_scatter(IntPtr tensor, long dimension, IntPtr index, IntPtr source);
+
+        /// <summary>
+        ///  Writes all values from the tensor src into self at the indices specified in the index tensor. For each
+        ///  value in src, its output index is specified by its index in src for dimension != dim and by the #
+        ///  corresponding value in index for dimension = dim.
+        /// </summary>
+        public TorchTensor Scatter(long dimension, TorchTensor index, TorchTensor src)
+        {
+            var res = THSTensor_scatter(handle, dimension, index.Handle, src.Handle);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_gather(IntPtr tensor, long dimension, IntPtr index);
+
+        /// <summary>
+        /// Gathers values along an axis specified by dim.
+        /// </summary>
+        public TorchTensor Gather(long dimension, TorchTensor index)
+        {
+            var res = THSTensor_gather(handle, dimension, index.Handle);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_flip(IntPtr src, IntPtr psizes, int length);
 
         /// <summary>

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -215,7 +215,7 @@ namespace TorchSharp.Tensor
         [DllImport("LibTorchSharp")]
         private static extern sbyte THSTensor_type(IntPtr handle);
 
-        public ATenScalarMapping Type => (ATenScalarMapping)THSTensor_type(handle);
+        public ScalarType Type => (ScalarType)THSTensor_type(handle);
 
         [DllImport("LibTorchSharp")]
         [return: MarshalAs(UnmanagedType.LPStr)]
@@ -248,7 +248,7 @@ namespace TorchSharp.Tensor
         [DllImport("LibTorchSharp")]
         private static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type);
 
-        public TorchTensor ToType(ATenScalarMapping type)
+        public TorchTensor ToType(ScalarType type)
         {
             var res = THSTensor_to_type(handle, (sbyte)type);
             Torch.CheckForErrors();
@@ -1659,7 +1659,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         /// Returns the sum of all elements in the :attr:`input` tensor.
         /// </summary>
-        public TorchTensor Sum(ATenScalarMapping? type = null)
+        public TorchTensor Sum(ScalarType? type = null)
         {
             var res = THSTensor_sum(handle, type.HasValue, (sbyte)type.GetValueOrDefault());
             Torch.CheckForErrors();
@@ -1672,7 +1672,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Returns the sum of each row of the input tensor in the given dimensions.
         /// </summary>
-        public TorchTensor Sum(long[] dimensions, bool keepDimension = false, ATenScalarMapping? type = null)
+        public TorchTensor Sum(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
         {
             unsafe
             {
@@ -2000,6 +2000,41 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
+        private static extern void THSTensor_maxpool1d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        public (TorchTensor output, TorchTensor indices) MaxPool1DWithIndices(long kernelSize, long? stride = null,
+            long? padding = null, long? dilation = null, bool ceil_mode = false)
+        {
+            var kernelSizes = new long[] { kernelSize };
+            var strides = new long[] { stride ?? 1 };
+            var paddings = new long[] { padding ?? 0 };
+            var dilations = new long[] { dilation ?? 1 };
+            IntPtr[] ptrArray;
+
+            using (var pa = new PinnedArray<IntPtr>()) {
+                unsafe {
+                    fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings, pdilation = dilations) {
+                        THSTensor_maxpool1d_with_indices(handle,
+                            pa.CreateArray,
+                            (IntPtr)pkernelSize, kernelSizes.Length,
+                            (IntPtr)pstrides, strides.Length,
+                            (IntPtr)ppadding, paddings.Length,
+                            (IntPtr)pdilation, dilations.Length,
+                            ceil_mode);
+                        Torch.CheckForErrors();
+                    }
+                }
+                ptrArray = pa.Array;
+            }
+            return (new TorchTensor(ptrArray[0]), new TorchTensor(ptrArray[1]));
+        }
+
+        [DllImport("LibTorchSharp")]
         private static extern IntPtr THSTensor_maxpool2d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
@@ -2031,6 +2066,40 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
+        private static extern void THSTensor_maxpool2d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        public (TorchTensor output, TorchTensor indices) MaxPool2DWithIndices(long[] kernelSize, long[] strides = null,
+            long[] padding = null, long[] dilation = null, bool ceil_mode = false)
+        {
+            strides = strides ?? kernelSize.Select(x => 1L).ToArray();
+            padding = padding ?? kernelSize.Select(x => 0L).ToArray();
+            dilation = dilation ?? kernelSize.Select(x => 1L).ToArray();
+            IntPtr[] ptrArray;
+
+            using (var pa = new PinnedArray<IntPtr>()) {
+                unsafe {
+                    fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding, pdilation = dilation) {
+                        THSTensor_maxpool2d_with_indices(handle,
+                            pa.CreateArray,
+                            (IntPtr)pkernelSize, kernelSize.Length,
+                            (IntPtr)pstrides, strides.Length,
+                            (IntPtr)ppadding, padding.Length,
+                            (IntPtr)pdilation, dilation.Length,
+                            ceil_mode);
+                        Torch.CheckForErrors();
+                    }
+                }
+                ptrArray = pa.Array;
+            }
+            return (new TorchTensor(ptrArray[0]), new TorchTensor(ptrArray[1]));
+        }
+
+        [DllImport("LibTorchSharp")]
         private static extern IntPtr THSTensor_maxpool3d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
@@ -2055,6 +2124,73 @@ namespace TorchSharp.Tensor
                             (IntPtr)ppadding, padding.Length,
                             (IntPtr)pdilation, dilation.Length,
                             ceil_mode);
+                    Torch.CheckForErrors();
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern void THSTensor_maxpool3d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        public (TorchTensor output, TorchTensor indices) MaxPool3DWithIndices(long[] kernelSize, long[] strides = null,
+            long[] padding = null, long[] dilation = null, bool ceil_mode = false)
+        {
+            strides = strides ?? kernelSize.Select(x => 1L).ToArray();
+            padding = padding ?? kernelSize.Select(x => 0L).ToArray();
+            dilation = dilation ?? kernelSize.Select(x => 1L).ToArray();
+            IntPtr[] ptrArray;
+
+            using (var pa = new PinnedArray<IntPtr>()) {
+                unsafe {
+                    fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding, pdilation = dilation) {
+                        THSTensor_maxpool3d_with_indices(handle,
+                            pa.CreateArray,
+                            (IntPtr)pkernelSize, kernelSize.Length,
+                            (IntPtr)pstrides, strides.Length,
+                            (IntPtr)ppadding, padding.Length,
+                            (IntPtr)pdilation, dilation.Length,
+                            ceil_mode);
+                        Torch.CheckForErrors();
+                    }
+                }
+                ptrArray = pa.Array;
+            }
+            return (new TorchTensor(ptrArray[0]), new TorchTensor(ptrArray[1]));
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_maxunpool2d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength);
+
+        public TorchTensor MaxUnpool2D(TorchTensor indices, long[] outputSize)
+        {
+            unsafe {
+                fixed (long* poutputSize = outputSize) {
+                    var res = THSTensor_maxunpool2d(handle, indices.Handle,
+                        (IntPtr)poutputSize, outputSize.Length);
+                    Torch.CheckForErrors();
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_maxunpool3d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength, IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength);
+
+        public TorchTensor MaxUnpool3D(TorchTensor indices, long[] outputSize, long[] strides, long[] padding)
+        {
+            unsafe {
+                fixed (long* poutputSize = outputSize, pstrides = strides, ppadding = padding) {
+                    var res = THSTensor_maxunpool3d(handle, indices.Handle,
+                        (IntPtr)poutputSize, outputSize.Length,
+                        (IntPtr)pstrides, strides.Length,
+                        (IntPtr)ppadding, padding.Length);
                     Torch.CheckForErrors();
                     return new TorchTensor(res);
                 }
@@ -2280,7 +2416,7 @@ namespace TorchSharp.Tensor
         }
     }
 
-    public enum ATenScalarMapping : sbyte
+    public enum ScalarType : sbyte
     {
         Byte = 0,
         SByte = 1,
@@ -2290,8 +2426,14 @@ namespace TorchSharp.Tensor
         Half = 5,
         Float = 6,
         Double = 7,
-        ComplexFloat = 8,
-        ComplexDouble = 9
+        //ComplexHalf = 8,
+        //ComplexFloat = 9,
+        //ComplexDouble = 10,
+        Bool = 11,
+        //QInt8 = 12,
+        //QUInt8 = 13,
+        //QUInt32 = 14,
+        //BFloat16 = 15
     }
 
     public static class TensorExtensionMethods
@@ -2330,6 +2472,18 @@ namespace TorchSharp.Tensor
                     {
                         return FloatTensor.From(array as float[], dimensions, requiresGrad);
                     }
+                case bool _ when typeof(T) == typeof(Half):
+                    {
+                        return HalfTensor.From(array as Half[], dimensions, requiresGrad);
+                    }
+                case bool _ when typeof(T) == typeof(bool):
+                    {
+                        return BoolTensor.From(array as bool[], dimensions, requiresGrad);
+                    }
+                //case bool _ when typeof(T) == typeof(System.Numerics.Complex):
+                //    {
+                //        return ComplexDoubleTensor.From(array as System.Numerics.Complex[], dimensions, requiresGrad);
+                //    }
                 default: throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
             }
         }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -32,7 +32,7 @@ namespace TorchSharp.Tensor {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.Byte, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Byte, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -49,7 +49,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Byte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, device, requiresGrad));
                 }
             }
         }
@@ -68,7 +68,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Byte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, device, requiresGrad));
                 }
             }
         }
@@ -87,7 +87,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Byte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, device, requiresGrad));
                 }
             }
         }
@@ -106,7 +106,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Byte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, device, requiresGrad));
                 }
             }
         }
@@ -126,9 +126,9 @@ namespace TorchSharp.Tensor {
         {
             var length = dimensions.Length;
 
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Byte, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Byte, requiresGrad));
         }
-
+        
         public static TorchTensor From(byte[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -145,7 +145,7 @@ namespace TorchSharp.Tensor {
                             deleters.TryRemove(deleter, out deleter);
                          });
                     deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Byte, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Byte, requiresGrad));
                 }
             }
         }
@@ -166,7 +166,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Byte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, device, requiresGrad));
                 }
             }
         }
@@ -195,7 +195,7 @@ namespace TorchSharp.Tensor {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.SByte, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.SByte, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -212,7 +212,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.SByte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, device, requiresGrad));
                 }
             }
         }
@@ -231,7 +231,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.SByte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, device, requiresGrad));
                 }
             }
         }
@@ -250,7 +250,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.SByte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, device, requiresGrad));
                 }
             }
         }
@@ -269,7 +269,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.SByte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, device, requiresGrad));
                 }
             }
         }
@@ -289,9 +289,9 @@ namespace TorchSharp.Tensor {
         {
             var length = dimensions.Length;
 
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.SByte, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad));
         }
-
+        
         public static TorchTensor From(sbyte[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -308,7 +308,7 @@ namespace TorchSharp.Tensor {
                             deleters.TryRemove(deleter, out deleter);
                          });
                     deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.SByte, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad));
                 }
             }
         }
@@ -329,7 +329,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.SByte, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, device, requiresGrad));
                 }
             }
         }
@@ -358,7 +358,7 @@ namespace TorchSharp.Tensor {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.Short, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Short, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -375,7 +375,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Short, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, device, requiresGrad));
                 }
             }
         }
@@ -394,7 +394,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Short, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, device, requiresGrad));
                 }
             }
         }
@@ -413,7 +413,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Short, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, device, requiresGrad));
                 }
             }
         }
@@ -432,7 +432,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Short, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, device, requiresGrad));
                 }
             }
         }
@@ -452,9 +452,9 @@ namespace TorchSharp.Tensor {
         {
             var length = dimensions.Length;
 
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Short, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad));
         }
-
+        
         public static TorchTensor From(short[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -471,7 +471,7 @@ namespace TorchSharp.Tensor {
                             deleters.TryRemove(deleter, out deleter);
                          });
                     deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Short, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad));
                 }
             }
         }
@@ -492,7 +492,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Short, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, device, requiresGrad));
                 }
             }
         }
@@ -521,7 +521,7 @@ namespace TorchSharp.Tensor {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.Int, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Int, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -538,7 +538,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Int, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, device, requiresGrad));
                 }
             }
         }
@@ -557,7 +557,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Int, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, device, requiresGrad));
                 }
             }
         }
@@ -576,7 +576,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Int, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, device, requiresGrad));
                 }
             }
         }
@@ -595,7 +595,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Int, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, device, requiresGrad));
                 }
             }
         }
@@ -615,9 +615,9 @@ namespace TorchSharp.Tensor {
         {
             var length = dimensions.Length;
 
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Int, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad));
         }
-
+        
         public static TorchTensor From(int[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -634,7 +634,7 @@ namespace TorchSharp.Tensor {
                             deleters.TryRemove(deleter, out deleter);
                          });
                     deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Int, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad));
                 }
             }
         }
@@ -655,7 +655,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Int, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, device, requiresGrad));
                 }
             }
         }
@@ -684,7 +684,7 @@ namespace TorchSharp.Tensor {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.Long, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Long, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -701,7 +701,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Long, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, device, requiresGrad));
                 }
             }
         }
@@ -720,7 +720,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Long, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, device, requiresGrad));
                 }
             }
         }
@@ -739,7 +739,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Long, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, device, requiresGrad));
                 }
             }
         }
@@ -758,7 +758,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Long, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, device, requiresGrad));
                 }
             }
         }
@@ -780,7 +780,7 @@ namespace TorchSharp.Tensor {
 
             return new TorchTensor(THSTensor_newLong(rawArray, null, dimensions, dimensions.Length, requiresGrad));
         }
-
+        
         public static TorchTensor From(long[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -818,20 +818,20 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Long, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, device, requiresGrad));
                 }
             }
         }
     }
     /// <summary>
-    ///   Tensor of type Double.
+    ///   Tensor of type Half.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class DoubleTensor
+    public class HalfTensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static DoubleTensor()
+        static HalfTensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -843,11 +843,11 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(double start, double stop, double step, string device = "cpu", bool requiresGrad = false)
+        static public TorchTensor Arange(TorchSharp.Half start, TorchSharp.Half stop, TorchSharp.Half step, string device = "cpu", bool requiresGrad = false)
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Half, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -864,7 +864,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, device, requiresGrad));
                 }
             }
         }
@@ -883,7 +883,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, device, requiresGrad));
                 }
             }
         }
@@ -902,7 +902,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, device, requiresGrad));
                 }
             }
         }
@@ -921,54 +921,17 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
-                }
-            }
-        }
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_rand(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
-
-        /// <summary>
-        ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
-        /// </summary>
-        static public TorchTensor Random(long[] size, string device = "cpu", bool requiresGrad = false)
-        {
-            TorchTensor.CheckForCUDA (device);
-
-            unsafe
-            {
-                fixed (long* psizes = size)
-                {
-                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, device, requiresGrad));
                 }
             }
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_randn(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+        extern static IntPtr THSTensor_newHalfScalar(TorchSharp.Half scalar, bool requiresGrad);
 
-        /// <summary>
-        ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
-        /// </summary>
-        static public TorchTensor RandomN(long[] size, string device = "cpu", bool requiresGrad = false)
+        public static TorchTensor From(TorchSharp.Half scalar, bool requiresGrad = false)
         {
-            TorchTensor.CheckForCUDA (device);
-
-            unsafe
-            {
-                fixed (long* psizes = size)
-                {
-                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
-                }
-            }
-        }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newDoubleScalar(double scalar, bool requiresGrad);
-
-        public static TorchTensor From(double scalar, bool requiresGrad = false)
-        {
-            return new TorchTensor(THSTensor_newDoubleScalar(scalar, requiresGrad));
+            return new TorchTensor(THSTensor_newHalfScalar(scalar, requiresGrad));
         }
 
         [DllImport("LibTorchSharp")]
@@ -978,14 +941,14 @@ namespace TorchSharp.Tensor {
         {
             var length = dimensions.Length;
 
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Double, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Half, requiresGrad));
         }
-
-        public static TorchTensor From(double[] rawArray, long[] dimensions, bool requiresGrad = false)
+        
+        public static TorchTensor From(TorchSharp.Half[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
             {
-                fixed (double* parray = rawArray)
+                fixed (TorchSharp.Half* parray = rawArray)
                 {
                     var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
                     var addr = dataHandle.AddrOfPinnedObject();
@@ -997,12 +960,12 @@ namespace TorchSharp.Tensor {
                             deleters.TryRemove(deleter, out deleter);
                          });
                     deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Double, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Half, requiresGrad));
                 }
             }
         }
 
-        public static TorchTensor From(double[] rawArray, bool requiresGrad = false)
+        public static TorchTensor From(TorchSharp.Half[] rawArray, bool requiresGrad = false)
         {
             return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
@@ -1018,7 +981,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Double, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, device, requiresGrad));
                 }
             }
         }
@@ -1047,7 +1010,7 @@ namespace TorchSharp.Tensor {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Float, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -1064,7 +1027,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
                 }
             }
         }
@@ -1083,7 +1046,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
                 }
             }
         }
@@ -1102,7 +1065,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
                 }
             }
         }
@@ -1121,7 +1084,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
                 }
             }
         }
@@ -1139,7 +1102,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
                 }
             }
         }
@@ -1158,7 +1121,7 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
                 }
             }
         }
@@ -1178,9 +1141,9 @@ namespace TorchSharp.Tensor {
         {
             var length = dimensions.Length;
 
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Float, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad));
         }
-
+        
         public static TorchTensor From(float[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -1197,7 +1160,7 @@ namespace TorchSharp.Tensor {
                             deleters.TryRemove(deleter, out deleter);
                          });
                     deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.Float, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad));
                 }
             }
         }
@@ -1218,7 +1181,370 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ATenScalarMapping.Float, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, device, requiresGrad));
+                }
+            }
+        }
+    }
+    /// <summary>
+    ///   Tensor of type Double.
+    ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
+    ///   Please do no mix Aten Tensors and Torch Tensors.
+    /// </summary>
+    public class DoubleTensor
+    {
+        static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
+        static DoubleTensor()
+        {
+            deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
+		/// common difference step, starting from start
+        /// </summary>
+        static public TorchTensor Arange(double start, double stop, double step, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Double, device, requiresGrad));
+        }
+		
+		[DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with zeros
+        /// </summary>
+        static public TorchTensor Zeros(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_ones(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with ones
+        /// </summary>
+        static public TorchTensor Ones(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_empty(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with ones
+        /// </summary>
+        static public TorchTensor Empty(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randint(long max, IntPtr psizes, int length, int scalarType, string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
+        /// </summary>
+        static public TorchTensor RandomIntegers(long max, long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rand(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
+        /// </summary>
+        static public TorchTensor Random(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randn(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
+        /// </summary>
+        static public TorchTensor RandomN(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_newDoubleScalar(double scalar, bool requiresGrad);
+
+        public static TorchTensor From(double scalar, bool requiresGrad = false)
+        {
+            return new TorchTensor(THSTensor_newDoubleScalar(scalar, requiresGrad));
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
+
+        public static TorchTensor From(IntPtr rawArray, long[] dimensions, bool requiresGrad)
+        {
+            var length = dimensions.Length;
+
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad));
+        }
+        
+        public static TorchTensor From(double[] rawArray, long[] dimensions, bool requiresGrad = false)
+        {
+            unsafe
+            {
+                fixed (double* parray = rawArray)
+                {
+                    var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
+                    var addr = dataHandle.AddrOfPinnedObject();
+                    var gchp = GCHandle.ToIntPtr(dataHandle);
+                    GCHandleDeleter deleter = null;
+                    deleter =
+                        new GCHandleDeleter(delegate (IntPtr ptr) {
+                            GCHandle.FromIntPtr(gchp).Free();
+                            deleters.TryRemove(deleter, out deleter);
+                         });
+                    deleters.TryAdd(deleter, deleter); // keep the delegate alive
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad));
+                }
+            }
+        }
+
+        public static TorchTensor From(double[] rawArray, bool requiresGrad = false)
+        {
+            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, device, requiresGrad));
+                }
+            }
+        }
+    }
+    /// <summary>
+    ///   Tensor of type Bool.
+    ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
+    ///   Please do no mix Aten Tensors and Torch Tensors.
+    /// </summary>
+    public class BoolTensor
+    {
+        static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
+        static BoolTensor()
+        {
+            deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
+		/// common difference step, starting from start
+        /// </summary>
+        static public TorchTensor Arange(bool start, bool stop, bool step, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Bool, device, requiresGrad));
+        }
+		
+		[DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with zeros
+        /// </summary>
+        static public TorchTensor Zeros(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_ones(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with ones
+        /// </summary>
+        static public TorchTensor Ones(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_empty(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with ones
+        /// </summary>
+        static public TorchTensor Empty(long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randint(long max, IntPtr psizes, int length, int scalarType, string device, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
+        /// </summary>
+        static public TorchTensor RandomIntegers(long max, long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, device, requiresGrad));
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_newBoolScalar(bool scalar, bool requiresGrad);
+
+        public static TorchTensor From(bool scalar, bool requiresGrad = false)
+        {
+            return new TorchTensor(THSTensor_newBoolScalar(scalar, requiresGrad));
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
+
+        public static TorchTensor From(IntPtr rawArray, long[] dimensions, bool requiresGrad)
+        {
+            var length = dimensions.Length;
+
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.Bool, requiresGrad));
+        }
+        
+        public static TorchTensor From(bool[] rawArray, long[] dimensions, bool requiresGrad = false)
+        {
+            unsafe
+            {
+                fixed (bool* parray = rawArray)
+                {
+                    var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
+                    var addr = dataHandle.AddrOfPinnedObject();
+                    var gchp = GCHandle.ToIntPtr(dataHandle);
+                    GCHandleDeleter deleter = null;
+                    deleter =
+                        new GCHandleDeleter(delegate (IntPtr ptr) {
+                            GCHandle.FromIntPtr(gchp).Free();
+                            deleters.TryRemove(deleter, out deleter);
+                         });
+                    deleters.TryAdd(deleter, deleter); // keep the delegate alive
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Bool, requiresGrad));
+                }
+            }
+        }
+
+        public static TorchTensor From(bool[] rawArray, bool requiresGrad = false)
+        {
+            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, [MarshalAs(UnmanagedType.LPStr)] string device, bool requiresGrad);
+
+        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, device, requiresGrad));
                 }
             }
         }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -39,7 +39,7 @@ foreach (var type in TorchTypeDef.Types) {
         {
             TorchTensor.CheckForCUDA (device);
 
-            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+            return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -56,7 +56,7 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_zeros ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }
@@ -75,7 +75,7 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_ones ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }
@@ -94,7 +94,7 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_empty ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }
@@ -113,7 +113,7 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randint (max, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }
@@ -134,7 +134,7 @@ if (type.IsFloat) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_rand ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_rand ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }
@@ -153,7 +153,7 @@ if (type.IsFloat) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randn ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_randn ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }
@@ -184,12 +184,12 @@ if (!type.IsLong) {
 <#
 if (!type.IsLong) {
 #>
-            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, requiresGrad));
+            return new TorchTensor(THSTensor_new(rawArray, null, dimensions, dimensions.Length, (sbyte)ScalarType.<#=type.Name#>, requiresGrad));
 <# } else { #>
             return new TorchTensor(THSTensor_newLong(rawArray, null, dimensions, dimensions.Length, requiresGrad));
 <# } #>
         }
-
+        
         public static TorchTensor From(<#=type.Storage#>[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             unsafe
@@ -209,7 +209,7 @@ if (!type.IsLong) {
 <#
 if (!type.IsLong) {
 #>
-                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, requiresGrad));
+                    return new TorchTensor(THSTensor_new(addr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.<#=type.Name#>, requiresGrad));
 <# } else { #>
                     return new TorchTensor(THSTensor_newLong(addr, deleter, dimensions, dimensions.Length, requiresGrad));
 <# } #>
@@ -233,7 +233,7 @@ if (!type.IsLong) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ATenScalarMapping.<#=type.Name#>, device, requiresGrad));
+                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
                 }
             }
         }

--- a/src/TorchSharp/Tensor/Types.ttinclude
+++ b/src/TorchSharp/Tensor/Types.ttinclude
@@ -1,4 +1,4 @@
-﻿<#+
+<#+
     public class TorchTypeDef {
 
         public readonly string Name;
@@ -9,10 +9,9 @@
         public readonly bool IsFloat;
         public readonly bool IsLong;
 
-        private TorchTypeDef(string name, string storage, string cstype) {
+        private TorchTypeDef(string name, string storage) {
             this.Name = name;
             this.Storage = storage;
-            this.CSType = cstype;
 
             this.IsSignedInt = name == "SByte" || name == "Short" || name == "Int" || name == "Long";
             this.IsFloat = name == "Float" || name == "Double";
@@ -20,13 +19,22 @@
         }
 
         public static readonly TorchTypeDef[] Types = {
-            new TorchTypeDef("Byte",   "byte",   "Byte"  ),
-            new TorchTypeDef("SByte",  "sbyte",  "SByte" ),
-            new TorchTypeDef("Short",  "short",  "Short"  ),
-            new TorchTypeDef("Int",    "int",    "Int"  ),
-            new TorchTypeDef("Long",   "long",   "Long"  ),
-            new TorchTypeDef("Double", "double", "Double"),
-            new TorchTypeDef("Float",  "float",  "Single"),
+            new TorchTypeDef("Byte",   "byte"),
+            new TorchTypeDef("SByte",  "sbyte"),
+            new TorchTypeDef("Short",  "short"),
+            new TorchTypeDef("Int",    "int"),
+            new TorchTypeDef("Long",   "long"),
+            new TorchTypeDef("Half",   "TorchSharp.Half"),
+            new TorchTypeDef("Float",  "float"),
+            new TorchTypeDef("Double", "double"),
+            //new TorchTypeDef("ComplexHalf",  "ComplexHalf"),
+            //new TorchTypeDef("ComplexFloat",  "ComplexFloat"),
+            //new TorchTypeDef("ComplexDouble",  "System.Numerics.Complex"),
+            new TorchTypeDef("Bool",  "bool"),
+            //new TorchTypeDef("QInt8",  "QInt8"),
+            //new TorchTypeDef("QUInt8",  "QUInt8"),
+            //new TorchTypeDef("QUInt32",  "QUInt32"),
+            //new TorchTypeDef("BFloat16",  "BFloat16"),
         };
 
         public readonly string Ptr = "IntPtr"; // "HType";

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using TorchSharp.NN;
 using static TorchSharp.NN.Modules;
@@ -20,6 +21,33 @@ namespace TorchSharp.Test
             var shape = new long[] { 2, 2 };
             TorchTensor ones = FloatTensor.Ones(shape);
             Assert.Equal(shape, ones.Shape);
+            Assert.Equal(1.0f, ones[0,0].DataItem<float>());
+            Assert.Equal(1.0f, ones[1,1].DataItem<float>());
+
+            TorchTensor onesB = ByteTensor.Ones(shape);
+            Assert.Equal(shape, onesB.Shape);
+            Assert.Equal((byte)1, onesB[0,0].DataItem<byte>());
+            Assert.Equal((byte)1, onesB[1,1].DataItem<byte>());
+
+            TorchTensor onesI = IntTensor.Ones(shape);
+            Assert.Equal(shape, onesI.Shape);
+            Assert.Equal(1, onesI[0,0].DataItem<int>());
+            Assert.Equal(1, onesI[1,1].DataItem<int>());
+
+            TorchTensor onesL = LongTensor.Ones(shape);
+            Assert.Equal(shape, onesL.Shape);
+            Assert.Equal((long)1, onesL[0,0].DataItem<int>());
+            Assert.Equal((long)1, onesL[1,1].DataItem<int>());
+
+            TorchTensor onesBool = BoolTensor.Ones(shape);
+            Assert.Equal(shape, onesBool.Shape);
+            Assert.Equal((object)true, onesBool[0,0].DataItem<bool>());
+            Assert.Equal((object)true, onesBool[1,1].DataItem<bool>());
+
+            TorchTensor onesHalf = HalfTensor.Ones(shape);
+            Assert.Equal(shape, onesHalf.Shape);
+            Assert.Equal((Half)1, onesHalf[0, 0].DataItem<Half>());
+            Assert.Equal((Half)1, onesHalf[1, 1].DataItem<Half>());
         }
 
         [Fact]
@@ -150,6 +178,55 @@ namespace TorchSharp.Test
             }
         }
 
+
+        [Fact]
+        public void CreateHalfTensorFromDataCheckStrides()
+        {
+            var data = new Half[] { (Half)0.2663158, (Half)0.1144736, (Half)0.1147367, (Half)0.1249998, (Half)0.1957895, (Half)0.1231576, (Half)0.1944732, (Half)0.111842, (Half)0.1065789, (Half)0.667881, (Half)0.5682123, (Half)0.5824502, (Half)0.4824504, (Half)0.4844371, (Half)0.6463582, (Half)0.5334439, (Half)0.5079474, (Half)0.2281452 };
+            var dataTensor = data.ToTorchTensor(new long[] { 2, 9 });
+
+            for (int r = 0; r < 2; r++) {
+                for (int i = 0; i < 9; i++) {
+                    var fromData = data[(r * 9) + i];
+                    var fromTensor = dataTensor[r, i].DataItem<Half> ();
+                    Assert.True(Math.Abs(fromData - fromTensor) < 0.01);
+                }
+            }
+
+            var firstHalf = dataTensor[0];
+
+            for (int i = 0; i < 9; i++) {
+                var fromData = data[i];
+                var fromChunk = firstHalf[i].DataItem<Half>();
+                Assert.True(Math.Abs(fromData - fromChunk) < 0.01);
+            }
+        }
+
+
+        //[Fact]
+        //public void CreateComplexDoubleTensorFromDataCheckStrides()
+        //{
+        //    var data = new Complex[] { new Complex(0.2663158,1.0), 0.1144736, 0.1147367, 0.1249998, 0.1957895, 0.1231576, 0.1944732, 0.111842, 0.1065789, 0.667881, 0.5682123, 0.5824502, 0.4824504, 0.4844371, 0.6463582, 0.5334439, 0.5079474, 0.2281452 };
+        //    var dataTensor = data.ToTorchTensor(new long[] { 2, 9 });
+
+        //    for (int r = 0; r < 2; r++) {
+        //        for (int i = 0; i < 9; i++) {
+        //            var fromData = data[(r * 9) + i];
+        //            var fromTensor = dataTensor[r, i].DataItem<Complex>();
+        //            Assert.True(Math.Abs((fromData - fromTensor).Real) < 0.00001);
+        //            Assert.True(Math.Abs((fromData - fromTensor).Imaginary) < 0.00001);
+        //        }
+        //    }
+
+        //    var firstHalf = dataTensor[0];
+
+        //    for (int i = 0; i < 9; i++) {
+        //        var fromData = data[i];
+        //        var fromChunk = firstHalf[i].DataItem<Complex>();
+        //        Assert.True(Math.Abs((fromData - fromChunk).Real) < 0.00001);
+        //        Assert.True(Math.Abs((fromData - fromChunk).Imaginary) < 0.00001);
+        //    }
+        //}
         [Fact]
         public void CreateFloatTensorFromScalar()
         {
@@ -183,37 +260,37 @@ namespace TorchSharp.Test
         {
             using (var tensor = 1.ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.Int, tensor.Type);
+                Assert.Equal(ScalarType.Int, tensor.Type);
                 Assert.Equal(1, tensor.DataItem<int>());
             }
             using (var tensor = ((byte)1).ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.Byte, tensor.Type);
+                Assert.Equal(ScalarType.Byte, tensor.Type);
                 Assert.Equal(1, tensor.DataItem<byte>());
             }
             using (var tensor = ((sbyte)-1).ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.SByte, tensor.Type);
+                Assert.Equal(ScalarType.SByte, tensor.Type);
                 Assert.Equal(-1, tensor.DataItem<sbyte>());
             }
             using (var tensor = ((short)-1).ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.Short, tensor.Type);
+                Assert.Equal(ScalarType.Short, tensor.Type);
                 Assert.Equal(-1, tensor.DataItem<short>());
             }
             using (var tensor = ((long)-1).ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.Long, tensor.Type);
+                Assert.Equal(ScalarType.Long, tensor.Type);
                 Assert.Equal(-1L, tensor.DataItem<short>());
             }
             using (var tensor = ((float)-1).ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.Float, tensor.Type);
+                Assert.Equal(ScalarType.Float, tensor.Type);
                 Assert.Equal(-1.0f, tensor.DataItem<float>());
             }
             using (var tensor = ((double)-1).ToTorchTensor())
             {
-                Assert.Equal(ATenScalarMapping.Double, tensor.Type);
+                Assert.Equal(ScalarType.Double, tensor.Type);
                 Assert.Equal(-1.0, tensor.DataItem<double>());
             }
         }
@@ -354,7 +431,7 @@ namespace TorchSharp.Test
         [Fact]
         public void TestSquareEuclideanDistance()
         {
-            var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).ToType(ATenScalarMapping.Float);
+            var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).ToType(ScalarType.Float);
             var zeros = FloatTensor.Zeros(new long[] { 1, 9 });
             var ones = FloatTensor.Ones(new long[] { 1, 9 });
             var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
@@ -721,12 +798,12 @@ namespace TorchSharp.Test
         public void TestGrad2()
         {
             var y = FloatTensor.RandomN(new long[] { 32, 1 }, device: "cpu:0");
-            var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).ToType(ATenScalarMapping.Float);
+            var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).ToType(ScalarType.Float);
             var inputs = new TorchTensor[] { input };
-            var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ATenScalarMapping.Float).RequiresGrad(true);
+            var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float).RequiresGrad(true);
             var linear = Linear(11, 1, true);
-            linear.Bias = new double[] { 373.8864 }.ToTorchTensor(new long[] { 1, 1 }).ToType(ATenScalarMapping.Float).RequiresGrad(true);
-            linear.Weight = new double[] { 300.2818, -0.5905267, 286.2787, 0.1970505, 0.9004903, 0.1373157, 55.85495, 11.43741, 1.525748, 0.4299785, 239.9356 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ATenScalarMapping.Float).RequiresGrad(true);
+            linear.Bias = new double[] { 373.8864 }.ToTorchTensor(new long[] { 1, 1 }).ToType(ScalarType.Float).RequiresGrad(true);
+            linear.Weight = new double[] { 300.2818, -0.5905267, 286.2787, 0.1970505, 0.9004903, 0.1373157, 55.85495, 11.43741, 1.525748, 0.4299785, 239.9356 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float).RequiresGrad(true);
 
             var afterCat = inputs.Cat(1);
             var afterScaler = afterCat * scaler;
@@ -1535,20 +1612,20 @@ namespace TorchSharp.Test
             var res1_0 = res1.DataItem<float>();
             Assert.Equal(6.0f, res1_0);
 
-            var res2 = FloatTensor.From(data).Sum(type: ATenScalarMapping.Double);
+            var res2 = FloatTensor.From(data).Sum(type: ScalarType.Double);
             var res2_0 = res2.DataItem<double>();
             Assert.Equal(6.0, res2_0);
 
             // summing integers gives long unless type is explicitly specified
             var dataInt32 = new int[] { 1, 2, 3 };
             var res3 = IntTensor.From(dataInt32).Sum();
-            Assert.Equal(ATenScalarMapping.Long, res3.Type);
+            Assert.Equal(ScalarType.Long, res3.Type);
             var res3_0 = res3.DataItem<long>();
             Assert.Equal(6L, res3_0);
 
             // summing integers gives long unless type is explicitly specified
-            var res4 = IntTensor.From(dataInt32).Sum(type: ATenScalarMapping.Int);
-            Assert.Equal(ATenScalarMapping.Int, res4.Type);
+            var res4 = IntTensor.From(dataInt32).Sum(type: ScalarType.Int);
+            Assert.Equal(ScalarType.Int, res4.Type);
             var res4_0 = res4.DataItem<int>();
             Assert.Equal(6L, res4_0);
 
@@ -1603,6 +1680,9 @@ namespace TorchSharp.Test
 
             var res5 = SByteTensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res5.Shape);
+
+            var res6 = HalfTensor.RandomIntegers(10, new long[] { 200 });
+            Assert.Equal(new long[] { 200 }, res6.Shape);
         }
 
         [Fact]


### PR DESCRIPTION
* Add half-precision floating point tensor support (currently using a TorchSharp.Half type for in/out creation).

* Add Torch 1.5.0 Bool/Byte tensor support 

* Add maxpool_with_indices and friends

* Add scatter/gather

* Rename ATenScalarMapping to ScalarType