### PR TITLE
Add the ops needed for DiffSharp

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -562,6 +562,70 @@ Tensor THSTensor_relu_(const Tensor tensor)
     CATCH_TENSOR(tensor->relu_());
 }
 
+Tensor THSTensor_bernoulli(const Tensor tensor, const double p)
+{
+    CATCH_TENSOR(tensor->bernoulli(p));
+}
+
+Tensor THSTensor_bernoulli_(const Tensor tensor, const double p)
+{
+    CATCH_TENSOR(tensor->bernoulli_(p));
+}
+
+Tensor THSTensor_cauchy_(const Tensor tensor, const double median, const double sigma)
+{
+    CATCH_TENSOR(tensor->cauchy_(median, sigma));
+}
+
+Tensor THSTensor_exponential_(const Tensor tensor, const double lambd)
+{
+    CATCH_TENSOR(tensor->exponential_(lambd));
+}
+
+Tensor THSTensor_geometric_(const Tensor tensor, const double p)
+{
+    CATCH_TENSOR(tensor->geometric_(p));
+}
+
+Tensor THSTensor_log_normal_(const Tensor tensor, const double mean, const double std)
+{
+    CATCH_TENSOR(tensor->log_normal_(mean, std));
+}
+
+Tensor THSTensor_normal_(const Tensor tensor, const double mean, const double std)
+{
+    CATCH_TENSOR(tensor->normal_(mean, std));
+}
+
+Tensor THSTensor_uniform_(const Tensor tensor, const double from, const double to)
+{
+    CATCH_TENSOR(tensor->uniform_(from, to));
+}
+
+Tensor THSTensor_randperm(const int64_t n,
+    const int8_t scalar_type,
+    const char * device,
+    const bool requires_grad)
+{
+    Tensor tensor;
+    CATCH(
+        auto options =
+            at::TensorOptions()
+            .dtype(at::ScalarType(scalar_type))
+            .device(device)
+            .requires_grad(requires_grad);
+
+        tensor = new torch::Tensor(torch::randperm(n, options));
+    )
+    return tensor;
+}
+
+Tensor THSTensor_multinomial(const Tensor tensor, const double num_samples, const bool replacement)
+{
+    CATCH_TENSOR(tensor->multinomial(num_samples, replacement));
+}
+
+
 Tensor THSTensor_acos(const Tensor tensor)
 {
     CATCH_TENSOR(tensor->acos());

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -1726,6 +1726,91 @@ namespace TorchSharp.Tensor
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_bernoulli(IntPtr src, double p);
+
+        public TorchTensor Bernoulli(double p)
+        {
+            var res = THSTensor_bernoulli(handle, p);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_bernoulli_(IntPtr src, double p);
+
+        public TorchTensor BernoulliInPlace(double p)
+        {
+            var res = THSTensor_bernoulli_(handle, p);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_cauchy_(IntPtr src, double median, double sigma);
+
+        public TorchTensor CauchyInPlace(double median = 0.0, double sigma = 1.0)
+        {
+            var res = THSTensor_cauchy_(handle, median, sigma);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_exponential_(IntPtr src, double lambd);
+
+        public TorchTensor ExponentialInPlace(double lambd = 1.0)
+        {
+            var res = THSTensor_exponential_(handle, lambd);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_geometric_(IntPtr src, double p);
+
+        public TorchTensor GeometricInPlace(double p)
+        {
+            var res = THSTensor_geometric_(handle, p);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_log_normal_(IntPtr src, double mean, double std);
+
+        public TorchTensor LogNormalInPlace(double mean = 1.0, double std = 2.0)
+        {
+            var res = THSTensor_log_normal_(handle, mean, std);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_normal_(IntPtr src, double mean, double std);
+
+        public TorchTensor NormalInPlace(double mean = 0.0, double std = 1.0)
+        {
+            var res = THSTensor_normal_(handle, mean, std);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_uniform_(IntPtr src, double from, double to);
+
+        public TorchTensor UniformInPlace(double from = 0.0, double to = 1.0)
+        {
+            var res = THSTensor_uniform_(handle, from, to);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_multinomial(IntPtr src, double num_samples, bool replacement);
+
+        public TorchTensor Multinomial(double num_samples, bool replacement = false)
+        {
+            var res = THSTensor_multinomial(handle, num_samples, replacement);
+            Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_expand(IntPtr src, IntPtr psizes, int length, bool isImplicit);

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -35,6 +35,19 @@ namespace TorchSharp.Tensor {
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Byte, device, requiresGrad));
         }
 		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Byte, device, requiresGrad));
+        }
+		
 		[DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
 
@@ -196,6 +209,19 @@ namespace TorchSharp.Tensor {
             TorchTensor.CheckForCUDA (device);
 
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.SByte, device, requiresGrad));
+        }
+		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.SByte, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -361,6 +387,19 @@ namespace TorchSharp.Tensor {
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Short, device, requiresGrad));
         }
 		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Short, device, requiresGrad));
+        }
+		
 		[DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
 
@@ -522,6 +561,19 @@ namespace TorchSharp.Tensor {
             TorchTensor.CheckForCUDA (device);
 
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Int, device, requiresGrad));
+        }
+		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Int, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -687,6 +739,19 @@ namespace TorchSharp.Tensor {
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Long, device, requiresGrad));
         }
 		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Long, device, requiresGrad));
+        }
+		
 		[DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
 
@@ -850,6 +915,19 @@ namespace TorchSharp.Tensor {
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Half, device, requiresGrad));
         }
 		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Half, device, requiresGrad));
+        }
+		
 		[DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
 
@@ -1011,6 +1089,19 @@ namespace TorchSharp.Tensor {
             TorchTensor.CheckForCUDA (device);
 
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Float, device, requiresGrad));
+        }
+		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Float, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -1213,6 +1304,19 @@ namespace TorchSharp.Tensor {
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Double, device, requiresGrad));
         }
 		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Double, device, requiresGrad));
+        }
+		
 		[DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
 
@@ -1411,6 +1515,19 @@ namespace TorchSharp.Tensor {
             TorchTensor.CheckForCUDA (device);
 
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.Bool, device, requiresGrad));
+        }
+		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Bool, device, requiresGrad));
         }
 		
 		[DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -42,6 +42,19 @@ foreach (var type in TorchTypeDef.Types) {
             return new TorchTensor (THSTensor_arange (start.ToScalar().Handle, stop.ToScalar().Handle, step.ToScalar().Handle, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
         }
 		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, string device = "cpu", bool requiresGrad = false)
+        {
+            TorchTensor.CheckForCUDA (device);
+
+            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.<#=type.Name#>, device, requiresGrad));
+        }
+		
 		[DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_zeros(<#=type.Ptr#> psizes, int length, int scalarType, [MarshalAs(UnmanagedType.LPStr)] string device, bool requireGrad);
 


### PR DESCRIPTION
@gbaydin requested these ops in #140 

In some cases (for the distributions) only the inplace versions of the ops appear to be available in the C++ API.