### PR TITLE
Add explicit memory pressure option for tensors

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -1,0 +1,154 @@
+
+# Building
+
+
+## Windows
+
+Requirements:
+- Visual Studio
+- git
+- cmake (tested with 3.14)
+
+Commands:
+- Building: `build.cmd build` (can use  `dotnet build` after first time)
+- Building from Visual Studio: first build using the command line
+- Run tests from command line: `dotnet test`
+
+
+## Linux/Mac
+
+Requirements:
+- requirements to run .NET Core 2.0
+- git
+- cmake (tested with 3.14)
+- clang 4.x +
+
+Example to fulfill the requirements in Ubuntu 16:
+```
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+sudo apt-get -y update
+sudo apt-get -y install clang-6.0 git cmake libunwind8 curl libssl1.0.0 libomp-dev
+```
+
+Commands:
+- Building: `./build.sh`
+- Building from Visual Studio: first build using the command line
+- Run tests from command line: `dotnet test`
+- Build packages: `dotnet pack`
+
+
+## Packages
+
+An ephemeral feed of packages from CI is available 
+
+* View link: https://donsyme.visualstudio.com/TorchSharp/_packaging?_a=feed&feed=packages2
+* Nuget feed: https://donsyme.pkgs.visualstudio.com/TorchSharp/_packaging/packages2/nuget/v3/index.json
+
+
+## Building the TorchSharp package
+
+The managed package can be built with `dotnet pack`, e.g.
+
+    ./build.cmd pack
+
+or just 
+
+    dotnet pack
+
+Locally built packages have names like this, names update every day.  If repeatedly rebuilding them locally you may have to remove them
+from your local `.nuget` package cache.
+
+    bin/packages/Debug/TorchSharp.0.3.0-local-Debug-20200520.nupkg
+    bin/packages/Release/TorchSharp.0.3.0-local-Release-20200520.nupkg
+
+To change the TorchSharp package version update this [file](https://github.com/xamarin/TorchSharp/blob/master/build/BranchInfo.props).
+
+## Making releases of the TorchSharp package
+
+The TorchSharp package is pushed to nuget.org either manually or as part of Azure DevOps CI release pipeline, see below.
+
+# The libtorch packages
+
+The libtorch packages are huge (~1.6GB compressed) and cause a lot of problems to make and delier due to nuget package size restrictions.
+These problems include:
+
+1. A massive 1GB binary in the linux CUDA package and multiple 0.5GB binaries in Windows CUDA package
+
+2. Size limitations of about ~500MB on nuget packages on the Azure DevOps CI system and about ~250MB on `nuget.org`
+
+4. Regular download/upload failures on these systems due to network interruptions for packages of this size
+
+5. 10GB VM image size restrictions for the containers userd to build these packages in the Azure DevOps CI system, we can easily run out of room.
+
+6. Complete libtorch-cpu packages can't be built using your local machine alone, since they won't contain the
+   full range of native bits. Instead they are built using Azure Pipelines.
+
+For this reason, we do the following
+
+1. The head, referenceable packages that deliver a functioning runtime are any of:
+
+   libtorch-cpu
+   libtorch-cuda-10.2
+   libtorch-cuda-10.2-linux-x64
+   libtorch-cuda-10.2-win-x64
+
+2. These packages are combo packages that reference multiple parts.  The parts are **not** independently useful.
+
+3. Some parts deliver a single vast file via `primary` and `fragment` packages.  A build task is then used to "stitch" these files back together 
+   to one file on the target machine with a SHA check.  This is a hack but there is no other realistic way to deliver
+   these vast files as packages (the alternative is to abandon packaging and require a manual
+   install/detect/link of PyTorch CUDA on all downstream systems, whcih is extremely problematic
+   for many practical reasons).
+
+4. The `libtorch-*` packages are built in Azure DevOps CI
+   [using this build pipeline](https://donsyme.visualstudio.com/TorchSharp/_build?definitionId=1&_a=summary) but only in master
+   branch and only when `<BuildLibTorchPackages>true</BuildLibTorchPackages>` is set in that branch.  You must currently
+   manually set this, increment `LibTorchPackageVersion`, do a push to master and the packages will build.  This process could be adjusted
+   but at least gets us off the ground.
+
+5. After a successful build, the `libtorch-*` packages can be trialled using the package feed from CI (see above).  When
+   they are appropriate they can be  pushed to nuget using
+   [this manually invoked release pipeline](https://donsyme.visualstudio.com/TorchSharp/_release?_a=releases&view=mine&definitionId=1) in
+   Azure DevOps CI (so they don't have to be manually downloaded and pushed to `nuget.org`)
+
+   a. [Go to release pipeline](https://donsyme.visualstudio.com/TorchSharp/_release?_a=releases&view=mine&definitionId=1)
+
+   b. Press 'New Release'
+
+   c. Select the successful master CI build that includes the `libtorch` packages, create the release and wait for it to finish. You should
+      see `Initialize job`, `Download artifact - _xamarin.TorchSharp - packages`, `NuGet push`, `Finalize Job` succeeded.
+
+   d. All packages should now be pushed to `nuget.org` and will appear after indexing.
+
+
+### Updating PyTorch version for libtorch packages
+
+This project grabs LibTorch and makes a C API wrapper for it, then calls these from C#. When updating to a newer
+version of PyTorch then quite a lot of careful work needs to be done.
+
+See https://pytorch.org/get-started/locally/ for download links.
+
+For example Linux, LibTorch 1.5.0 uses link
+
+    https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.5.0%2Bcpu.zip
+
+To update the version, update these:
+
+    <LibtorchVersion>1.5.0</LibtorchVersion>
+
+Then run these to test downloads and update SHA hashes for the various LibTorch downloads:
+
+    msbuild src\Redist\libtorch-cuda-10.2\libtorch-cuda-10.2.proj /p:UpdateSHA=true /p:TargetOS=linux /t:Build
+    msbuild src\Redist\libtorch-cuda-10.2\libtorch-cuda-10.2.proj /p:UpdateSHA=true /p:TargetOS=windows /t:Build
+
+    msbuild src\Redist\libtorch-cpu\libtorch-cpu.proj /p:UpdateSHA=true /p:TargetOS=linux /t:Build
+    msbuild src\Redist\libtorch-cpu\libtorch-cpu.proj /p:UpdateSHA=true /p:TargetOS=windows /t:Build
+    msbuild src\Redist\libtorch-cpu\libtorch-cpu.proj /p:UpdateSHA=true /p:TargetOS=mac /t:Build
+
+You must also update the "FilesFromArchive= ..." entries under src\Redist projects. Check the contents
+of the unzip of the archive, e.g.
+
+     bin\obj\x86.Debug\libtorch-cpu\libtorch-shared-with-deps-1.5.0%2Bcpu\libtorch\lib
+
+You must also adjust the set of binaries referenced for tests, see various files under `tests`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://donsyme.visualstudio.com/TorchSharp/_apis/build/status/xamarin.TorchSharp?branchName=master)](https://donsyme.visualstudio.com/TorchSharp/_build/latest?definitionId=1&branchName=master)
 
-TorchSharp
-==========
+# TorchSharp
 
 TorchSharp is a .NET library that provides access to the library that powers
 PyTorch.  It is a work in progress, but already provides a .NET API that can
@@ -47,168 +46,20 @@ for (int i = 0; i < 10; i++)
 }
 ```
 
+# Memory management
+
+See [docfx/articles/memory.md](docfx/articles/memory.md).
+
+# Developing
+
+See [DEVGUIDE.md](DEVGUIDE.md).
+
 # Discussions
 
 We have a chat room on Gitter [![Gitter](https://badges.gitter.im/xamarin/TorchSharp.svg)](https://gitter.im/xamarin/TorchSharp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
-# Building
+# Uses
 
-
-## Windows
-
-Requirements:
-- Visual Studio
-- git
-- cmake (tested with 3.14)
-
-Commands:
-- Building: `build.cmd build` (can use  `dotnet build` after first time)
-- Building from Visual Studio: first build using the command line
-- Run tests from command line: `dotnet test`
-
-
-## Linux/Mac
-
-Requirements:
-- requirements to run .NET Core 2.0
-- git
-- cmake (tested with 3.14)
-- clang 4.x +
-
-Example to fulfill the requirements in Ubuntu 16:
-```
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
-sudo apt-get -y update
-sudo apt-get -y install clang-6.0 git cmake libunwind8 curl libssl1.0.0 libomp-dev
-```
-
-Commands:
-- Building: `./build.sh`
-- Building from Visual Studio: first build using the command line
-- Run tests from command line: `dotnet test`
-- Build packages: `dotnet pack`
-
-
-## Packages
-
-An ephemeral feed of packages from CI is available 
-
-* View link: https://donsyme.visualstudio.com/TorchSharp/_packaging?_a=feed&feed=packages2
-* Nuget feed: https://donsyme.pkgs.visualstudio.com/TorchSharp/_packaging/packages2/nuget/v3/index.json
-
-
-## Building the TorchSharp package
-
-The managed package can be built with `dotnet pack`, e.g.
-
-    ./build.cmd pack
-
-or just 
-
-    dotnet pack
-
-Locally built packages have names like this, names update every day.  If repeatedly rebuilding them locally you may have to remove them
-from your local `.nuget` package cache.
-
-    bin/packages/Debug/TorchSharp.0.3.0-local-Debug-20200520.nupkg
-    bin/packages/Release/TorchSharp.0.3.0-local-Release-20200520.nupkg
-
-To change the TorchSharp package version update this [file](https://github.com/xamarin/TorchSharp/blob/master/build/BranchInfo.props).
-
-## Making releases of the TorchSharp package
-
-The TorchSharp package is pushed to nuget.org either manually or as part of Azure DevOps CI release pipeline, see below.
-
-# The libtorch packages
-
-The libtorch packages are huge (~1.6GB compressed) and cause a lot of problems to make and delier due to nuget package size restrictions.
-These problems include:
-
-1. A massive 1GB binary in the linux CUDA package and multiple 0.5GB binaries in Windows CUDA package
-
-2. Size limitations of about ~500MB on nuget packages on the Azure DevOps CI system and about ~250MB on `nuget.org`
-
-4. Regular download/upload failures on these systems due to network interruptions for packages of this size
-
-5. 10GB VM image size restrictions for the containers userd to build these packages in the Azure DevOps CI system, we can easily run out of room.
-
-6. Complete libtorch-cpu packages can't be built using your local machine alone, since they won't contain the
-   full range of native bits. Instead they are built using Azure Pipelines.
-
-For this reason, we do the following
-
-1. The head, referenceable packages that deliver a functioning runtime are any of:
-
-   libtorch-cpu
-   libtorch-cuda-10.2
-   libtorch-cuda-10.2-linux-x64
-   libtorch-cuda-10.2-win-x64
-
-2. These packages are combo packages that reference multiple parts.  The parts are **not** independently useful.
-
-3. Some parts deliver a single vast file via `primary` and `fragment` packages.  A build task is then used to "stitch" these files back together 
-   to one file on the target machine with a SHA check.  This is a hack but there is no other realistic way to deliver
-   these vast files as packages (the alternative is to abandon packaging and require a manual
-   install/detect/link of PyTorch CUDA on all downstream systems, whcih is extremely problematic
-   for many practical reasons).
-
-4. The `libtorch-*` packages are built in Azure DevOps CI
-   [using this build pipeline](https://donsyme.visualstudio.com/TorchSharp/_build?definitionId=1&_a=summary) but only in master
-   branch and only when `<BuildLibTorchPackages>true</BuildLibTorchPackages>` is set in that branch.  You must currently
-   manually set this, increment `LibTorchPackageVersion`, do a push to master and the packages will build.  This process could be adjusted
-   but at least gets us off the ground.
-
-5. After a successful build, the `libtorch-*` packages can be trialled using the package feed from CI (see above).  When
-   they are appropriate they can be  pushed to nuget using
-   [this manually invoked release pipeline](https://donsyme.visualstudio.com/TorchSharp/_release?_a=releases&view=mine&definitionId=1) in
-   Azure DevOps CI (so they don't have to be manually downloaded and pushed to `nuget.org`)
-
-   a. [Go to release pipeline](https://donsyme.visualstudio.com/TorchSharp/_release?_a=releases&view=mine&definitionId=1)
-
-   b. Press 'New Release'
-
-   c. Select the successful master CI build that includes the `libtorch` packages, create the release and wait for it to finish. You should
-      see `Initialize job`, `Download artifact - _xamarin.TorchSharp - packages`, `NuGet push`, `Finalize Job` succeeded.
-
-   d. All packages should now be pushed to `nuget.org` and will appear after indexing.
-
-
-### Updating PyTorch version for libtorch packages
-
-This project grabs LibTorch and makes a C API wrapper for it, then calls these from C#. When updating to a newer
-version of PyTorch then quite a lot of careful work needs to be done.
-
-See https://pytorch.org/get-started/locally/ for download links.
-
-For example Linux, LibTorch 1.5.0 uses link
-
-    https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.5.0%2Bcpu.zip
-
-To update the version, update these:
-
-    <LibtorchVersion>1.5.0</LibtorchVersion>
-
-Then run these to test downloads and update SHA hashes for the various LibTorch downloads:
-
-    msbuild src\Redist\libtorch-cuda-10.2\libtorch-cuda-10.2.proj /p:UpdateSHA=true /p:TargetOS=linux /t:Build
-    msbuild src\Redist\libtorch-cuda-10.2\libtorch-cuda-10.2.proj /p:UpdateSHA=true /p:TargetOS=windows /t:Build
-
-    msbuild src\Redist\libtorch-cpu\libtorch-cpu.proj /p:UpdateSHA=true /p:TargetOS=linux /t:Build
-    msbuild src\Redist\libtorch-cpu\libtorch-cpu.proj /p:UpdateSHA=true /p:TargetOS=windows /t:Build
-    msbuild src\Redist\libtorch-cpu\libtorch-cpu.proj /p:UpdateSHA=true /p:TargetOS=mac /t:Build
-
-You must also update the "FilesFromArchive= ..." entries under src\Redist projects. Check the contents
-of the unzip of the archive, e.g.
-
-     bin\obj\x86.Debug\libtorch-cpu\libtorch-shared-with-deps-1.5.0%2Bcpu\libtorch\lib
-
-You must also adjust the set of binaries referenced for tests, see various files under `tests`.
-
-Examples
-===========
-
-Porting of the more famous network architectures to TorchSharp is in progress. For the moment we only support [MNIST](https://github.com/xamarin/TorchSharp/blob/master/src/Examples/MNIST.cs) and [AlexNet](https://github.com/xamarin/TorchSharp/blob/master/src/Examples/AlexNet.cs)
-
-[DiffSharp](https://github.com/DiffSharp/DiffSharp/) also uses this repository extensively and has been a major factor in iterating support.
+[DiffSharp](https://github.com/DiffSharp/DiffSharp/) also uses this
+repository extensively and has been a major factor in iterating support.

--- a/docfx/articles/memory.md
+++ b/docfx/articles/memory.md
@@ -1,8 +1,6 @@
-
-
 # Memory Management
 
-Three approches are available for memory management.
+Three approaches are available for memory management.
 
 - If having trouble with GPU memory you may have to resort to technique 1.
 
@@ -10,48 +8,44 @@ Three approches are available for memory management.
 
 DiffSharp relied on technique 2 and 3.
 
-## 1. Explicit disposal of large tensors using IDisposable
+## Technique 1. Explicit disposal
 
-In this technique specific tensors (CPU and GPU) are explicitly disposed
-using `using` in C# or explicit calls to `System.IDisposable.Dispose()`.
+   In this technique specific tensors (CPU and GPU) are explicitly disposed
+   using `using` in C# or explicit calls to `System.IDisposable.Dispose()`.
 
-Pro: control
+   👍 control
 
-Con: you must know when to dispose
+   👎 you must know when to dispose
 
-> NOTE: Disposing a tensor only releases the underlying storage if this is the last
-> live TorchTensor which has a view on that tensor.
+   > NOTE: Disposing a tensor only releases the underlying storage if this is the last
+   > live TorchTensor which has a view on that tensor.
 
-## 2. Implicit disposal using finalizers
+## Technique 2. Implicit disposal using finalizers
 
-In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers.
+   In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers.
 
-Pro: Simple
+   👍 Simple
 
-Con: Failure may happen if large tensors can't be allocated
+   👎 The .NET GC doesn't know of the memory pressure from CPU tensors, so failure may happen if large tensors can't be allocated
 
-Con: The .NET GC doesn't know of the memory pressure from CPU tensors
+   👎 The .NET GC doesn't know of GPU resources
 
-Con: The .NET GC doesn't know of GPU resources
+## Technique 3. Implicit disposal using finalizers with memory pressure
 
-## 3. Implicit disposal using finalizers with memory pressure
+   In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers,
+   but you can explicitly register large tensors as giving memory pressure
 
-In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers,
-but you can explicitly register large tensors as giving memory pressure
+       var t = <make a large tensor>
+       t.RegisterAsMemoryPressure()
 
-    var t = <make a large tensor>
-    t.RegisterForMemoryPressure()
+   This helps the .NET GC reliably know when to force GC and finalization of large tensors
+   (even though they are small .NET objects). Memory pressure is automatically removed when the tensor is finalised.
 
-This helps the .NET GC reliably know when to force GC and finalization of large tensors
-(even though they are small .NET objects)
+   You should only register a tensor for memory pressure once, and should **not** register derived
+   tensors which use the same storage (e.g. views, slices).
 
-Memory pressure is automatically removed when the tensor is finalised.
+   👍 You have to know when to register memory pressure
 
-You should only register a tensor for memory pressure once, and should **not** register derived
-tensors which use the same storage (e.g. views, slices).
-
-Pro: You have to know when to register memory pressure
-
-Con: The .NET GC doesn't know of GPU resources
+   👎 The .NET GC doesn't know of GPU resources
 
 

--- a/docfx/articles/memory.md
+++ b/docfx/articles/memory.md
@@ -1,0 +1,57 @@
+
+
+# Memory Management
+
+Three approches are available for memory management.
+
+- If having trouble with GPU memory you may have to resort to technique 1.
+
+- If having trouble with CPU memory you may have to resort to technique 3, else 1.
+
+DiffSharp relied on technique 2 and 3.
+
+## 1. Explicit disposal of large tensors using IDisposable
+
+In this technique specific tensors (CPU and GPU) are explicitly disposed
+using `using` in C# or explicit calls to `System.IDisposable.Dispose()`.
+
+Pro: control
+
+Con: you must know when to dispose
+
+> NOTE: Disposing a tensor only releases the underlying storage if this is the last
+> live TorchTensor which has a view on that tensor.
+
+## 2. Implicit disposal using finalizers
+
+In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers.
+
+Pro: Simple
+
+Con: Failure may happen if large tensors can't be allocated
+
+Con: The .NET GC doesn't know of the memory pressure from CPU tensors
+
+Con: The .NET GC doesn't know of GPU resources
+
+## 3. Implicit disposal using finalizers with memory pressure
+
+In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers,
+but you can explicitly register large tensors as giving memory pressure
+
+    var t = <make a large tensor>
+    t.RegisterForMemoryPressure()
+
+This helps the .NET GC reliably know when to force GC and finalization of large tensors
+(even though they are small .NET objects)
+
+Memory pressure is automatically removed when the tensor is finalised.
+
+You should only register a tensor for memory pressure once, and should **not** register derived
+tensors which use the same storage (e.g. views, slices).
+
+Pro: You have to know when to register memory pressure
+
+Con: The .NET GC doesn't know of GPU resources
+
+

--- a/docfx/articles/memory.md
+++ b/docfx/articles/memory.md
@@ -1,26 +1,16 @@
 # Memory Management
 
-Three approaches are available for memory management.
+Three approaches are available for memory management. Technique 1 is the default and simplest way to program.
 
-- If having trouble with GPU memory you may have to resort to technique 1.
+- If having trouble with CPU memory you may have to resort to technique 2, else 3.
 
-- If having trouble with CPU memory you may have to resort to technique 3, else 1.
+- If having trouble with GPU memory you may have to resort to technique 3.
 
-DiffSharp relied on technique 2 and 3.
+Note DiffSharp (which uses TorchSharp) relies on techniques 1 (and sometime soon 2).
 
-## Technique 1. Explicit disposal
 
-   In this technique specific tensors (CPU and GPU) are explicitly disposed
-   using `using` in C# or explicit calls to `System.IDisposable.Dispose()`.
 
-   👍 control
-
-   👎 you must know when to dispose
-
-   > NOTE: Disposing a tensor only releases the underlying storage if this is the last
-   > live TorchTensor which has a view on that tensor.
-
-## Technique 2. Implicit disposal using finalizers
+## Technique 1. Implicit disposal using finalizers
 
    In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers.
 
@@ -30,7 +20,7 @@ DiffSharp relied on technique 2 and 3.
 
    👎 The .NET GC doesn't know of GPU resources
 
-## Technique 3. Implicit disposal using finalizers with memory pressure
+## Technique 2. Implicit disposal using finalizers with memory pressure
 
    In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers,
    but you can explicitly register large tensors as giving memory pressure
@@ -47,5 +37,28 @@ DiffSharp relied on technique 2 and 3.
    👍 You have to know when to register memory pressure
 
    👎 The .NET GC doesn't know of GPU resources
+
+
+## Technique 3. Explicit disposal
+
+   In this technique specific tensors (CPU and GPU) are explicitly disposed
+   using `using` in C# or explicit calls to `System.IDisposable.Dispose()`.
+
+   👍 control
+
+   👎 you must know when to dispose
+
+   > NOTE: Disposing a tensor only releases the underlying storage if this is the last
+   > live TorchTensor which has a view on that tensor.
+
+## Re-attempting allocation of large tensors
+
+When allocation of tensors via `FloatTensor.*` (likewise `LongTensor.*` etc.) fails (whether on GPU or CPU),
+then TorchSharp forces a .NET garbage collection and execution of all pending finalizers.
+
+This is not yet done when using general tensor operations.  It is possible a more general retry-after-GC-on-out-of-memory will be added at some point.
+
+
+
 
 

--- a/docfx/articles/memory.md
+++ b/docfx/articles/memory.md
@@ -58,7 +58,15 @@ then TorchSharp forces a .NET garbage collection and execution of all pending fi
 
 This is not yet done when using general tensor operations.  It is possible a more general retry-after-GC-on-out-of-memory will be added at some point.
 
+## Links and resources
 
+These articles might give you ides about techniques to use to analyse memory. The code is in python but generally will translate across:
+
+* https://gitmemory.com/issue/pytorch/pytorch/31252/565550016
+
+* https://discuss.pytorch.org/t/how-to-debug-causes-of-gpu-memory-leaks/6741
+
+* https://discuss.pytorch.org/t/i-run-out-of-memory-after-a-certain-amount-of-batches-when-training-a-resnet18/1911
 
 
 

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -284,6 +284,16 @@ int64_t THSTensor_size(const Tensor tensor, const int64_t dimension)
     CATCH_RETURN(int64_t, 0, tensor->size(dimension));
 }
 
+int64_t THSTensor_numel(const Tensor tensor)
+{
+    CATCH_RETURN(int64_t, 0, tensor->numel());
+}
+
+int64_t THSTensor_element_size(const Tensor tensor)
+{
+    CATCH_RETURN(int64_t, 0, tensor->element_size());
+}
+
 //void THSTensor_sizes(const Tensor tensor, int64_t* (*allocator)(size_t length))
 //{
 //    CATCH(
@@ -335,6 +345,16 @@ Tensor THSTensor_get4(const Tensor tensor, int64_t index1, int64_t index2, int64
     CATCH_TENSOR((*tensor)[index1][index2][index3][index4]);
 }
 
+Tensor THSTensor_get5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5)
+{
+    CATCH_TENSOR((*tensor)[index1][index2][index3][index4][index5]);
+}
+
+Tensor THSTensor_get6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6)
+{
+    CATCH_TENSOR((*tensor)[index1][index2][index3][index4][index5][index6]);
+}
+
 void THSTensor_set1(const Tensor tensor, int64_t index, Scalar value)
 {
     CATCH(
@@ -360,6 +380,20 @@ void THSTensor_set4(const Tensor tensor, int64_t index1, int64_t index2, int64_t
 {
     CATCH(
         (*tensor)[index1][index2][index3][index4] = *value;
+    )
+}
+
+void THSTensor_set5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, Scalar value)
+{
+    CATCH(
+        (*tensor)[index1][index2][index3][index4][index5] = *value;
+    )
+}
+
+void THSTensor_set6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6, Scalar value)
+{
+    CATCH(
+        (*tensor)[index1][index2][index3][index4][index5][index6] = *value;
     )
 }
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -137,6 +137,12 @@ EXPORT_API(int64_t) THSTensor_ndimension(const Tensor tensor);
 // Returns the size of the target dimension of the input tensor.
 EXPORT_API(int64_t) THSTensor_size(const Tensor tensor, const int64_t dimension);
 
+// Returns the number of elements in the tensor.
+EXPORT_API(int64_t) THSTensor_numel(const Tensor tensor);
+
+// Returns the size of elements in the tensor.
+EXPORT_API(int64_t) THSTensor_element_size(const Tensor tensor);
+
 // Returns the stride of the target dimension of the input tensor.
 EXPORT_API(int64_t) THSTensor_stride(const Tensor tensor, const int64_t dimension);
 
@@ -167,6 +173,12 @@ EXPORT_API(Tensor) THSTensor_get3(const Tensor tensor, int64_t index1, int64_t i
 // Returns the sub-tensor identified by the indexes.
 EXPORT_API(Tensor) THSTensor_get4(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4);
 
+// Returns the sub-tensor identified by the indexes.
+EXPORT_API(Tensor) THSTensor_get5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5);
+
+// Returns the sub-tensor identified by the indexes.
+EXPORT_API(Tensor) THSTensor_get6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6);
+
 // Fill the tensor with a given value.
 EXPORT_API(Tensor) THSTensor_fill_(const Tensor tensor, Scalar value);
 
@@ -181,6 +193,12 @@ EXPORT_API(void) THSTensor_set3(const Tensor tensor, int64_t index1, int64_t ind
 
 // Set the sub-tensor identified by the indexes to value.
 EXPORT_API(void) THSTensor_set4(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, Scalar value);
+
+// Set the sub-tensor identified by the indexes to value.
+EXPORT_API(void) THSTensor_set5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, Scalar value);
+
+// Set the sub-tensor identified by the indexes to value.
+EXPORT_API(void) THSTensor_set6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6, Scalar value);
 
 // Returns the inner type of the tensor.
 EXPORT_API(int8_t) THSTensor_type(const Tensor tensor);

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -64,24 +65,21 @@ namespace TorchSharp.Tensor
         /// </summary>
         public long Dimensions => THSTensor_ndimension(handle);
 
+        [DllImport("LibTorchSharp")]
+        private static extern long THSTensor_element_size(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        private static extern long THSTensor_numel(IntPtr handle);
+
         /// <summary>
-        ///  Returns a pointer to the unmanaged data managed by this tensor.
+        ///  Get the number of elements in the tensor.
         /// </summary>
-        public long NumberOfElements
-        {
-            get
-            {
-                switch (Dimensions)
-                {
-                    case 0:
-                        return 1;
-                    case 1:
-                        return (int)Shape[0];
-                    default:
-                        return (int)Shape.Aggregate((x, y) => x * y);
-                }
-            }
-        }
+        public long NumberOfElements => THSTensor_numel(handle);
+
+        /// <summary>
+        ///  Get the size of each element in the tensor.
+        /// </summary>
+        public long ElementSize => THSTensor_element_size(handle);
 
         [DllImport("LibTorchSharp")]
         private static extern IntPtr THSTensor_data(IntPtr handle);
@@ -230,6 +228,44 @@ namespace TorchSharp.Tensor
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_get5(IntPtr handle, long i1, long i2, long i3, long i4, long i5);
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
+
+        [IndexerName("TensorItems")]
+        public TorchTensor this[long i1, long i2, long i3, long i4, long i5] {
+            get {
+                var res = THSTensor_get5(handle, i1, i2, i3, i4, i5);
+                Torch.CheckForErrors();
+                return new TorchTensor(res);
+            }
+            set {
+                THSTensor_set5(handle, i1, i2, i3, i4, i5, value.Item().Handle);
+                Torch.CheckForErrors();
+            }
+        }
+
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_get6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6);
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
+
+        [IndexerName("TensorItems")]
+        public TorchTensor this[long i1, long i2, long i3, long i4, long i5, long i6] {
+            get {
+                var res = THSTensor_get6(handle, i1, i2, i3, i4, i5, i6);
+                Torch.CheckForErrors();
+                return new TorchTensor(res);
+            }
+            set {
+                THSTensor_set6(handle, i1, i2, i3, i4, i5, i6, value.Item().Handle);
+                Torch.CheckForErrors();
+            }
+        }
         [DllImport("LibTorchSharp")]
         private static extern sbyte THSTensor_type(IntPtr handle);
 

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -32,7 +32,7 @@ namespace TorchSharp.Tensor
         /// Records that the created tensor adds CPU memory pressure.  The pressure will be removed
         /// when this particular TorchTensor handle is disposed or finalised.
         /// </summary>
-        public void RegisterForMemoryPressure()
+        public void RegisterAsMemoryPressure()
         {
             if (DeviceType == DeviceType.CPU) {
                 if (memoryPressureRegistrations == null)

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -32,7 +32,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -45,7 +47,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -62,7 +66,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -81,7 +87,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -100,7 +108,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -119,7 +129,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -129,7 +141,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(byte scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newByteScalar(scalar, requiresGrad));
+            var handle = THSTensor_newByteScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -150,7 +164,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Byte, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Byte, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -170,7 +186,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -199,7 +217,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -212,7 +232,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -229,7 +251,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -248,7 +272,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -267,7 +293,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -286,7 +314,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -296,7 +326,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(sbyte scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newSByteScalar(scalar, requiresGrad));
+            var handle = THSTensor_newSByteScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -317,7 +349,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -337,7 +371,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -366,7 +402,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -379,7 +417,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -396,7 +436,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -415,7 +457,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -434,7 +478,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -453,7 +499,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -463,7 +511,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(short scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newShortScalar(scalar, requiresGrad));
+            var handle = THSTensor_newShortScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -484,7 +534,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -504,7 +556,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -533,7 +587,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -546,7 +602,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -563,7 +621,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -582,7 +642,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -601,7 +663,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -620,7 +684,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -630,7 +696,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(int scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newIntScalar(scalar, requiresGrad));
+            var handle = THSTensor_newIntScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -651,7 +719,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -671,7 +741,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -700,7 +772,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -713,7 +787,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -730,7 +806,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -749,7 +827,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -768,7 +848,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -787,7 +869,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -797,7 +881,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(long scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newLongScalar(scalar, requiresGrad));
+            var handle = THSTensor_newLongScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -818,7 +904,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_newLong(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad));
+                var handle = THSTensor_newLong(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -838,7 +926,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -867,7 +957,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -880,7 +972,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -897,7 +991,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -916,7 +1012,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -935,7 +1033,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -954,7 +1054,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -972,7 +1074,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -991,7 +1095,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1001,7 +1107,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(float scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newHalfScalar(scalar, requiresGrad));
+            var handle = THSTensor_newHalfScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -1024,7 +1132,9 @@ namespace TorchSharp.Tensor {
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 fixed (float* pRawArray = rawArray)
                 {
-                    return new TorchTensor(THSTensor_newHalf((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad));
+                    var handle = THSTensor_newHalf((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor(handle);
                 }
             }
         }
@@ -1045,7 +1155,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1074,7 +1186,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -1087,7 +1201,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -1104,7 +1220,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1123,7 +1241,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1132,7 +1252,7 @@ namespace TorchSharp.Tensor {
         extern static IntPtr THSTensor_empty(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
 
         /// <summary>
-        ///  Create a new tensor filled with arbitrary values
+        ///  Create a new tensor filled with ones
         /// </summary>
         static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
@@ -1142,7 +1262,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1161,7 +1283,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1179,7 +1303,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1198,7 +1324,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1208,7 +1336,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(float scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newFloatScalar(scalar, requiresGrad));
+            var handle = THSTensor_newFloatScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -1229,7 +1359,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -1249,7 +1381,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1278,7 +1412,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -1291,7 +1427,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -1308,7 +1446,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1327,7 +1467,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1346,7 +1488,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1365,7 +1509,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1383,7 +1529,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1402,7 +1550,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1412,7 +1562,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(double scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newDoubleScalar(scalar, requiresGrad));
+            var handle = THSTensor_newDoubleScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -1433,7 +1585,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -1453,7 +1607,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1482,7 +1638,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -1495,7 +1653,9 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -1512,7 +1672,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1531,7 +1693,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1550,7 +1714,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1569,7 +1735,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -1579,7 +1747,9 @@ namespace TorchSharp.Tensor {
 
         public static TorchTensor From(bool scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_newBoolScalar(scalar, requiresGrad));
+            var handle = THSTensor_newBoolScalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -1600,7 +1770,9 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Bool, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Bool, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
             }
         }
         
@@ -1620,7 +1792,9 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -33,6 +33,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -48,6 +53,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -67,6 +77,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -88,6 +103,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -109,6 +129,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -130,6 +155,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -165,6 +195,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Byte, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Byte, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -187,6 +222,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Byte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -218,6 +258,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -233,6 +278,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -252,6 +302,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -273,6 +328,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -294,6 +354,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -315,6 +380,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -350,6 +420,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -372,6 +447,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -403,6 +483,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -418,6 +503,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -437,6 +527,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -458,6 +553,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -479,6 +579,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -500,6 +605,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -535,6 +645,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -557,6 +672,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -588,6 +708,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -603,6 +728,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -622,6 +752,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -643,6 +778,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -664,6 +804,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -685,6 +830,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -720,6 +870,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -742,6 +897,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -773,6 +933,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -788,6 +953,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -807,6 +977,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -828,6 +1003,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -849,6 +1029,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -870,6 +1055,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -905,6 +1095,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_newLong(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_newLong(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -927,6 +1122,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -958,6 +1158,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -973,6 +1178,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -992,6 +1202,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1013,6 +1228,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1034,6 +1254,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1055,6 +1280,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1075,6 +1305,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1096,6 +1331,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1133,6 +1373,11 @@ namespace TorchSharp.Tensor {
                 fixed (float* pRawArray = rawArray)
                 {
                     var handle = THSTensor_newHalf((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_newHalf((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor(handle);
                 }
@@ -1156,6 +1401,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1187,6 +1437,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -1202,6 +1457,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -1221,6 +1481,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1242,6 +1507,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1263,6 +1533,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1284,6 +1559,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1304,6 +1584,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1325,6 +1610,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1360,6 +1650,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -1382,6 +1677,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1413,6 +1713,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -1428,6 +1733,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -1447,6 +1757,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1468,6 +1783,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1489,6 +1809,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1510,6 +1835,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1530,6 +1860,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1551,6 +1886,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1586,6 +1926,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -1608,6 +1953,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1639,6 +1989,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -1654,6 +2009,11 @@ namespace TorchSharp.Tensor {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -1673,6 +2033,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1694,6 +2059,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1715,6 +2085,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1736,6 +2111,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -1771,6 +2151,11 @@ namespace TorchSharp.Tensor {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Bool, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Bool, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
             }
@@ -1793,6 +2178,11 @@ namespace TorchSharp.Tensor {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Bool, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -1132,7 +1132,7 @@ namespace TorchSharp.Tensor {
         extern static IntPtr THSTensor_empty(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
 
         /// <summary>
-        ///  Create a new tensor filled with ones
+        ///  Create a new tensor filled with arbitrary values
         /// </summary>
         static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -39,7 +39,9 @@ foreach (var type in TorchTypeDef.Types) {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
         [DllImport("LibTorchSharp")]
@@ -52,7 +54,9 @@ foreach (var type in TorchTypeDef.Types) {
         {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
-            return new TorchTensor (THSTensor_randperm (n, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor (handle);
         }
 		
 		[DllImport("LibTorchSharp")]
@@ -69,7 +73,9 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_zeros ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_zeros ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -88,7 +94,9 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_ones ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_ones ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -107,7 +115,9 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_empty ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_empty ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -126,7 +136,9 @@ foreach (var type in TorchTypeDef.Types) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randint (max, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randint (max, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -147,7 +159,9 @@ if (type.IsFloatingPoint) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_rand ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_rand ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -166,7 +180,9 @@ if (type.IsFloatingPoint) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_randn ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_randn ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }
@@ -177,7 +193,9 @@ if (type.IsFloatingPoint) {
 
         public static TorchTensor From(<#=type.Storage#> scalar, bool requiresGrad = false)
         {
-            return new TorchTensor(THSTensor_new<#=type.Name#>Scalar(scalar, requiresGrad));
+            var handle = THSTensor_new<#=type.Name#>Scalar(scalar, requiresGrad);
+            Torch.CheckForErrors();
+            return new TorchTensor(handle);
         }
 
 <#
@@ -223,18 +241,24 @@ if (type.IsHalf) {
 <#
 if (type.IsLong) {
 #>
-                return new TorchTensor(THSTensor_new<#=type.Name#>(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad));
+                var handle = THSTensor_new<#=type.Name#>(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
 <#
 } else if (type.IsHalf) {
 #>
                 fixed (<#=type.Storage#>* pRawArray = rawArray)
                 {
-                    return new TorchTensor(THSTensor_new<#=type.Name#>((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad));
+                    var handle = THSTensor_new<#=type.Name#>((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor(handle);
                 }
 <#
 } else {
 #>
-                return new TorchTensor(THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.<#=type.Name#>, requiresGrad));
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.<#=type.Name#>, requiresGrad);
+                Torch.CheckForErrors();
+                return new TorchTensor(handle);
 <# } #>
             }
         }
@@ -255,7 +279,9 @@ if (type.IsLong) {
             {
                 fixed (long* psizes = size)
                 {
-                    return new TorchTensor (THSTensor_sparse (indices.Handle, values.Handle, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad));
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    Torch.CheckForErrors();
+                    return new TorchTensor (handle);
                 }
             }
         }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -40,6 +40,11 @@ foreach (var type in TorchTypeDef.Types) {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -55,6 +60,11 @@ foreach (var type in TorchTypeDef.Types) {
             Torch.InitializeDevice (deviceType, deviceIndex);
 
             var handle = THSTensor_randperm (n, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+            }
             Torch.CheckForErrors();
             return new TorchTensor (handle);
         }
@@ -74,6 +84,11 @@ foreach (var type in TorchTypeDef.Types) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_zeros ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -95,6 +110,11 @@ foreach (var type in TorchTypeDef.Types) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_ones ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -116,6 +136,11 @@ foreach (var type in TorchTypeDef.Types) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_empty ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -137,6 +162,11 @@ foreach (var type in TorchTypeDef.Types) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randint (max, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -160,6 +190,11 @@ if (type.IsFloatingPoint) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_rand ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_rand ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -181,6 +216,11 @@ if (type.IsFloatingPoint) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_randn ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randn ((<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }
@@ -242,6 +282,11 @@ if (type.IsHalf) {
 if (type.IsLong) {
 #>
                 var handle = THSTensor_new<#=type.Name#>(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new<#=type.Name#>(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
 <#
@@ -250,6 +295,11 @@ if (type.IsLong) {
                 fixed (<#=type.Storage#>* pRawArray = rawArray)
                 {
                     var handle = THSTensor_new<#=type.Name#>((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_new<#=type.Name#>((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor(handle);
                 }
@@ -257,6 +307,11 @@ if (type.IsLong) {
 } else {
 #>
                 var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.<#=type.Name#>, requiresGrad);
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.<#=type.Name#>, requiresGrad);
+                }
                 Torch.CheckForErrors();
                 return new TorchTensor(handle);
 <# } #>
@@ -280,6 +335,11 @@ if (type.IsLong) {
                 fixed (long* psizes = size)
                 {
                     var handle = THSTensor_sparse (indices.Handle, values.Handle, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (<#=type.Ptr#>)psizes, size.Length, (sbyte)ScalarType.<#=type.Name#>, (int) deviceType, deviceIndex, requiresGrad);
+                    }
                     Torch.CheckForErrors();
                     return new TorchTensor (handle);
                 }

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -29,8 +29,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -38,7 +38,7 @@ namespace TorchSharp
         {
             // Allocate many 256MB tensors. Without explicit disposal memory use relies on finalization.
             // This will often succeed but not reliably
-            int n = 50;
+            int n = 25;
             for (int i = 0; i < n; i++) {
                 Console.WriteLine("ExplicitDisposal: Loop iteration {0}", i);
 
@@ -53,7 +53,7 @@ namespace TorchSharp
             // 
             // Allocate many 512MB tensors. Without explicit disposal memory use relies on finalization.
             // Use explicit memory pressure for large tensors makes this succeed reliably.
-            int n = 50;
+            int n = 25;
             for (int i = 0; i < n; i++) {
                 Console.WriteLine("FinalizeWithExplicitMemoryPressure: Loop iteration {0}", i);
 

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -33,10 +33,6 @@ namespace TorchSharp
             //Assert.Equal(1.0f, t[1, 1].DataItem<float>());
         }
 
-    }
-
-    public class TestTorchMemoryPressure1
-    {
         [Fact]
         public void ExplicitDisposal()
         {
@@ -50,9 +46,7 @@ namespace TorchSharp
             }
             Console.WriteLine("Hello World!");
         }
-    }
-    public class TestTorchMemoryPressure2
-    {
+
         [Fact]
         public void FinalizeWithExplicitMemoryPressure()
         {

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -45,7 +45,7 @@ namespace TorchSharp
             // This will often succeed but not reliably
             int n = 50;
             for (int i = 0; i < n; i++) {
-                Console.WriteLine("Loop iteration %d", i);
+                Console.WriteLine("ExplicitDisposal: Loop iteration {0}", i);
 
                 using (var x = FloatTensor.Empty(new long[] { 64000, 2000 }, deviceType: DeviceType.CPU)) { }
             }
@@ -60,11 +60,11 @@ namespace TorchSharp
             // Use explicit memory pressure for large tensors makes this succeed reliably.
             int n = 50;
             for (int i = 0; i < n; i++) {
-                Console.WriteLine("Loop iteration %d", i);
+                Console.WriteLine("FinalizeWithExplicitMemoryPressure: Loop iteration {0}", i);
 
                 // Allocate a 512MB tensor
                 var x = FloatTensor.Empty(new long[] { 64000, 2000 }, deviceType: DeviceType.CPU);
-                x.RegisterForMemoryPressure();
+                x.RegisterAsMemoryPressure();
             }
             Console.WriteLine("Hello World!");
         }

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -41,13 +41,13 @@ namespace TorchSharp
         [Fact]
         public void ExplicitDisposal()
         {
-            // Allocate many 512MB tensors. Without explicit disposal memory use relies on finalization.
+            // Allocate many 256MB tensors. Without explicit disposal memory use relies on finalization.
             // This will often succeed but not reliably
             int n = 50;
             for (int i = 0; i < n; i++) {
                 Console.WriteLine("ExplicitDisposal: Loop iteration {0}", i);
 
-                using (var x = FloatTensor.Empty(new long[] { 64000, 2000 }, deviceType: DeviceType.CPU)) { }
+                using (var x = FloatTensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU)) { }
             }
             Console.WriteLine("Hello World!");
         }
@@ -62,8 +62,8 @@ namespace TorchSharp
             for (int i = 0; i < n; i++) {
                 Console.WriteLine("FinalizeWithExplicitMemoryPressure: Loop iteration {0}", i);
 
-                // Allocate a 512MB tensor
-                var x = FloatTensor.Empty(new long[] { 64000, 2000 }, deviceType: DeviceType.CPU);
+                // Allocate a 256MB tensor
+                var x = FloatTensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU);
                 x.RegisterAsMemoryPressure();
             }
             Console.WriteLine("Hello World!");

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -35,8 +35,7 @@ namespace TorchSharp
 
     }
 
-    [CollectionDefinition("TestTorchImplicitMemoryPressure", DisableParallelization = true)]
-    public class TestTorchMemoryPressure
+    public class TestTorchMemoryPressure1
     {
         [Fact]
         public void ExplicitDisposal()
@@ -51,7 +50,9 @@ namespace TorchSharp
             }
             Console.WriteLine("Hello World!");
         }
-
+    }
+    public class TestTorchMemoryPressure2
+    {
         [Fact]
         public void FinalizeWithExplicitMemoryPressure()
         {

--- a/test/TorchSharpTest/TorchSharp.cs
+++ b/test/TorchSharpTest/TorchSharp.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 using TorchSharp;
+using TorchSharp.Tensor;
 using Xunit;
 
 #nullable enable
@@ -10,9 +11,6 @@ namespace TorchSharp
 {
     public class TestTorch
     {
-        [DllImport("kernel32.dll")]
-        public static extern IntPtr LoadLibrary(string dllToLoad);
-
         [Fact]
         public void TestDeviceCount()
         {
@@ -33,6 +31,23 @@ namespace TorchSharp
             //Assert.Equal(shape, t.Shape);
             //Assert.Equal(1.0f, t[0, 0].DataItem<float>());
             //Assert.Equal(1.0f, t[1, 1].DataItem<float>());
+        }
+
+        [Fact]
+        public void TestMemoryUsage()
+        {
+            int n = 1000;
+            for (int i = 0; i < n; i++) {
+                Console.WriteLine("Loop iteration %d", i);
+
+                // This will fail:
+                // var x = FloatTensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU);
+
+                // This will succeed:
+                using (var x = FloatTensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU)) { }
+
+            }
+            Console.WriteLine("Hello World!");
         }
 
     }

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -21,8 +21,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <!--<PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -12,6 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <ProjectReference Include="..\..\src\TorchSharp\TorchSharp.csproj" />
   </ItemGroup>
 
@@ -21,8 +24,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!--<PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/test/TorchSharpTest/TorchTensor.cs
+++ b/test/TorchSharpTest/TorchTensor.cs
@@ -316,6 +316,67 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void GetSetItem2()
+        {
+            var shape = new long[] { 2, 3 };
+            TorchTensor t = FloatTensor.Ones(shape);
+            Assert.Equal(shape, t.Shape);
+            Assert.Equal(1.0f, t[0, 0].DataItem<float>());
+            Assert.Equal(1.0f, t[1, 2].DataItem<float>());
+            t[1, 2] = FloatTensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2].DataItem<float>());
+        }
+
+        [Fact]
+        public void GetSetItem3()
+        {
+            var shape = new long[] { 2, 3, 4 };
+            TorchTensor t = FloatTensor.Ones(shape);
+            Assert.Equal(shape, t.Shape);
+            Assert.Equal(1.0f, t[0, 0, 0].DataItem<float>());
+            Assert.Equal(1.0f, t[1, 2, 3].DataItem<float>());
+            t[1, 2, 3] = FloatTensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3].DataItem<float>());
+        }
+
+        [Fact]
+        public void GetSetItem4()
+        {
+            var shape = new long[] { 2, 3, 4, 5 };
+            TorchTensor t = FloatTensor.Ones(shape);
+            Assert.Equal(shape, t.Shape);
+            Assert.Equal(1.0f, t[0, 0, 0, 0].DataItem<float>());
+            Assert.Equal(1.0f, t[1, 2, 3, 4].DataItem<float>());
+            t[1, 2, 3, 4] = FloatTensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3, 4].DataItem<float>());
+        }
+
+        [Fact]
+        public void GetSetItem5()
+        {
+            var shape = new long[] { 2, 3, 4, 5, 6 };
+            TorchTensor t = FloatTensor.Ones(shape);
+            Assert.Equal(shape, t.Shape);
+            Assert.Equal(1.0f, t[0, 0, 0, 0, 0].DataItem<float>());
+            Assert.Equal(1.0f, t[1, 2, 3, 4, 5].DataItem<float>());
+            t[1, 2, 3, 4, 5] = FloatTensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3, 4, 5].DataItem<float>());
+        }
+
+
+        [Fact]
+        public void GetSetItem6()
+        {
+            var shape = new long[] { 2, 3, 4, 5, 6, 7 };
+            TorchTensor t = FloatTensor.Ones(shape);
+            Assert.Equal(shape, t.Shape);
+            Assert.Equal(1.0f, t[0, 0, 0, 0, 0, 0].DataItem<float>());
+            Assert.Equal(1.0f, t[1, 2, 3, 4, 5, 6].DataItem<float>());
+            t[1, 2, 3, 4, 5, 6] = FloatTensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3, 4, 5, 6].DataItem<float>());
+        }
+
+        [Fact]
         public void TestScalarToTensor()
         {
             Assert.Throws<ArgumentException>(() => 1.ToTorchTensor(requiresGrad: true));


### PR DESCRIPTION
Partially addresses #167 

# Memory Management

Three approaches are available for memory management.

- If having trouble with GPU memory you may have to resort to technique 1.

- If having trouble with CPU memory you may have to resort to technique 3, else 1.

DiffSharp relied on technique 2 and 3.

## Technique 1. Explicit disposal

   In this technique specific tensors (CPU and GPU) are explicitly disposed
   using `using` in C# or explicit calls to `System.IDisposable.Dispose()`.

   👍 control

   👎 you must know when to dispose

   > NOTE: Disposing a tensor only releases the underlying storage if this is the last
   > live TorchTensor which has a view on that tensor.

## Technique 2. Implicit disposal using finalizers

   In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers.

   👍 Simple

   👎 The .NET GC doesn't know of the memory pressure from CPU tensors, so failure may happen if large tensors can't be allocated

   👎 The .NET GC doesn't know of GPU resources

## Technique 3. Implicit disposal using finalizers with memory pressure

   In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers,
   but you can explicitly register large tensors as giving memory pressure

       var t = <make a large tensor>
       t.RegisterAsMemoryPressure()

   This helps the .NET GC reliably know when to force GC and finalization of large tensors
   (even though they are small .NET objects). Memory pressure is automatically removed when the tensor is finalised.

   You should only register a tensor for memory pressure once, and should **not** register derived
   tensors which use the same storage (e.g. views, slices).

   👍 You have to know when to register memory pressure

   👎 The .NET GC doesn't know of GPU resources


