### PR TITLE
rm scalar ops

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -121,6 +121,9 @@ For this reason, we do the following
 
    d. All packages should now be pushed to `nuget.org` and will appear after indexing.
 
+6. If updating libtorch packages, remember to delete all massive artifacts from Azure DevOps and reset this:
+
+         <BuildLibTorchPackages>false</BuildLibTorchPackages>
 
 ### Updating PyTorch version for libtorch packages
 
@@ -207,3 +210,6 @@ version of PyTorch then quite a lot of careful work needs to be done.
 
 10. Submit to CI and debug problems
 
+11. Remember to delete all massive artifacts from Azure DevOps and reset this:
+
+         <BuildLibTorchPackages>false</BuildLibTorchPackages>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,7 @@
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
-    <BuildLibTorchPackages>true</BuildLibTorchPackages>
+    <BuildLibTorchPackages>false</BuildLibTorchPackages>
   </PropertyGroup>
 
   <!-- SourceLink properties used by dotnet/buildtools - need to be set before importing $(ToolsDir)versioning.props -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,14 +179,6 @@ jobs:
     displayName: Clean up space (bin\AnyCPU.Release)
     continueOnError: true
 
-  - script: rmdir /q /s bin\x64.Release
-    displayName: Clean up space (bin\x64.Release)
-    continueOnError: true
-
-  - script: rmdir /q /s bin\downloads
-    displayName: Clean up space (bin\downloads)
-    continueOnError: true
-
   - script: rmdir /q /s packages
     displayName: Clean up space (packages)
     continueOnError: true

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -562,12 +562,6 @@ Tensor THSTensor_div_scalar(const Tensor left, const Scalar right)
     CATCH_TENSOR(left->div(*right));
 }
 
-// TODO: this derived operation should not be at this level
-Tensor THSTensor_scalar_div(const Scalar left, const Tensor right)
-{
-    CATCH_TENSOR(at::empty(right->sizes(), right->options()).fill_(*left).div_(*right));
-}
-
 Tensor THSTensor_div_scalar_(const Tensor left, const Scalar right)
 {
     CATCH_TENSOR(left->div_(*right));
@@ -744,12 +738,6 @@ Tensor THSTensor_fmod_scalar(const Tensor left, const Scalar right)
 Tensor THSTensor_fmod_scalar_(const Tensor left, const Scalar right)
 {
     CATCH_TENSOR(left->fmod_(*right));
-}
-
-// TODO: this derived operation should not be at this level
-Tensor THSTensor_scalar_fmod(const Scalar left, const Tensor right)
-{
-    CATCH_TENSOR(at::empty(right->sizes(), right->options()).fill_(*left).fmod_(*right));
 }
 
 Tensor THSTensor_frac(const Tensor tensor)
@@ -1613,12 +1601,6 @@ Tensor THSTensor_remainder_scalar_(const Tensor left, const Scalar right)
     CATCH_TENSOR(left->remainder_(*right));
 }
 
-// TODO: this derived operation should not be at this level
-Tensor THSTensor_scalar_remainder(const Scalar left, const Tensor right)
-{
-    CATCH_TENSOR(at::empty(right->sizes(), right->options()).fill_(*left).remainder_(*right));
-}
-
 Tensor THSTensor_renorm(const Tensor tensor, const float p, const int64_t dim, const float maxnorm)
 {
     CATCH_TENSOR(tensor->renorm(p, dim, maxnorm));
@@ -1833,12 +1815,6 @@ Tensor THSTensor_sub_(const Tensor left, const Tensor right)
 Tensor THSTensor_sub_scalar(const Tensor left, const Scalar right)
 {
     CATCH_TENSOR(left->sub(*right));
-}
-
-// TODO: this derived operation should not be at this level
-Tensor THSTensor_scalar_sub(const Scalar left, const Tensor right)
-{
-    CATCH_TENSOR(at::empty(right->sizes(), right->options()).fill_(*left).sub_(*right));
 }
 
 Tensor THSTensor_set_requires_grad(const Tensor tensor, const bool requires_grad)

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -286,8 +286,6 @@ EXPORT_API(Tensor) THSTensor_fmod_scalar(const Tensor left, const Scalar right);
 
 EXPORT_API(Tensor) THSTensor_fmod_scalar_(const Tensor left, const Scalar right);
 
-EXPORT_API(Tensor) THSTensor_scalar_fmod(const Scalar left, const Tensor right);
-
 EXPORT_API(Tensor) THSTensor_digamma(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_digamma_(const Tensor tensor);
@@ -596,11 +594,7 @@ EXPORT_API(Tensor) THSTensor_rsqrt(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_rsqrt_(const Tensor tensor);
 
-EXPORT_API(Tensor) THSTensor_scalar_remainder(const Scalar left, const Tensor right);
-
 EXPORT_API(Tensor) THSTensor_renorm(const Tensor tensor, const float p, const int64_t dim, const float maxnorm);
-
-EXPORT_API(Tensor) THSTensor_scalar_div(const Scalar left, const Tensor right);
 
 EXPORT_API(Tensor) THSTensor_sigmoid(const Tensor tensor);
 
@@ -631,8 +625,6 @@ EXPORT_API(Tensor) THSTensor_sub_(const Tensor left, const Tensor right);
 EXPORT_API(Tensor) THSTensor_sub_scalar(const Tensor left, const Scalar right);
 
 EXPORT_API(Tensor) THSTensor_sub_scalar_(const Tensor left, const Scalar right);
-
-EXPORT_API(Tensor) THSTensor_scalar_sub(const Scalar left, const Tensor right);
 
 EXPORT_API(Tensor) THSTensor_sum(const Tensor tensor, bool has_type, const int8_t dtype);
 

--- a/src/Redist/libtorch-cuda-10.2/libtorch-cuda-10.2.proj
+++ b/src/Redist/libtorch-cuda-10.2/libtorch-cuda-10.2.proj
@@ -60,7 +60,6 @@
     <File Include= "libtorch\lib\uv.dll" PackageSuffix="part3" />
 
     <!-- This vast file needs a special magic, we split it into multiple chunks in different packages. -->
-    <!-- The chunks actually all have the same size but have different sections zero'd out. We "or" the bits back together on package restore. -->
     <File Include= "libtorch\lib\torch_cuda.dll"  PackageSuffix="part4-primary" FileUnstitchIndex="0" FileUnstitchStart="0" FileUnstitchSize="250000000" />
     <File Include= "libtorch\lib\torch_cuda.dll"  PackageSuffix="part4-fragment1" FileUnstitchIndex="1" FileUnstitchStart="250000000" FileUnstitchSize="250000000" />
     <File Include= "libtorch\lib\torch_cuda.dll"  PackageSuffix="part4-fragment2" FileUnstitchIndex="2" FileUnstitchStart="500000000" FileUnstitchSize="-1" />

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -3556,11 +3556,6 @@ namespace TorchSharp.Tensor
             return left.Sub(right);
         }
 
-        public static TorchTensor operator -(TorchScalar left, TorchTensor right)
-        {
-            return ScalarSub(left, right);
-        }
-
         public static TorchTensor operator /(TorchTensor left, TorchTensor right)
         {
             return left.Div(right);
@@ -3571,11 +3566,6 @@ namespace TorchSharp.Tensor
             return left.Div(right);
         }
 
-        public static TorchTensor operator /(TorchScalar left, TorchTensor right)
-        {
-            return ScalarDiv(left, right);
-        }
-
         public static TorchTensor operator %(TorchTensor left, TorchTensor right)
         {
             return left.Remainder(right);
@@ -3584,11 +3574,6 @@ namespace TorchSharp.Tensor
         public static TorchTensor operator %(TorchTensor left, TorchScalar right)
         {
             return left.Remainder(right);
-        }
-
-        public static TorchTensor operator %(TorchScalar left, TorchTensor right)
-        {
-            return ScalarRemainder(left, right);
         }
 
         public static TorchTensor operator <(TorchTensor left, TorchTensor right)

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -1856,16 +1856,6 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_scalar_div(IntPtr scalar, IntPtr tensor);
-
-        public static TorchTensor ScalarDiv(TorchScalar scalar, TorchTensor divisor)
-        {
-            var res = THSTensor_scalar_div(scalar.Handle, divisor.Handle);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
-        [DllImport("LibTorchSharp")]
         private static extern IntPtr THSTensor_erf(IntPtr tensor);
 
         public TorchTensor Erf()
@@ -2595,15 +2585,6 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_scalar_remainder(IntPtr scalar, IntPtr tensor);
-
-        public static TorchTensor ScalarRemainder(TorchScalar scalar, TorchTensor divisor)
-        {
-            var res = THSTensor_scalar_remainder(scalar.Handle, divisor.Handle);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-        [DllImport("LibTorchSharp")]
         private static extern IntPtr THSTensor_remainder_scalar_(IntPtr tensor, IntPtr scalar);
 
         public TorchTensor RemainderInPlace(TorchScalar scalar)
@@ -2720,17 +2701,6 @@ namespace TorchSharp.Tensor
         public TorchTensor SubInPlace(TorchScalar target)
         {
             var res = THSTensor_sub_scalar_(handle, target.Handle);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
-
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_scalar_sub(IntPtr scalar, IntPtr tensor);
-
-        public static TorchTensor ScalarSub(TorchScalar scalar, TorchTensor divisor)
-        {
-            var res = THSTensor_scalar_sub(scalar.Handle, divisor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(res);
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -711,11 +711,9 @@ namespace TorchSharp
             TestOneTensor<float, float>(a => a + 0.5f, a => a + 0.5f);
             TestOneTensor<float, float>(a => 0.5f + a, a => 0.5f + a);
             TestOneTensor<float, float>(a => a - 0.5f, a => a - 0.5f);
-            TestOneTensor<float, float>(a => 0.5f - a, a => 0.5f - a);
             TestOneTensor<float, float>(a => a * 0.5f, a => a * 0.5f);
             TestOneTensor<float, float>(a => 0.5f * a, a => 0.5f * a);
             TestOneTensor<float, float>(a => a / 0.5f, a => a / 0.5f);
-            TestOneTensor<float, float>(a => 0.5f / a, a => 0.5f / a);
 
             TestOneTensor<float, float>(a => a.Add(0.5f), a => a + 0.5f);
             TestOneTensor<float, float>(a => a.Sub(0.5f), a => a - 0.5f);
@@ -767,7 +765,6 @@ namespace TorchSharp
             TestOneTensorInPlace<float>(a => a.GtInPlace(5.0f), a => a > 5.0f ? 1.0f : 0.0f);
             TestOneTensorInPlace<float>(a => a.GeInPlace(5.0f), a => a >= 5.0f ? 1.0f : 0.0f);
 
-            TestOneTensor<float, float>(a => 5.0f % a, a => 5.0f % a);
             TestOneTensor<float, float>(a => a % 5.0f, a => a % 5.0f);
             TestOneTensorInPlace<float>(a => a.RemainderInPlace(5.0f), a => a % 5.0f);
 


### PR DESCRIPTION

The ScalarDiv, ScalarSub and ScalarRemainder ops have to direct LibTorch equivalent AFAICS, at least not as they are written.  Furthermore they are buggy with integral types