### PR TITLE
start of #146 (Load/Save models, JIT)

### DIFF
--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -57,6 +57,9 @@ EXPORT_API(void)     THSNN_Linear_set_weight(const NNModule module, const Tensor
 EXPORT_API(NNModule) THSNN_ReLU_ctor(bool inplace, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_ReLU_forward(const NNModule module, const Tensor tensor);
 
+EXPORT_API(NNModule) THSNN_LogSoftMax_ctor(int64_t dim, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_LogSoftMax_forward(const NNModule module, const Tensor tensor);
+
 EXPORT_API(NNModule) THSNN_Sequential_ctor();
 EXPORT_API(void)     THSNN_Sequential_push_back(const NNModule module, const char* name, const NNAnyModule submodule);
 EXPORT_API(Tensor)   THSNN_Sequential_forward(const NNModule module, const Tensor tensor);

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -11,13 +11,6 @@ namespace TorchSharp.NN
     {
         internal Linear (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
-        public new static Linear Load (String modelPath)
-        {
-            var res = Module.Load (modelPath);
-            Torch.CheckForErrors ();
-            return new Linear (res.handle.DangerousGetHandle(), IntPtr.Zero);
-        }
-
         [DllImport ("LibTorchSharp")]
         extern static IntPtr THSNN_Linear_forward (Module.HType module, IntPtr tensor);
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -91,15 +91,6 @@ namespace TorchSharp.NN
                 handle.SetHandleAsInvalid ();
             }
         }
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Module_load([MarshalAs(UnmanagedType.LPStr)] string location);
-
-        public static Module Load(String location)
-        {
-            var handle = THSNN_Module_load (location);
-            Torch.CheckForErrors ();
-            return new Module (handle, IntPtr.Zero);
-        }
 
         [DllImport ("LibTorchSharp")]
         extern static void THSNN_Module_save (HType handle, [MarshalAs(UnmanagedType.LPStr)] string location);

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -972,9 +972,10 @@ namespace TorchSharp.Test
             if (File.Exists (".model.ts")) File.Delete (".model.ts");
             var linear = Linear(100, 10, true);
             linear.Save(".model.ts");
-            var loadedLinear = NN.Linear.Load(".model.ts");
-            File.Delete(".model.ts");
-            Assert.NotNull(loadedLinear);
+            // See https://github.com/xamarin/TorchSharp/issues/146
+            //var loadedLinear = NN.Linear.Load(".model.ts");
+            //File.Delete(".model.ts");
+            //Assert.NotNull(loadedLinear);
         }
 
         [Fact]
@@ -983,9 +984,10 @@ namespace TorchSharp.Test
             if (File.Exists (".model.ts")) File.Delete (".model.ts");
             var conv = Conv2D(100, 10, 5);
             conv.Save(".model.ts");
-            var loaded = NN.Conv2D.Load(".model.ts");
-            File.Delete(".model.ts");
-            Assert.NotNull(loaded);
+            // See https://github.com/xamarin/TorchSharp/issues/146
+            //var loaded = NN.Conv2D.Load(".model.ts");
+            //File.Delete(".model.ts");
+            //Assert.NotNull(loaded);
         }
 
         [Fact]
@@ -996,9 +998,10 @@ namespace TorchSharp.Test
             var lin2 = Linear(10, 5, true);
             var seq = Sequential(("lin1", lin1), ("lin2", lin2));
             seq.Save(".model-list.txt");
-            var loaded = NN.Sequential.Load(".model-list.txt");
-            File.Delete("model-list.txt");
-            Assert.NotNull(loaded);
+            // See https://github.com/xamarin/TorchSharp/issues/146
+            //var loaded = NN.Sequential.Load(".model-list.txt");
+            //File.Delete("model-list.txt");
+            //Assert.NotNull(loaded);
         }
 
         [Fact]


### PR DESCRIPTION
This is the start of https://github.com/xamarin/TorchSharp/issues/146

* [ ] The existing Load/Save on the module type is broken because the incorrect C++ Impl object is created for the loaded model (e.g. `torch::nn::Module` not `torch::nn::ReLUImpl`).  It should be removed.

* [ ] To get loading according to the C++ PyTorch docs, the JIT functionality needs to be brought back.

