### PR TITLE
Fix DLL loading on Windows

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -109,6 +109,7 @@
           DestinationFolder="$(OutputPath)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
+          SkipUnchangedFiles="true"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
           UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
           UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -18,7 +18,7 @@ namespace TorchSharp.Tensor
             this.handle = handle;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is TorchTensor) && this.Equal((obj as TorchTensor)!);
 

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -16,9 +16,6 @@ namespace TorchSharp
             THSTorch_seed(seed);
         }
 
-        [DllImport("kernel32.dll")]
-        static extern IntPtr LoadLibrary(string lpFileName);
-
         internal static bool TryInitializeDeviceType(DeviceType deviceType)
         {
             if (deviceType == DeviceType.CUDA) {

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace TorchSharp
@@ -17,13 +16,19 @@ namespace TorchSharp
             THSTorch_seed(seed);
         }
 
+        [DllImport("kernel32.dll")]
+        static extern IntPtr LoadLibrary(string lpFileName);
+
         internal static bool TryInitializeDeviceType(DeviceType deviceType)
         {
             if (deviceType == DeviceType.CUDA) {
 
                 // See https://github.com/pytorch/pytorch/issues/33415
-                if (System.Environment.OSVersion.Platform == PlatformID.Win32NT) {
-                    LoadLibrary(@"torch_cuda.dll");
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+                    NativeLibrary.TryLoad("torch_cuda", typeof(Torch).Assembly, null, out var res1);
+                    NativeLibrary.TryLoad("nvrtc-builtins64_102", typeof(Torch).Assembly, null, out var res2);
+                    NativeLibrary.TryLoad("caffe2_nvrtc", typeof(Torch).Assembly, null, out var res3);
+                    NativeLibrary.TryLoad("nvrtc64_102_0", typeof(Torch).Assembly, null, out var res4);
                 }
                 return THSTorchCuda_is_available();
 
@@ -55,8 +60,6 @@ namespace TorchSharp
         [DllImport("LibTorchSharp")]
         private static extern bool THSTorchCuda_is_available();
 
-        [DllImport("kernel32.dll")]
-        public static extern IntPtr LoadLibrary(string dllToLoad);
 
         public static bool IsCudaAvailable()
         {

--- a/src/TorchSharp/TorchSharp.csproj
+++ b/src/TorchSharp/TorchSharp.csproj
@@ -1,9 +1,9 @@
-﻿<Project>
+<Project>
   <!-- Implicit top import -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-      <TargetFrameworks>netstandard2.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
       <IncludeInPackage>TorchSharp</IncludeInPackage>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <UseMLCodeAnalyzer>false</UseMLCodeAnalyzer>

--- a/test/TorchSharpTest/TorchTensor.cs
+++ b/test/TorchSharpTest/TorchTensor.cs
@@ -452,6 +452,67 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestCat()
+        {
+            var zeros = FloatTensor.Zeros(new long[] { 1, 9 });
+            var ones = FloatTensor.Ones(new long[] { 1, 9 });
+            var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
+
+            var shape = centroids.Shape;
+            Assert.Equal(new long[] { 2, 9 }, shape);
+        }
+
+        [Fact]
+        public void TestCatCuda()
+        {
+            if (Torch.IsCudaAvailable()) {
+                var zeros = FloatTensor.Zeros(new long[] { 1, 9 }).Cuda();
+                var ones = FloatTensor.Ones(new long[] { 1, 9 }).Cuda();
+                var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
+                var shape = centroids.Shape;
+                Assert.Equal(new long[] { 2, 9 }, shape);
+                Assert.Equal(DeviceType.CUDA, centroids.DeviceType);
+            }
+        }
+
+        void TestStackGen(DeviceType device)
+        {
+            {
+                var t1 = FloatTensor.Zeros( new long[] { }, device );
+                var t2 = FloatTensor.Ones(new long[] { }, device);
+                var t3 = FloatTensor.Ones(new long[] { }, device);
+                var res = new TorchTensor[] { t1, t2, t3 }.Stack(0);
+
+                var shape = res.Shape;
+                Assert.Equal(new long[] { 3 }, shape);
+                Assert.Equal(device, res.DeviceType);
+            }
+            {
+                var t1 = FloatTensor.Zeros(new long[] { 2, 9 }, device);
+                var t2 = FloatTensor.Ones(new long[] { 2, 9 }, device);
+                var res = new TorchTensor[] { t1, t2 }.Stack(0);
+
+                var shape = res.Shape;
+                Assert.Equal(new long[] { 2, 2, 9 }, shape);
+                Assert.Equal(device, res.DeviceType);
+            }
+        }
+
+        [Fact]
+        public void TestStackCpu()
+        {
+            TestStackGen(DeviceType.CPU);
+        }
+
+        [Fact]
+        public void TestStackCuda()
+        {
+            if (Torch.IsCudaAvailable()) {
+                TestStackGen(DeviceType.CUDA);
+            }
+        }
+
+        [Fact]
         public void TestSetGrad()
         {
             var x = FloatTensor.Random(new long[] { 10, 10 });


### PR DESCRIPTION
This fixes #159 

Note that TorchSharp is now `netcoreapp3.0` in order to use the relevent API to load native components accurately