### PR TITLE
bfloat16, float16 testing and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ var lin1 = Linear(1000, 100);
 var lin2 = Linear(100, 10);
 var seq = Sequential(lin1, Relu(), lin2);
 
-var x = FloatTensor.RandomN(new long[] { 64, 1000 }, device: "cpu:0");
-var y = FloatTensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
+var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, device: "cpu:0");
+var y = Float32Tensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
 
 double learning_rate = 0.00004f;
 float prevLoss = float.MaxValue;
@@ -34,7 +34,7 @@ for (int i = 0; i < 10; i++)
 {
     var eval = seq.Forward(x);
     var output = loss(eval, y);
-    var lossVal = output.DataItem<float>();
+    var lossVal = output.ToSingle();
 
     Assert.True(lossVal < prevLoss);
     prevLoss = lossVal;

--- a/build/Codecoverage.proj
+++ b/build/Codecoverage.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- We need to specify a framework in order for the Restore target to work -->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docfx/articles/memory.md
+++ b/docfx/articles/memory.md
@@ -12,7 +12,7 @@ Note DiffSharp (which uses TorchSharp) relies on techniques 1.
 
 In this technique all tensors (CPU and GPU) are implicitly disposed via .NET finalizers.
 
-When allocation of tensors via `FloatTensor.*` (likewise `LongTensor.*` etc.) fails (whether on GPU or CPU),
+When allocation of tensors via `Float32Tensor.*` (likewise `Int64Tensor.*` etc.) fails (whether on GPU or CPU),
 then TorchSharp forces a .NET garbage collection and execution of all pending finalizers.
 
 This is not yet done when using general tensor operations.  It is possible a more general retry-after-GC-on-out-of-memory will be added at some point.

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -6,7 +6,7 @@ __PACKAGES_DIR="$__scriptpath/packages"
 __TOOLRUNTIME_DIR="$__scriptpath/Tools"
 __DOTNET_PATH="$__TOOLRUNTIME_DIR/dotnetcli"
 __DOTNET_CMD="$__DOTNET_PATH/dotnet"
-__TARGET_FRAMEWORK="netcoreapp3.0"
+__TARGET_FRAMEWORK="netcoreapp3.1"
 if [ -z "${__BUILDTOOLS_SOURCE:-}" ]; then __BUILDTOOLS_SOURCE=https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json; fi
 export __BUILDTOOLS_USE_CSPROJ=true
 __BUILD_TOOLS_PACKAGE_VERSION=$(cat "$__scriptpath/BuildToolsVersion.txt" | sed 's/\r$//') # remove CR if mounted repo on Windows drive
@@ -16,7 +16,7 @@ DotNetCliFileName="DotnetCLIVersion.txt"
 for i do
     if [[ "$i" == *"Intrinsics"* ]]; then
         DotNetCliFileName="DotnetCLIVersion.netcoreapp.latest.txt"
-        __TARGET_FRAMEWORK="netcoreapp3.0"
+        __TARGET_FRAMEWORK="netcoreapp3.1"
     fi
 done
 

--- a/pkg/TorchSharp/TorchSharp.nupkgproj
+++ b/pkg/TorchSharp/TorchSharp.nupkgproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <PackageDescription>.NET Bindings for Torch. Requires reference to one of libtorch-cpu, libtorch-cuda-$(CudaVersion), libtorch-cuda-$(CudaVersion)-win-x64 or libtorch-cuda-$(CudaVersion)-linux-x64 version $(LibTorchPackageVersion) to execute.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="..\common\NormalPackage.props" Pack="true" PackagePath="buildTransitive\netcoreapp3.0\$(MSBuildProjectName).props" />
-    <Content Include="..\common\NormalPackage.targets" Pack="true" PackagePath="buildTransitive\netcoreapp3.0\$(MSBuildProjectName).targets" />
+    <Content Include="..\common\NormalPackage.props" Pack="true" PackagePath="buildTransitive\netcoreapp3.1\$(MSBuildProjectName).props" />
+    <Content Include="..\common\NormalPackage.targets" Pack="true" PackagePath="buildTransitive\netcoreapp3.1\$(MSBuildProjectName).targets" />
     <Content Include="$(RepoRoot)\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -125,11 +125,11 @@ namespace TorchSharp.Examples
 
                     var predicted = prediction.Argmax(1);
                     total += target.Shape[0];
-                    correct += predicted.Eq(target).Sum().DataItem<long>();
+                    correct += predicted.Eq(target).Sum().ToInt64();
 
                     if (batchId % _logInterval == 0)
                     {
-                        Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.DataItem<float>()} Acc: { (float)correct / total }");
+                        Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.ToSingle()} Acc: { (float)correct / total }");
                     }
 
                     batchId++;
@@ -156,11 +156,11 @@ namespace TorchSharp.Examples
                 using (var prediction = model.Forward(data))
                 using (var output = loss(LogSoftMax(prediction, 1), target))
                 {
-                    testLoss += output.DataItem<float>();
+                    testLoss += output.ToSingle();
 
                     var pred = prediction.Argmax(1);
 
-                    correct += pred.Eq(target).Sum().DataItem<long>();
+                    correct += pred.Eq(target).Sum().ToInt64();
 
                     data.Dispose();
                     target.Dispose();

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TestUsesLibTorch>true</TestUsesLibTorch>
     <UseMLCodeAnalyzer>false</UseMLCodeAnalyzer>
     <UseStyleCopAnalyzer>false</UseStyleCopAnalyzer>

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -107,7 +107,7 @@ namespace TorchSharp.Examples
 
                     if (batchId % _logInterval == 0)
                     {
-                        Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.DataItem<float>()}");
+                        Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.ToSingle()}");
                     }
 
                     batchId++;
@@ -134,11 +134,11 @@ namespace TorchSharp.Examples
                 using (var prediction = model.Forward(data))
                 using (var output = loss(prediction, target))
                 {
-                    testLoss += output.DataItem<float>();
+                    testLoss += output.ToSingle();
 
                     var pred = prediction.Argmax(1);
 
-                    correct += pred.Eq(target).Sum().DataItem<int>(); // Memory leak here
+                    correct += pred.Eq(target).Sum().ToInt32(); // Memory leak here
 
                     data.Dispose();
                     target.Dispose();

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -1406,6 +1406,51 @@ Tensor THSTensor_newBoolScalar(bool  data, const int device_type, const int devi
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
+Tensor THSTensor_newInt16Scalar(short data, const int device_type, const int device_index, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Short))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
+Tensor THSTensor_newInt32Scalar(int data, const int device_type, const int device_index, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Int))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
+Tensor THSTensor_newInt64Scalar(int64_t data, const int device_type, const int device_index, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Long))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
+Tensor THSTensor_newFloat64Scalar(double data, const int device_type, const int device_index, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Double))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
+Tensor THSTensor_newFloat32Scalar(float data, const int device_type, const int device_index, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::Float))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor(data, options));
+}
+
 Tensor THSTensor_newFloat16Scalar(float data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
@@ -1422,51 +1467,6 @@ Tensor THSTensor_newBFloat16Scalar(float data, const int device_type, const int 
         .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor((c10::BFloat16)data, options));
-}
-
-Tensor THSTensor_newShortScalar(short data, const int device_type, const int device_index, bool requires_grad)
-{
-    auto options = at::TensorOptions()
-        .dtype(at::ScalarType(c10::ScalarType::Short))
-        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
-        .requires_grad(requires_grad);
-    CATCH_TENSOR(torch::tensor(data, options));
-}
-
-Tensor THSTensor_newIntScalar(int data, const int device_type, const int device_index, bool requires_grad)
-{
-    auto options = at::TensorOptions()
-        .dtype(at::ScalarType(c10::ScalarType::Int))
-        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
-        .requires_grad(requires_grad);
-    CATCH_TENSOR(torch::tensor(data, options));
-}
-
-Tensor THSTensor_newLongScalar(int64_t data, const int device_type, const int device_index, bool requires_grad)
-{
-    auto options = at::TensorOptions()
-        .dtype(at::ScalarType(c10::ScalarType::Long))
-        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
-        .requires_grad(requires_grad);
-    CATCH_TENSOR(torch::tensor(data, options));
-}
-
-Tensor THSTensor_newDoubleScalar(double data, const int device_type, const int device_index, bool requires_grad)
-{
-    auto options = at::TensorOptions()
-        .dtype(at::ScalarType(c10::ScalarType::Double))
-        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
-        .requires_grad(requires_grad);
-    CATCH_TENSOR(torch::tensor(data, options));
-}
-
-Tensor THSTensor_newFloatScalar(float data, const int device_type, const int device_index, bool requires_grad)
-{
-    auto options = at::TensorOptions()
-        .dtype(at::ScalarType(c10::ScalarType::Float))
-        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
-        .requires_grad(requires_grad);
-    CATCH_TENSOR(torch::tensor(data, options));
 }
 
 Tensor THSTensor_norm(const Tensor tensor, float p)

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -1320,7 +1320,7 @@ Tensor THSTensor_new(
     CATCH_TENSOR(torch::from_blob(data, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
 }
 
-Tensor THSTensor_newLong(
+Tensor THSTensor_newInt64(
     int64_t* data,
     void (*deleter)(void*),
     const int64_t* sizes,
@@ -1379,7 +1379,7 @@ Tensor THSTensor_newBFloat16(
     )
 }
 
-Tensor THSTensor_newSByteScalar(int8_t data, const int device_type, const int device_index, bool requires_grad)
+Tensor THSTensor_newInt8Scalar(int8_t data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Char))

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -503,9 +503,14 @@ void* THSTensor_data(const Tensor tensor)
     CATCH_RETURN(void*, NULL, tensor->data_ptr());
 }
 
-float THSTensor_data_idx_half(const Tensor tensor, const int64_t i)
+float THSTensor_data_idx_float16(const Tensor tensor, const int64_t i)
 {
     CATCH_RETURN(float, NULL, (float)(tensor->data_ptr<c10::Half>())[i]);
+}
+
+float THSTensor_data_idx_bfloat16(const Tensor tensor, const int64_t i)
+{
+    CATCH_RETURN(float, NULL, (float)(tensor->data_ptr<c10::BFloat16>())[i]);
 }
 
 const char* THSTensor_device_str(const Tensor tensor)
@@ -1329,8 +1334,8 @@ Tensor THSTensor_newLong(
 }
 
 // The data is passed in as float and copied into the array of Half in the C++ code
-// since .NET doesn't know about 'half' values.
-Tensor THSTensor_newHalf(
+// since .NET doesn't know about 'float16' values.
+Tensor THSTensor_newFloat16(
     float* rawArray,
     c10::Half* dataArray,
     void (*deleter)(void*),
@@ -1351,74 +1356,115 @@ Tensor THSTensor_newHalf(
     )
 }
 
-Tensor THSTensor_newSByteScalar(int8_t data, bool requires_grad)
+// The data is passed in as float and copied into the array of Half in the C++ code
+// since .NET doesn't know about 'float16' values.
+Tensor THSTensor_newBFloat16(
+    float* rawArray,
+    c10::BFloat16* dataArray,
+    void (*deleter)(void*),
+    const int64_t* sizes,
+    const int szlength,
+    const bool requires_grad)
+{
+    CATCH_RETURN_Tensor(
+        int64_t sz = 1;
+    for (int k = 0; k < szlength; k++)
+        sz *= sizes[k];
+    for (int64_t i = 0; i < sz; i++)
+        dataArray[i] = (c10::BFloat16)rawArray[i];
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(at::kBFloat16))
+        .requires_grad(requires_grad);
+    res = ResultTensor(torch::from_blob(dataArray, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
+    )
+}
+
+Tensor THSTensor_newSByteScalar(int8_t data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Char))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newByteScalar(char data, bool requires_grad)
+Tensor THSTensor_newByteScalar(char data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Byte))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newBoolScalar(bool  data, bool requires_grad)
+Tensor THSTensor_newBoolScalar(bool  data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Bool))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newHalfScalar(float data, bool requires_grad)
+Tensor THSTensor_newFloat16Scalar(float data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Half))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor((c10::Half)data, options));
 }
 
-Tensor THSTensor_newShortScalar(short data, bool requires_grad)
+Tensor THSTensor_newBFloat16Scalar(float data, const int device_type, const int device_index, bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(c10::ScalarType::BFloat16))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+    CATCH_TENSOR(torch::tensor((c10::BFloat16)data, options));
+}
+
+Tensor THSTensor_newShortScalar(short data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Short))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newIntScalar(int data, bool requires_grad)
+Tensor THSTensor_newIntScalar(int data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Int))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newLongScalar(int64_t data, bool requires_grad)
+Tensor THSTensor_newLongScalar(int64_t data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Long))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newDoubleScalar(double data, bool requires_grad)
+Tensor THSTensor_newDoubleScalar(double data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Double))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }
 
-Tensor THSTensor_newFloatScalar(float data, bool requires_grad)
+Tensor THSTensor_newFloatScalar(float data, const int device_type, const int device_index, bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(c10::ScalarType::Float))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
         .requires_grad(requires_grad);
     CATCH_TENSOR(torch::tensor(data, options));
 }

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -511,7 +511,7 @@ EXPORT_API(Tensor) THSTensor_new(
     int8_t scalar_type,
     const bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newLong(
+EXPORT_API(Tensor) THSTensor_newInt64(
     int64_t* data,
     void (*deleter)(void*),
     const int64_t* sizes,
@@ -534,7 +534,7 @@ EXPORT_API(Tensor) THSTensor_newBFloat16(
     const int szlength,
     const bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newSByteScalar(int8_t data, const int device_type, const int device_index, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newInt8Scalar(int8_t data, const int device_type, const int device_index, bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_newByteScalar(char data, const int device_type, const int device_index, bool requires_grad);
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -544,15 +544,15 @@ EXPORT_API(Tensor) THSTensor_newFloat16Scalar(float data, const int device_type,
 
 EXPORT_API(Tensor) THSTensor_newBFloat16Scalar(float data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newShortScalar(short data, const int device_type, const int device_index, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newInt16Scalar(short data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newIntScalar(int data, const int device_type, const int device_index, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newInt32Scalar(int data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newLongScalar(int64_t data, const int device_type, const int device_index, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newInt64Scalar(int64_t data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newDoubleScalar(double data, const int device_type, const int device_index, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newFloat64Scalar(double data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newFloatScalar(float data, const int device_type, const int device_index, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newFloat32Scalar(float data, const int device_type, const int device_index, bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_norm(const Tensor tensor, float p);
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -195,7 +195,9 @@ EXPORT_API(Tensor) THSTensor_cumsum(const Tensor tensor, const int64_t dim, bool
 
 EXPORT_API(void*) THSTensor_data(const Tensor tensor);
 
-EXPORT_API(float) THSTensor_data_idx_half(const Tensor tensor, const int64_t i);
+EXPORT_API(float) THSTensor_data_idx_float16(const Tensor tensor, const int64_t i);
+
+EXPORT_API(float) THSTensor_data_idx_bfloat16(const Tensor tensor, const int64_t i);
 
 EXPORT_API(const char*) THSTensor_device_str(const Tensor tensor);
 
@@ -516,7 +518,7 @@ EXPORT_API(Tensor) THSTensor_newLong(
     const int szlength,
     const bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newHalf(
+EXPORT_API(Tensor) THSTensor_newFloat16(
     float* rawArray,
     c10::Half* dataArray,
     void (*deleter)(void*),
@@ -524,23 +526,33 @@ EXPORT_API(Tensor) THSTensor_newHalf(
     const int szlength,
     const bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newSByteScalar(int8_t data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newBFloat16(
+    float* rawArray,
+    c10::BFloat16* dataArray,
+    void (*deleter)(void*),
+    const int64_t* sizes,
+    const int szlength,
+    const bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newByteScalar(char data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newSByteScalar(int8_t data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newBoolScalar(bool data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newByteScalar(char data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newHalfScalar(float data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newBoolScalar(bool data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newShortScalar(short data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newFloat16Scalar(float data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newIntScalar(int data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newBFloat16Scalar(float data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newLongScalar(int64_t data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newShortScalar(short data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newDoubleScalar(double data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newIntScalar(int data, const int device_type, const int device_index, bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_newFloatScalar(float data, bool requires_grad);
+EXPORT_API(Tensor) THSTensor_newLongScalar(int64_t data, const int device_type, const int device_index, bool requires_grad);
+
+EXPORT_API(Tensor) THSTensor_newDoubleScalar(double data, const int device_type, const int device_index, bool requires_grad);
+
+EXPORT_API(Tensor) THSTensor_newFloatScalar(float data, const int device_type, const int device_index, bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_norm(const Tensor tensor, float p);
 

--- a/src/Native/LibTorchSharp/THSTorch.cpp
+++ b/src/Native/LibTorchSharp/THSTorch.cpp
@@ -41,7 +41,7 @@ Scalar THSTorch_uint8_to_scalar(uint8_t value)
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_short_to_scalar(short value)
+Scalar THSTorch_int16_to_scalar(short value)
 {
     return new torch::Scalar(value);
 }
@@ -51,7 +51,7 @@ Scalar THSTorch_int32_to_scalar(int value)
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_long_to_scalar(long value)
+Scalar THSTorch_int64_to_scalar(long value)
 {
     return new torch::Scalar(int64_t(value));
 }
@@ -66,14 +66,59 @@ Scalar THSTorch_float64_to_scalar(double value)
     return new torch::Scalar(value);
 }
 
-Scalar THSTorch_half_to_scalar(float value)
+Scalar THSTorch_float16_to_scalar(float value)
 {
     return new torch::Scalar((c10::Half)value);
+}
+
+Scalar THSTorch_bfloat16_to_scalar(float value)
+{
+    return new torch::Scalar((c10::BFloat16)value);
 }
 
 Scalar THSTorch_bool_to_scalar(bool value)
 {
     return new torch::Scalar(value);
+}
+
+int8_t THSTorch_scalar_to_int8(Scalar value)
+{
+    return value->toChar();
+}
+
+uint8_t THSTorch_scalar_to_uint8(Scalar value)
+{
+    return value->toByte();
+}
+
+int16_t THSTorch_scalar_to_int16(Scalar value)
+{
+    return value->toShort();
+}
+
+int32_t THSTorch_scalar_to_int32(Scalar value)
+{
+    return value->toInt();
+}
+
+int64_t THSTorch_scalar_to_int64(Scalar value)
+{
+    return value->toLong();
+}
+
+float THSTorch_scalar_to_float32(Scalar value)
+{
+    return value->toFloat();
+}
+
+double THSTorch_scalar_to_float64(Scalar value)
+{
+    return value->toDouble();
+}
+
+bool THSTorch_scalar_to_bool(Scalar value)
+{
+    return value->toBool();
 }
 
 void THSTorch_dispose_scalar(Scalar scalar)

--- a/src/Native/LibTorchSharp/THSTorch.h
+++ b/src/Native/LibTorchSharp/THSTorch.h
@@ -19,13 +19,23 @@ EXPORT_API(const char *) THSTorch_get_and_reset_last_err();
 
 EXPORT_API(Scalar) THSTorch_int8_to_scalar(int8_t value);
 EXPORT_API(Scalar) THSTorch_uint8_to_scalar(uint8_t value);
-EXPORT_API(Scalar) THSTorch_short_to_scalar(short value);
+EXPORT_API(Scalar) THSTorch_int16_to_scalar(short value);
 EXPORT_API(Scalar) THSTorch_int32_to_scalar(int value);
-EXPORT_API(Scalar) THSTorch_long_to_scalar(long value);
+EXPORT_API(Scalar) THSTorch_int64_to_scalar(long value);
 EXPORT_API(Scalar) THSTorch_float32_to_scalar(float value);
 EXPORT_API(Scalar) THSTorch_float64_to_scalar(double value);
 EXPORT_API(Scalar) THSTorch_bool_to_scalar(bool value);
-EXPORT_API(Scalar) THSTorch_half_to_scalar(float value);
+EXPORT_API(Scalar) THSTorch_float16_to_scalar(float value);
+EXPORT_API(Scalar) THSTorch_bfloat16_to_scalar(float value);
+
+EXPORT_API(int8_t) THSTorch_scalar_to_int8(Scalar value);
+EXPORT_API(uint8_t) THSTorch_scalar_to_uint8(Scalar value);
+EXPORT_API(int16_t) THSTorch_scalar_to_int16(Scalar value);
+EXPORT_API(int32_t) THSTorch_scalar_to_int32(Scalar value);
+EXPORT_API(int64_t) THSTorch_scalar_to_int64(Scalar value);
+EXPORT_API(float) THSTorch_scalar_to_float32(Scalar value);
+EXPORT_API(double) THSTorch_scalar_to_float64(Scalar value);
+EXPORT_API(bool) THSTorch_scalar_to_bool(Scalar value);
 
 // Dispose the scalar.
 EXPORT_API(void) THSTorch_dispose_scalar(Scalar scalar);

--- a/src/Redist/libtorch-cpu/libtorch-cpu.proj
+++ b/src/Redist/libtorch-cpu/libtorch-cpu.proj
@@ -25,7 +25,7 @@
                         libtorch\lib\torch.dll;
                         libtorch\lib\torch_cpu.dll;
                         libtorch\lib\torch_global_deps.dll;
-                        libtorch\lib\uv.dll" 
+                        libtorch\lib\uv.dll;" 
       Runtime="win-x64"/>
 
     <LibtorchConfig Include="darwin" 

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -167,11 +167,12 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newByteScalar(byte scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newByteScalar(byte scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(byte scalar, bool requiresGrad = false)
+        public static TorchTensor From(byte scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newByteScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newByteScalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
@@ -234,14 +235,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type SByte.
+    ///   Tensor of type Int8.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class SByteTensor
+    public class Int8Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static SByteTensor()
+        static Int8Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -257,11 +258,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -277,11 +278,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -301,11 +302,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -327,11 +328,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -353,11 +354,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -379,11 +380,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -392,11 +393,12 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newSByteScalar(sbyte scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newInt8Scalar(sbyte scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(sbyte scalar, bool requiresGrad = false)
+        public static TorchTensor From(sbyte scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newSByteScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newInt8Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
@@ -419,11 +421,11 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad);
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int8, requiresGrad);
                 if (handle == IntPtr.Zero) {
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.SByte, requiresGrad);
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int8, requiresGrad);
                 }
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
@@ -446,11 +448,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.SByte, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int8, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -459,14 +461,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type Short.
+    ///   Tensor of type Int16.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class ShortTensor
+    public class Int16Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static ShortTensor()
+        static Int16Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -482,11 +484,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -502,11 +504,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -526,11 +528,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -552,11 +554,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -578,11 +580,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -604,11 +606,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -617,11 +619,12 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newShortScalar(short scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newInt16Scalar(short scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(short scalar, bool requiresGrad = false)
+        public static TorchTensor From(short scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newShortScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newInt16Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
@@ -644,11 +647,11 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad);
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int16, requiresGrad);
                 if (handle == IntPtr.Zero) {
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Short, requiresGrad);
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int16, requiresGrad);
                 }
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
@@ -671,11 +674,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Short, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -684,14 +687,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type Int.
+    ///   Tensor of type Int32.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class IntTensor
+    public class Int32Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static IntTensor()
+        static Int32Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -707,11 +710,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -727,11 +730,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -751,11 +754,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -777,11 +780,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -803,11 +806,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -829,11 +832,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -842,11 +845,12 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newIntScalar(int scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newInt32Scalar(int scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(int scalar, bool requiresGrad = false)
+        public static TorchTensor From(int scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newIntScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newInt32Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
@@ -869,11 +873,11 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad);
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int32, requiresGrad);
                 if (handle == IntPtr.Zero) {
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int, requiresGrad);
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Int32, requiresGrad);
                 }
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
@@ -896,11 +900,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int32, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -909,14 +913,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type Long.
+    ///   Tensor of type Int64.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class LongTensor
+    public class Int64Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static LongTensor()
+        static Int64Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -932,11 +936,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -952,11 +956,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -976,11 +980,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1002,11 +1006,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1028,11 +1032,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1054,11 +1058,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1067,17 +1071,18 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newLongScalar(long scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newInt64Scalar(long scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(long scalar, bool requiresGrad = false)
+        public static TorchTensor From(long scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newLongScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newInt64Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newLong(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
+        extern static IntPtr THSTensor_newInt64(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
 
         public static TorchTensor From(long[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
@@ -1094,11 +1099,11 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                var handle = THSTensor_newLong(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                var handle = THSTensor_newInt64(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
                 if (handle == IntPtr.Zero) {
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    handle = THSTensor_newLong(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    handle = THSTensor_newInt64(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
                 }
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
@@ -1121,11 +1126,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Long, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Int64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1134,14 +1139,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type Half.
+    ///   Tensor of type Float16.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class HalfTensor
+    public class Float16Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static HalfTensor()
+        static Float16Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -1157,11 +1162,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -1177,11 +1182,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -1201,11 +1206,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1227,11 +1232,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1253,11 +1258,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1279,11 +1284,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1304,11 +1309,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1330,11 +1335,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1343,17 +1348,18 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newHalfScalar(float scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newFloat16Scalar(float scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(float scalar, bool requiresGrad = false)
+        public static TorchTensor From(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newHalfScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newFloat16Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newHalf(IntPtr rawArray, IntPtr dataArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
+        extern static IntPtr THSTensor_newFloat16(IntPtr rawArray, IntPtr dataArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
 
         public static TorchTensor From(float[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
@@ -1372,11 +1378,11 @@ namespace TorchSharp.Tensor {
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
                 fixed (float* pRawArray = rawArray)
                 {
-                    var handle = THSTensor_newHalf((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    var handle = THSTensor_newFloat16((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_newHalf((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                        handle = THSTensor_newFloat16((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor(handle);
@@ -1400,11 +1406,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Half, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1413,14 +1419,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type Float.
+    ///   Tensor of type BFloat16.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class FloatTensor
+    public class BFloat16Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static FloatTensor()
+        static BFloat16Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -1436,11 +1442,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -1456,11 +1462,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -1480,11 +1486,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1506,11 +1512,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1532,11 +1538,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1558,11 +1564,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1583,11 +1589,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1609,11 +1615,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1622,11 +1628,292 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newFloatScalar(float scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newBFloat16Scalar(float scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(float scalar, bool requiresGrad = false)
+        public static TorchTensor From(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newFloatScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newBFloat16Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_newBFloat16(IntPtr rawArray, IntPtr dataArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
+
+        public static TorchTensor From(float[] rawArray, long[] dimensions, bool requiresGrad = false)
+        {
+            var dataArray = new Int16[rawArray.Length];
+            unsafe
+            {
+                var dataHandle = GCHandle.Alloc(dataArray, GCHandleType.Pinned);
+                var dataArrayAddr = dataHandle.AddrOfPinnedObject();
+                var gchp = GCHandle.ToIntPtr(dataHandle);
+                GCHandleDeleter deleter = null;
+                deleter =
+                    new GCHandleDeleter(delegate (IntPtr ptr) {
+                        GCHandle.FromIntPtr(gchp).Free();
+                        deleters.TryRemove(deleter, out deleter);
+                        });
+                deleters.TryAdd(deleter, deleter); // keep the delegate alive
+                fixed (float* pRawArray = rawArray)
+                {
+                    var handle = THSTensor_newBFloat16((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_newBFloat16((IntPtr)pRawArray, dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(handle);
+                }
+            }
+        }
+        
+        public static TorchTensor From(float[] rawArray, bool requiresGrad = false)
+        {
+            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
+
+        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.BFloat16, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+    }
+    /// <summary>
+    ///   Tensor of type Float32.
+    ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
+    ///   Please do no mix Aten Tensors and Torch Tensors.
+    /// </summary>
+    public class Float32Tensor
+    {
+        static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
+        static Float32Tensor()
+        {
+            deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, int scalarType, int deviceType, int deviceIndex, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
+		/// common difference step, starting from start
+        /// </summary>
+        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+		
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randperm(long n, int scalarType, int deviceType, int deviceIndex, bool requireGrad);
+
+        /// <summary>
+        /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
+        /// </summary>
+        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+		
+		[DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requireGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with zeros
+        /// </summary>
+        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_ones(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with ones
+        /// </summary>
+        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_empty(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with ones
+        /// </summary>
+        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randint(long max, IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
+        /// </summary>
+        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rand(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
+        /// </summary>
+        static public TorchTensor Random(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_randn(IntPtr psizes, int length, int scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
+        /// </summary>
+        static public TorchTensor RandomN(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+
+            unsafe
+            {
+                fixed (long* psizes = size)
+                {
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    if (handle == IntPtr.Zero) {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
+                    }
+                    if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor (handle);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_newFloat32Scalar(float scalar, int deviceType, int deviceIndex, bool requiresGrad);
+
+        public static TorchTensor From(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        {
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newFloat32Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
@@ -1649,11 +1936,11 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad);
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float32, requiresGrad);
                 if (handle == IntPtr.Zero) {
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float, requiresGrad);
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float32, requiresGrad);
                 }
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
@@ -1676,11 +1963,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float32, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1689,14 +1976,14 @@ namespace TorchSharp.Tensor {
         }
     }
     /// <summary>
-    ///   Tensor of type Double.
+    ///   Tensor of type Float64.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
     ///   Please do no mix Aten Tensors and Torch Tensors.
     /// </summary>
-    public class DoubleTensor
+    public class Float64Tensor
     {
         static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static DoubleTensor()
+        static Float64Tensor()
         {
             deleters = new ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter>();
         }
@@ -1712,11 +1999,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_arange (start.Handle, stop.Handle, step.Handle, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -1732,11 +2019,11 @@ namespace TorchSharp.Tensor {
         {
             Torch.InitializeDeviceType (deviceType);
 
-            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+            var handle = THSTensor_randperm (n, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                handle = THSTensor_randperm (n, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                handle = THSTensor_randperm (n, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
             }
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (handle);
@@ -1756,11 +2043,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_zeros ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1782,11 +2069,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_ones ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1808,11 +2095,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_empty ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1834,11 +2121,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randint (max, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1859,11 +2146,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_rand ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1885,11 +2172,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_randn ((IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -1898,11 +2185,12 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newDoubleScalar(double scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newFloat64Scalar(double scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(double scalar, bool requiresGrad = false)
+        public static TorchTensor From(double scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newDoubleScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newFloat64Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
@@ -1925,11 +2213,11 @@ namespace TorchSharp.Tensor {
                         deleters.TryRemove(deleter, out deleter);
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
-                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad);
+                var handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float64, requiresGrad);
                 if (handle == IntPtr.Zero) {
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Double, requiresGrad);
+                    handle = THSTensor_new(dataArrayAddr, deleter, dimensions, dimensions.Length, (sbyte)ScalarType.Float64, requiresGrad);
                 }
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
@@ -1952,11 +2240,11 @@ namespace TorchSharp.Tensor {
             {
                 fixed (long* psizes = size)
                 {
-                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                    var handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     if (handle == IntPtr.Zero) {
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
-                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Double, (int) deviceType, deviceIndex, requiresGrad);
+                        handle = THSTensor_sparse (indices.Handle, values.Handle, (IntPtr)psizes, size.Length, (sbyte)ScalarType.Float64, (int) deviceType, deviceIndex, requiresGrad);
                     }
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (handle);
@@ -2123,11 +2411,12 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newBoolScalar(bool scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_newBoolScalar(bool scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(bool scalar, bool requiresGrad = false)
+        public static TorchTensor From(bool scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_newBoolScalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_newBoolScalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -229,22 +229,23 @@ if (type.IsFloatingPoint) {
 <# } #>
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_new<#=type.Name#>Scalar(<#=type.Storage#> scalar, bool requiresGrad);
+        extern static IntPtr THSTensor_new<#=type.Name#>Scalar(<#=type.Storage#> scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(<#=type.Storage#> scalar, bool requiresGrad = false)
+        public static TorchTensor From(<#=type.Storage#> scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
-            var handle = THSTensor_new<#=type.Name#>Scalar(scalar, requiresGrad);
+            Torch.InitializeDeviceType (deviceType);
+            var handle = THSTensor_new<#=type.Name#>Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(handle);
         }
 
 <#
-if (type.IsLong) {
+if (type.IsInt64) {
 #>
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new<#=type.Name#>(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
 <#
-} else if (type.IsHalf) {
+} else if (type.IsFloat16 || type.IsBFloat16) {
 #>
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new<#=type.Name#>(IntPtr rawArray, IntPtr dataArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
@@ -258,7 +259,7 @@ if (type.IsLong) {
         public static TorchTensor From(<#=type.Storage#>[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
 <#
-if (type.IsHalf) {
+if (type.IsFloat16 || type.IsBFloat16) {
 #>
             var dataArray = new Int16[rawArray.Length];
 <#
@@ -279,7 +280,7 @@ if (type.IsHalf) {
                         });
                 deleters.TryAdd(deleter, deleter); // keep the delegate alive
 <#
-if (type.IsLong) {
+if (type.IsInt64) {
 #>
                 var handle = THSTensor_new<#=type.Name#>(dataArrayAddr, deleter, dimensions, dimensions.Length, requiresGrad);
                 if (handle == IntPtr.Zero) {
@@ -290,7 +291,7 @@ if (type.IsLong) {
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(handle);
 <#
-} else if (type.IsHalf) {
+} else if (type.IsFloat16 || type.IsBFloat16) {
 #>
                 fixed (<#=type.Storage#>* pRawArray = rawArray)
                 {

--- a/src/TorchSharp/Tensor/Types.ttinclude
+++ b/src/TorchSharp/Tensor/Types.ttinclude
@@ -5,10 +5,11 @@
         public readonly string Storage;
         public readonly string CSType;
 
-        public bool IsSignedInt => (Name == "SByte" || Name == "Short" || Name == "Int" || Name == "Long");
-        public bool IsFloatingPoint => (Name == "Half" || Name == "Float" || Name == "Double");
-        public bool IsLong => Name == "Long";
-        public bool IsHalf => Name == "Half";
+        public bool IsSignedInt => (Name == "Int8" || Name == "Int16" || Name == "Int32" || Name == "Unt64");
+        public bool IsFloatingPoint => (Name == "Float16" || Name == "BFloat16" || Name == "Float32" || Name == "Float64");
+        public bool IsInt64 => Name == "Int64";
+        public bool IsFloat16 => Name == "Float16";
+        public bool IsBFloat16 => Name == "BFloat16";
 
         private TorchTypeDef(string name, string storage) {
             this.Name = name;
@@ -17,21 +18,22 @@
 
         public static readonly TorchTypeDef[] Types = {
             new TorchTypeDef("Byte",   "byte"),
-            new TorchTypeDef("SByte",  "sbyte"),
-            new TorchTypeDef("Short",  "short"),
-            new TorchTypeDef("Int",    "int"),
-            new TorchTypeDef("Long",   "long"),
-            new TorchTypeDef("Half",   "float"),
-            new TorchTypeDef("Float",  "float"),
-            new TorchTypeDef("Double", "double"),
-            //new TorchTypeDef("ComplexHalf",  "(float, float)"),
-            //new TorchTypeDef("ComplexFloat",  "(float, float)"),
-            //new TorchTypeDef("ComplexDouble",  "System.Numerics.Complex"),
+            new TorchTypeDef("Int8",  "sbyte"),
+            new TorchTypeDef("Int16",  "short"),
+            new TorchTypeDef("Int32",   "int"),
+            new TorchTypeDef("Int64",   "long"),
+            new TorchTypeDef("Float16", "float"),
+            new TorchTypeDef("BFloat16","float"),
+            new TorchTypeDef("Float32", "float"),
+            new TorchTypeDef("Float64", "double"),
+            //new TorchTypeDef("ComplexFloat16",  "(float, float)"),
+            //new TorchTypeDef("ComplexFloat32",  "(float, float)"),
+            //new TorchTypeDef("ComplexFloat64",  "System.Numerics.Complex"),
             new TorchTypeDef("Bool",  "bool"),
             //new TorchTypeDef("QInt8",  "QInt8"),
             //new TorchTypeDef("QUInt8",  "QUInt8"),
             //new TorchTypeDef("QUInt32",  "QUInt32"),
-            //new TorchTypeDef("BHalf",  "BHalf"),
+            //new TorchTypeDef("BFloat16",  "BFloat16"),
         };
 
         public readonly string Ptr = "IntPtr"; // "HType";

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -70,7 +70,7 @@ namespace TorchSharp
                     //
                     // So we shadow copy the DLLs to the TorchSharp package, make a copy of the native DLL and continue
                     //
-                    // Assumed to be in ...\packages\torchsharp\0.3.0-local-debug-20200918\lib\netcoreapp3.0\TorchSharp.dll
+                    // Assumed to be in ...\packages\torchsharp\0.3.0-local-debug-20200918\lib\netcoreapp3.1\TorchSharp.dll
                     var cpuRootPackage = "libtorch-cpu";
                     var cudaRootPackage = $"libtorch-cuda-{cudaVersion}-{nativeRid}";
                     var torchsharpLoc = Path.GetDirectoryName(typeof(Torch).Assembly.Location);

--- a/src/TorchSharp/TorchScalar.cs
+++ b/src/TorchSharp/TorchScalar.cs
@@ -77,19 +77,11 @@ namespace TorchSharp
                 Handle = IntPtr.Zero;
             }
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_half_to_scalar(float value);
-
-        public static TorchScalar CreateHalf(float value)
-        {
-            return value.ToScalar();
-        }
-
     }
 
     public static class ScalarExtensionMethods
     {
+
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTorch_uint8_to_scalar(byte value);
 
@@ -107,11 +99,11 @@ namespace TorchSharp
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_short_to_scalar(short value);
+        extern static IntPtr THSTorch_int16_to_scalar(short value);
 
         public static TorchScalar ToScalar(this short value)
         {
-            return new TorchScalar(THSTorch_short_to_scalar(value));
+            return new TorchScalar(THSTorch_int16_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
@@ -123,11 +115,11 @@ namespace TorchSharp
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_long_to_scalar(long value);
+        extern static IntPtr THSTorch_int64_to_scalar(long value);
 
         public static TorchScalar ToScalar(this long value)
         {
-            return new TorchScalar(THSTorch_long_to_scalar(value));
+            return new TorchScalar(THSTorch_int64_to_scalar(value));
         }
 
         [DllImport("LibTorchSharp")]
@@ -152,5 +144,86 @@ namespace TorchSharp
         {
             return new TorchScalar(THSTorch_bool_to_scalar(value));
         }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTorch_float16_to_scalar(float value);
+
+        public static TorchScalar ToFloat16Scalar(this float value)
+        {
+            return new TorchScalar(THSTorch_float16_to_scalar(value));
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTorch_bfloat16_to_scalar(float value);
+
+        public static TorchScalar ToBFloat16Scalar(this float value)
+        {
+            return new TorchScalar(THSTorch_bfloat16_to_scalar(value));
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static float THSTorch_scalar_to_float32(IntPtr handle);
+
+        public static float ToSingle(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_float32(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static double THSTorch_scalar_to_float64(IntPtr handle);
+
+        public static double ToDouble(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_float64(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static sbyte THSTorch_scalar_to_int8(IntPtr handle);
+
+        public static sbyte ToSByte(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_int8(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static byte THSTorch_scalar_to_uint8(IntPtr handle);
+
+        public static byte ToByte(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_uint8(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static short THSTorch_scalar_to_int16(IntPtr handle);
+
+        public static short ToInt16(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_int16(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static int THSTorch_scalar_to_int32(IntPtr handle);
+
+        public static int ToInt32(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_int32(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static long THSTorch_scalar_to_int64(IntPtr handle);
+
+        public static long ToInt64(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_int64(value.Handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static bool THSTorch_scalar_to_bool(IntPtr handle);
+
+        public static bool ToBoolean(this TorchScalar value)
+        {
+            return THSTorch_scalar_to_bool(value.Handle);
+        }
+
     }
 }

--- a/src/TorchSharp/TorchSharp.csproj
+++ b/src/TorchSharp/TorchSharp.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       <IncludeInPackage>TorchSharp</IncludeInPackage>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <UseMLCodeAnalyzer>false</UseMLCodeAnalyzer>
@@ -57,7 +57,7 @@
 
     <MSBuild Projects="..\Redist\libtorch-cpu\libtorch-cpu.proj" Condition="'$(BuildingInsideVisualStudio)'!='true' AND '$(SkipNative)' != 'true'" Targets="Build" />
 
-    <MSBuild Projects="..\Native\build.proj" Condition="'$(BuildingInsideVisualStudio)'!='true' AND '$(SkipNative)' != 'true'" Targets="Build" />
+    <MSBuild Projects="..\Native\build.proj" Condition="'$(SkipNative)' != 'true'" Targets="Build" />
 
   </Target>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TestUsesLibTorch>true</TestUsesLibTorch>
     <TestCuda>true</TestCuda>
     <IsPackable>false</IsPackable>

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -46,7 +46,7 @@ namespace TorchSharp
         public void TestSetGetBiasInLinear()
         {
             var lin = Linear(1000, 100, true);
-            var bias = FloatTensor.Ones (new long[] { 1000 });
+            var bias = Float32Tensor.Ones (new long[] { 1000 });
             lin.Bias = bias;
             Assert.True(!(lin.Bias is null));
 
@@ -102,7 +102,7 @@ namespace TorchSharp
             var lin = Linear(1000, 100, true);
             var bias = lin.Bias!;
             var weight = lin.Weight.T();
-            var input = FloatTensor.RandomN(new long[] { 1, 1000 });
+            var input = Float32Tensor.RandomN(new long[] { 1, 1000 });
             var forward = lin.Forward(input);
             var matmul = input.MatMul(weight).Add(bias);
 
@@ -123,7 +123,7 @@ namespace TorchSharp
             Assert.False(!(lin.Bias is null));
 
             var weight = lin.Weight.Transpose(0, 1);
-            var input = FloatTensor.RandomN(new long[] { 1, 1000 });
+            var input = Float32Tensor.RandomN(new long[] { 1, 1000 });
             var forward = lin.Forward(input);
             var matmul = input.MatMul(weight);
 
@@ -141,7 +141,7 @@ namespace TorchSharp
         public void TestLinearEditBias()
         {
             var lin = Linear(1000, 100, true);
-            var bias = FloatTensor.RandomN(new long[] { 100 });
+            var bias = Float32Tensor.RandomN(new long[] { 100 });
             lin.Bias = bias;
 
             for (int i = 0; i < 100; i++)
@@ -154,8 +154,8 @@ namespace TorchSharp
         public void TestLinearEditWeightsAndBias()
         {
             var lin = Linear(1000, 1000, true);
-            var bias = FloatTensor.RandomN(new long[] { 100 });
-            var weights = FloatTensor.RandomN(new long[] { 100, 1000 });
+            var bias = Float32Tensor.RandomN(new long[] { 100 });
+            var weights = Float32Tensor.RandomN(new long[] { 100, 1000 });
 
             lin.Bias = bias;
             lin.Weight = weights;
@@ -174,8 +174,8 @@ namespace TorchSharp
         public void TestLinearEditWeightsAndBiasGetParameters()
         {
             var lin = Linear(1000, 1000, true);
-            var bias = FloatTensor.RandomN(new long[] { 100 });
-            var weights = FloatTensor.RandomN(new long[] { 1000, 1000 });
+            var bias = Float32Tensor.RandomN(new long[] { 100 });
+            var weights = Float32Tensor.RandomN(new long[] { 1000, 1000 });
             lin.Bias = bias;
             lin.Weight = weights;
 
@@ -204,7 +204,7 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
             var eval = seq.Forward(x);
         }
 
@@ -236,21 +236,21 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 });
-            var y = FloatTensor.RandomN(new long[] { 64, 10 });
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 });
 
             var eval = seq.Forward(x);
             var loss = MSE(NN.Reduction.Sum);
             var output = loss(eval, y);
 
-            var result = output.DataItem<float>();
+            var result = output.ToSingle();
         }
 
         [Fact]
         public void TestPoissonNLLLoss()
         {
-            using (TorchTensor input = FloatTensor.From(new float[] { 0.5f, 1.5f, 2.5f }))
-            using (TorchTensor target = FloatTensor.From(new float[] { 1f, 2f, 3f }))
+            using (TorchTensor input = Float32Tensor.From(new float[] { 0.5f, 1.5f, 2.5f }))
+            using (TorchTensor target = Float32Tensor.From(new float[] { 1f, 2f, 3f }))
             {
                 var componentWiseLoss = ((TorchTensor)input.Exp()) - target * input;
                 Assert.True(componentWiseLoss.Equal(PoissonNLL(reduction: NN.Reduction.None)(input, target)));
@@ -262,8 +262,8 @@ namespace TorchSharp
         [Fact]
         public void TestPoissonNLLLoss2()
         {
-            using (TorchTensor input = FloatTensor.Random(new long[] { 5, 2 }))
-            using (TorchTensor target = FloatTensor.Random(new long[] { 5, 2 }))
+            using (TorchTensor input = Float32Tensor.Random(new long[] { 5, 2 }))
+            using (TorchTensor target = Float32Tensor.Random(new long[] { 5, 2 }))
             {
                 var outTensor = PoissonNLL(true, true)(input, target);
             }
@@ -273,8 +273,8 @@ namespace TorchSharp
         [Fact(Skip = "Not working on Mac and Ubuntu (note: may now be working, we need to recheck)")]
         public void TestErrorHandling()
         {
-            using (TorchTensor input = FloatTensor.From(new float[] { 0.5f, 1.5f }))
-            using (TorchTensor target = FloatTensor.From(new float[] { 1f, 2f, 3f }))
+            using (TorchTensor input = Float32Tensor.From(new float[] { 0.5f, 1.5f }))
+            using (TorchTensor target = Float32Tensor.From(new float[] { 1f, 2f, 3f }))
             {
                 Assert.Throws<ExternalException>(() => PoissonNLL()(input, target));
             }
@@ -291,8 +291,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = FloatTensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.Forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -313,8 +313,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = FloatTensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.Forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -339,8 +339,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = FloatTensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.Forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -359,13 +359,13 @@ namespace TorchSharp
         [Fact]
         public void TestGrad2()
         {
-            var y = FloatTensor.RandomN(new long[] { 32, 1 });
-            var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).ToType(ScalarType.Float);
+            var y = Float32Tensor.RandomN(new long[] { 32, 1 });
+            var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).ToType(ScalarType.Float32);
             var inputs = new TorchTensor[] { input };
-            var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float).RequiresGrad(true);
+            var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float32).RequiresGrad(true);
             var linear = Linear(11, 1, true);
-            linear.Bias = new double[] { 373.8864 }.ToTorchTensor(new long[] { 1, 1 }).ToType(ScalarType.Float).RequiresGrad(true);
-            linear.Weight = new double[] { 300.2818, -0.5905267, 286.2787, 0.1970505, 0.9004903, 0.1373157, 55.85495, 11.43741, 1.525748, 0.4299785, 239.9356 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float).RequiresGrad(true);
+            linear.Bias = new double[] { 373.8864 }.ToTorchTensor(new long[] { 1, 1 }).ToType(ScalarType.Float32).RequiresGrad(true);
+            linear.Weight = new double[] { 300.2818, -0.5905267, 286.2787, 0.1970505, 0.9004903, 0.1373157, 55.85495, 11.43741, 1.525748, 0.4299785, 239.9356 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float32).RequiresGrad(true);
 
             var afterCat = inputs.Cat(1);
             var afterScaler = afterCat * scaler;
@@ -389,7 +389,7 @@ namespace TorchSharp
         [Fact]
         public void TestSetGrad()
         {
-            var x = FloatTensor.Random(new long[] { 10, 10 });
+            var x = Float32Tensor.Random(new long[] { 10, 10 });
             Assert.False(x.IsGradRequired);
 
             x.RequiresGrad(true);
@@ -441,8 +441,8 @@ namespace TorchSharp
             var psF = modF.GetParameters();
             Assert.Equal(4, psF.Length);
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = FloatTensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
             modT.Train();
 
@@ -486,7 +486,7 @@ namespace TorchSharp
         [Fact(Skip = "Not working on MacOS (note: may now be working, we need to recheck)")]
         public void TestAutoGradMode()
         {
-            var x = FloatTensor.RandomN(new long[] { 2, 3 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 2, 3 }, requiresGrad: true);
             using (var mode = new AutoGradMode(false))
             {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
@@ -548,7 +548,7 @@ namespace TorchSharp
         [Fact]
         public void TestCustomModule()
         {
-            var module = new TestModule("test", FloatTensor.RandomN(new long[] { 2, 2 }), true);
+            var module = new TestModule("test", Float32Tensor.RandomN(new long[] { 2, 2 }), true);
             var name = module.GetName();
             Assert.NotNull(name);
             Assert.Equal("test", name);
@@ -562,7 +562,7 @@ namespace TorchSharp
         [Fact]
         public void TestCustomModuleWithInPlaceModification()
         {
-            var param = FloatTensor.RandomN(new long[] { 1000, 100 });
+            var param = Float32Tensor.RandomN(new long[] { 1000, 100 });
             var module = new TestModule("test", param, true);
 
             Assert.Equal(1000, module.GetParameter("test").Shape[0]);
@@ -603,8 +603,8 @@ namespace TorchSharp
             var lin2 = Linear(100, 10);
             var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 });
-            var y = FloatTensor.RandomN(new long[] { 64, 10 });
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 });
 
             float learning_rate = 0.00004f;
             float prevLoss = float.MaxValue;
@@ -614,7 +614,7 @@ namespace TorchSharp
             {
                 var eval = seq.Forward(x);
                 var output = loss(eval, y);
-                var lossVal = output.DataItem<float>();
+                var lossVal = output.ToSingle();
 
                 Assert.True(lossVal < prevLoss);
                 prevLoss = lossVal;
@@ -660,8 +660,8 @@ namespace TorchSharp
             var lin2 = Linear(100, 10);
             var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
 
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 });
-            var y = FloatTensor.RandomN(new long[] { 64, 10 });
+            var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
+            var y = Float32Tensor.RandomN(new long[] { 64, 10 });
 
             double learning_rate = 0.00004f;
             float prevLoss = float.MaxValue;
@@ -672,7 +672,7 @@ namespace TorchSharp
             {
                 var eval = seq.Forward(x);
                 var output = loss(eval, y);
-                var lossVal = output.DataItem<float>();
+                var lossVal = output.ToSingle();
 
                 Assert.True(lossVal < prevLoss);
                 prevLoss = lossVal;
@@ -767,7 +767,7 @@ namespace TorchSharp
         [Fact]
         public void AvgPool2DObjectInitialized()
         {
-            TorchTensor ones = FloatTensor.Ones(new long[] { 2, 2, 2 });
+            TorchTensor ones = Float32Tensor.Ones(new long[] { 2, 2, 2 });
             var obj = Functions.AvgPool2D(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
         }
@@ -775,7 +775,7 @@ namespace TorchSharp
         [Fact]
         public void MaxPool2DObjectInitialized()
         {
-            TorchTensor ones = FloatTensor.Ones(new long[] { 2, 2, 2 });
+            TorchTensor ones = Float32Tensor.Ones(new long[] { 2, 2, 2 });
             var obj = Functions.MaxPool2D(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
         }

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -27,10 +27,10 @@ namespace TorchSharp
                 Assert.False(isCudnnAvailable);
             }
 
-            //TorchTensor t = FloatTensor.Ones(shape);
+            //TorchTensor t = Float32Tensor.Ones(shape);
             //Assert.Equal(shape, t.Shape);
-            //Assert.Equal(1.0f, t[0, 0].DataItem<float>());
-            //Assert.Equal(1.0f, t[1, 1].DataItem<float>());
+            //Assert.Equal(1.0f, t[0, 0].ToSingle());
+            //Assert.Equal(1.0f, t[1, 1].ToSingle());
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace TorchSharp
             for (int i = 0; i < n; i++) {
                 Console.WriteLine("ExplicitDisposal: Loop iteration {0}", i);
 
-                using (var x = FloatTensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU)) { }
+                using (var x = Float32Tensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU)) { }
             }
             Console.WriteLine("Hello World!");
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -14,13 +14,13 @@ namespace TorchSharp
     public class TestTorchTensor
     {
         [Fact]
-        public void CreateFloatTensorOnes()
+        public void CreateFloat32TensorOnes()
         {
             var shape = new long[] { 2, 2 };
-            TorchTensor t = FloatTensor.Ones(shape);
+            TorchTensor t = Float32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t[0, 0].DataItem<float>());
-            Assert.Equal(1.0f, t[1, 1].DataItem<float>());
+            Assert.Equal(1.0f, t[0, 0].ToSingle());
+            Assert.Equal(1.0f, t[1, 1].ToSingle());
         }
 
         [Fact]
@@ -29,29 +29,29 @@ namespace TorchSharp
             var shape = new long[] { 2, 2 };
             TorchTensor t = ByteTensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal((byte)1, t[0,0].DataItem<byte>());
-            Assert.Equal((byte)1, t[1,1].DataItem<byte>());
+            Assert.Equal((byte)1, t[0,0].ToByte());
+            Assert.Equal((byte)1, t[1,1].ToByte());
         }
 
         [Fact]
-        public void CreateIntTensorOnes()
+        public void CreateInt32TensorOnes()
         {
             var shape = new long[] { 2, 2 };
-            TorchTensor t = IntTensor.Ones(shape);
+            TorchTensor t = Int32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1, t[0,0].DataItem<int>());
-            Assert.Equal(1, t[1,1].DataItem<int>());
+            Assert.Equal(1, t[0,0].ToInt32());
+            Assert.Equal(1, t[1,1].ToInt32());
         }
 
         [Fact]
-        public void CreateLongTensorOnes()
+        public void CreateInt64TensorOnes()
         {
             var shape = new long[] { 2, 2 };
 
-            TorchTensor t = LongTensor.Ones(shape);
+            TorchTensor t = Int64Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal((long)1, t[0,0].DataItem<int>());
-            Assert.Equal((long)1, t[1,1].DataItem<int>());
+            Assert.Equal(1L, t[0,0].ToInt64());
+            Assert.Equal(1L, t[1,1].ToInt64());
         }
 
         [Fact]
@@ -61,27 +61,46 @@ namespace TorchSharp
 
             TorchTensor t = BoolTensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal((object)true, t[0,0].DataItem<bool>());
-            Assert.Equal((object)true, t[1,1].DataItem<bool>());
+            Assert.Equal((object)true, t[0,0].ToBoolean());
+            Assert.Equal((object)true, t[1,1].ToBoolean());
         }
 
         [Fact]
-        public void CreateHalfTensorOnes()
+        public void CreateFloat16TensorOnes()
         {
-            var shape = new long[] { 2, 2 };
+            foreach (var deviceType in new DeviceType[] { DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var shape = new long[] { 2, 2 };
 
-            TorchTensor t = HalfTensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t.ReadHalf(0));
-            Assert.Equal(1.0f, t.ReadHalf(3));
+                    TorchTensor t = Float16Tensor.Ones(shape, deviceType: deviceType);
+                    Assert.Equal(shape, t.Shape);
+                    Assert.Equal(1.0f, t[0, 0].ToSingle());
+                    Assert.Equal(1.0f, t[1, 1].ToSingle());
+                }
+            }
+        }
+
+        [Fact]
+        public void CreateBFloat16TensorOnes()
+        {
+            foreach (var deviceType in new DeviceType[] { DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var shape = new long[] { 2, 2 };
+
+                    TorchTensor t = BFloat16Tensor.Ones(shape, deviceType: deviceType);
+                    Assert.Equal(shape, t.Shape);
+                    Assert.Equal(1.0f, t[0, 0].ToSingle());
+                    Assert.Equal(1.0f, t[1, 1].ToSingle());
+                }
+            }
         }
 
         //[Fact]
-        //public void CreateComplexFloatTensorZeros()
+        //public void CreateComplexFloat32TensorZeros()
         //{
         //    var shape = new long[] { 2, 2 };
 
-        //    TorchTensor t = ComplexFloatTensor.Zeros(shape);
+        //    TorchTensor t = ComplexFloat32Tensor.Zeros(shape);
         //    Assert.Equal(shape, t.Shape);
         //    t.ReadComplexFloat(0, out var r3, out var i3);
         //    Assert.Equal(0.0f, r3);
@@ -93,11 +112,11 @@ namespace TorchSharp
         //}
 
         //[Fact]
-        //public void CreateComplexFloatTensorOnes()
+        //public void CreateComplexFloat32TensorOnes()
         //{
         //    var shape = new long[] { 2, 2 };
 
-        //    TorchTensor t = ComplexFloatTensor.Ones(shape);
+        //    TorchTensor t = ComplexFloat32Tensor.Ones(shape);
         //    Assert.Equal(shape, t.Shape);
         //    t.ReadComplexFloat(0, out var r3, out var i3);
         //    Assert.Equal(1.0f, r3);
@@ -109,41 +128,41 @@ namespace TorchSharp
         //}
 
         //[Fact]
-        //public void CreateComplexDoubleTensorZeros()
+        //public void CreateComplexFloat64TensorZeros()
         //{
         //    var shape = new long[] { 2, 2 };
 
-        //    TorchTensor t = ComplexDoubleTensor.Zeros(shape);
+        //    TorchTensor t = ComplexFloat64Tensor.Zeros(shape);
         //    Assert.Equal(shape, t.Shape);
-        //    var v3 = t.ReadComplexDouble(0);
+        //    var v3 = t.ReadComplexFloat64(0);
         //    Assert.Equal(0.0, v3.Real);
         //    Assert.Equal(0.0, v3.Imaginary);
-        //    var v4 = t.ReadComplexDouble(3);
+        //    var v4 = t.ReadComplexFloat64(3);
         //    Assert.Equal(0.0, v4.Real);
         //    Assert.Equal(0.0, v4.Imaginary);
 
         //}
 
         //[Fact]
-        //public void CreateComplexDoubleTensorOnes()
+        //public void CreateComplexFloat64TensorOnes()
         //{
         //    var shape = new long[] { 2, 2 };
-        //    TorchTensor t = ComplexDoubleTensor.Ones(shape);
+        //    TorchTensor t = ComplexFloat64Tensor.Ones(shape);
         //    Assert.Equal(shape, t.Shape);
-        //    var v5 = t.ReadComplexDouble(0);
+        //    var v5 = t.ReadComplexFloat64(0);
         //    Assert.Equal(new Complex(1.0, 0.0), v5);
-        //    var v6 = t.ReadComplexDouble(3);
+        //    var v6 = t.ReadComplexFloat64(3);
         //    Assert.Equal(new Complex(1.0, 0.0), v6);
         //}
 
         [Fact]
-        public void CreateFloatTensorCheckMemory()
+        public void CreateFloat32TensorCheckMemory()
         {
             TorchTensor? ones = null;
 
             for (int i = 0; i < 10; i++)
             {
-                using (var tmp = FloatTensor.Ones(new long[] { 100, 100, 100 }))
+                using (var tmp = Float32Tensor.Ones(new long[] { 100, 100, 100 }))
                 {
                     ones = tmp;
                     Assert.NotNull(ones);
@@ -152,9 +171,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void CreateFloatTensorOnesCheckData()
+        public void CreateFloat32TensorOnesCheckData()
         {
-            var ones = FloatTensor.Ones(new long[] { 2, 2 });
+            var ones = Float32Tensor.Ones(new long[] { 2, 2 });
             var data = ones.Data<float>();
 
             for (int i = 0; i < 4; i++)
@@ -164,9 +183,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void CreateFloatTensorZerosCheckData()
+        public void CreateFloat32TensorZerosCheckData()
         {
-            var zeros = FloatTensor.Zeros(new long[] { 2, 2 });
+            var zeros = Float32Tensor.Zeros(new long[] { 2, 2 });
             var data = zeros.Data<float>();
 
             for (int i = 0; i < 4; i++)
@@ -176,9 +195,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void CreateIntTensorOnesCheckData()
+        public void CreateInt32TensorOnesCheckData()
         {
-            var ones = IntTensor.Ones(new long[] { 2, 2 });
+            var ones = Int32Tensor.Ones(new long[] { 2, 2 });
             var data = ones.Data<int>();
 
             for (int i = 0; i < 4; i++)
@@ -188,33 +207,33 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void CreateFloatTensorCheckDevice()
+        public void CreateFloat32TensorCheckDevice()
         {
-            var ones = FloatTensor.Ones(new long[] { 2, 2 });
+            var ones = Float32Tensor.Ones(new long[] { 2, 2 });
             var device = ones.DeviceString;
 
             Assert.Equal("cpu", ones.DeviceString);
         }
 
         [Fact]
-        public void CreateFloatTensorFromData()
+        public void CreateFloat32TensorFromData()
         {
             var data = new float[1000];
             data[100] = 1;
 
-            using (var tensor = FloatTensor.From(data, new long[] { 100, 10 }))
+            using (var tensor = Float32Tensor.From(data, new long[] { 100, 10 }))
             {
                 Assert.Equal(1, tensor.Data<float>()[100]);
             }
         }
 
         [Fact]
-        public void CreateFloatTensorFromDataCheckDispose()
+        public void CreateFloat32TensorFromDataCheckDispose()
         {
             var data = new float[1000];
             data[100] = 1;
 
-            using (var tensor = FloatTensor.From(data, new long[] { 100, 10 }))
+            using (var tensor = Float32Tensor.From(data, new long[] { 100, 10 }))
             {
                 Assert.Equal(1, tensor.Data<float>()[100]);
             }
@@ -223,7 +242,7 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void CreateFloatTensorFromData2()
+        public void CreateFloat32TensorFromData2()
         {
             var data = new float[1000];
 
@@ -233,7 +252,7 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void CreateFloatTensorFromDataCheckStrides()
+        public void CreateFloat32TensorFromDataCheckStrides()
         {
             var data = new double[] { 0.2663158, 0.1144736, 0.1147367, 0.1249998, 0.1957895, 0.1231576, 0.1944732, 0.111842, 0.1065789, 0.667881, 0.5682123, 0.5824502, 0.4824504, 0.4844371, 0.6463582, 0.5334439, 0.5079474, 0.2281452 };
             var dataTensor = data.ToTorchTensor(new long[] { 2, 9 });
@@ -243,75 +262,108 @@ namespace TorchSharp
                 for (int i = 0; i < 9; i++)
                 {
                     var fromData = data[(r * 9) + i];
-                    var fromTensor = dataTensor[r, i].DataItem<double>();
+                    var fromTensor = dataTensor[r, i].ToDouble();
                     Assert.True(Math.Abs(fromData - fromTensor) < 0.0001);
                 }
             }
 
-            var firstHalf = dataTensor[0];
+            var firstPart = dataTensor[0];
 
             for (int i = 0; i < 9; i++)
             {
                 var fromData = data[i];
-                var fromChunk = firstHalf[i].DataItem<double>();
+                var fromChunk = firstPart[i].ToDouble();
                 Assert.True(Math.Abs(fromData - fromChunk) < 0.0001);
             }
         }
 
 
         [Fact]
-        public void CreateHalfTensorFromDataCheckStrides()
+        public void CreateFloat16TensorFromDataCheckStrides()
         {
             var data = new float[] { 0.2663158f, 0.1144736f, 0.1147367f, 0.1249998f, 0.1957895f, 0.1231576f, 0.1944732f, 0.111842f, 0.1065789f, 0.667881f, 0.5682123f, 0.5824502f, 0.4824504f, 0.4844371f, 0.6463582f, 0.5334439f, 0.5079474f, 0.2281452f };
-            var dataTensor = HalfTensor.From(data, new long[] { 2, 9 });
+            var dataTensor = Float16Tensor.From(data, new long[] { 2, 9 });
 
             for (int r = 0; r < 2; r++) {
                 for (int i = 0; i < 9; i++) {
                     var fromData = data[(r * 9) + i];
-                    var fromTensor = dataTensor.ReadHalf((r * 9) + i);
+                    var fromTensor = dataTensor[r, i].ToSingle();
                     Assert.True(Math.Abs(fromData - fromTensor) < 0.01);
                 }
             }
 
-            var firstHalf = dataTensor[0];
+            var firstPart = dataTensor[0];
 
             for (int i = 0; i < 9; i++) {
                 var fromData = data[i];
-                var fromChunk = firstHalf.ReadHalf(i);
+                var fromChunk = firstPart[i].ToSingle();
                 Assert.True(Math.Abs(fromData - fromChunk) < 0.01);
             }
         }
 
+        [Fact]
+        public void CreateBFloat16TensorFromDataCheckStrides()
+        {
+            var data = new float[] { 0.2663158f, 0.1144736f, 0.1147367f, 0.1249998f, 0.1957895f, 0.1231576f, 0.1944732f, 0.111842f, 0.1065789f, 0.667881f, 0.5682123f, 0.5824502f, 0.4824504f, 0.4844371f, 0.6463582f, 0.5334439f, 0.5079474f, 0.2281452f };
+            var dataTensor = BFloat16Tensor.From(data, new long[] { 2, 9 });
+
+            for (int r = 0; r < 2; r++) {
+                for (int i = 0; i < 9; i++) {
+                    var fromData = data[(r * 9) + i];
+                    var fromTensor = dataTensor[r,i].ToSingle();
+                    Assert.True(Math.Abs(fromData - fromTensor) < 0.1);
+                }
+            }
+
+            var firstPart = dataTensor[0];
+
+            for (int i = 0; i < 9; i++) {
+                var fromData = data[i];
+                var fromChunk = firstPart[i].ToSingle();
+                Assert.True(Math.Abs(fromData - fromChunk) < 0.1);
+            }
+        }
+
 
         [Fact]
-        public void CreateFloatTensorFromScalar()
+        public void CreateFloat32TensorFromScalar()
         {
             float scalar = 333.0f;
 
-            using (var tensor = FloatTensor.From(scalar))
+            using (var tensor = Float32Tensor.From(scalar))
             {
-                Assert.Equal(333.0f, tensor.DataItem<float>());
+                Assert.Equal(333.0f, tensor.ToSingle());
             }
         }
 
         [Fact]
-        public void CreateHalfTensorFromScalar()
+        public void CreateFloat16TensorFromScalar()
         {
             float scalar = 333.0f;
 
-            using (var tensor = HalfTensor.From(scalar)) {
-                Assert.Equal(333.0f, tensor.ReadHalf(0));
+            using (var tensor = Float16Tensor.From(scalar)) {
+                Assert.Equal(333.0f, tensor.ToSingle());
             }
         }
 
         [Fact]
-        public void CreateFloatTensorFromScalar2()
+        public void CreateBFloat16TensorFromScalar()
+        {
+            float scalar = 333.0f;
+
+            using (var tensor = BFloat16Tensor.From(scalar)) {
+                Assert.Equal(332.0f, tensor.ToSingle()); // NOTE: bfloat16 loses precision, this really is 332.0f
+            }
+        }
+
+        [Fact]
+        public void CreateFloat32TensorFromScalar2()
         {
             float scalar = 333.0f;
 
             using (var tensor = scalar.ToTorchTensor())
             {
-                Assert.Equal(333, tensor.DataItem<float>());
+                Assert.Equal(333, tensor.ToSingle());
             }
         }
 
@@ -319,48 +371,48 @@ namespace TorchSharp
         public void GetSetItem2()
         {
             var shape = new long[] { 2, 3 };
-            TorchTensor t = FloatTensor.Ones(shape);
+            TorchTensor t = Float32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t[0, 0].DataItem<float>());
-            Assert.Equal(1.0f, t[1, 2].DataItem<float>());
-            t[1, 2] = FloatTensor.From(2.0f);
-            Assert.Equal(2.0f, t[1, 2].DataItem<float>());
+            Assert.Equal(1.0f, t[0, 0].ToSingle());
+            Assert.Equal(1.0f, t[1, 2].ToSingle());
+            t[1, 2] = Float32Tensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2].ToSingle());
         }
 
         [Fact]
         public void GetSetItem3()
         {
             var shape = new long[] { 2, 3, 4 };
-            TorchTensor t = FloatTensor.Ones(shape);
+            TorchTensor t = Float32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t[0, 0, 0].DataItem<float>());
-            Assert.Equal(1.0f, t[1, 2, 3].DataItem<float>());
-            t[1, 2, 3] = FloatTensor.From(2.0f);
-            Assert.Equal(2.0f, t[1, 2, 3].DataItem<float>());
+            Assert.Equal(1.0f, t[0, 0, 0].ToSingle());
+            Assert.Equal(1.0f, t[1, 2, 3].ToSingle());
+            t[1, 2, 3] = Float32Tensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3].ToSingle());
         }
 
         [Fact]
         public void GetSetItem4()
         {
             var shape = new long[] { 2, 3, 4, 5 };
-            TorchTensor t = FloatTensor.Ones(shape);
+            TorchTensor t = Float32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t[0, 0, 0, 0].DataItem<float>());
-            Assert.Equal(1.0f, t[1, 2, 3, 4].DataItem<float>());
-            t[1, 2, 3, 4] = FloatTensor.From(2.0f);
-            Assert.Equal(2.0f, t[1, 2, 3, 4].DataItem<float>());
+            Assert.Equal(1.0f, t[0, 0, 0, 0].ToSingle());
+            Assert.Equal(1.0f, t[1, 2, 3, 4].ToSingle());
+            t[1, 2, 3, 4] = Float32Tensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3, 4].ToSingle());
         }
 
         [Fact]
         public void GetSetItem5()
         {
             var shape = new long[] { 2, 3, 4, 5, 6 };
-            TorchTensor t = FloatTensor.Ones(shape);
+            TorchTensor t = Float32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t[0, 0, 0, 0, 0].DataItem<float>());
-            Assert.Equal(1.0f, t[1, 2, 3, 4, 5].DataItem<float>());
-            t[1, 2, 3, 4, 5] = FloatTensor.From(2.0f);
-            Assert.Equal(2.0f, t[1, 2, 3, 4, 5].DataItem<float>());
+            Assert.Equal(1.0f, t[0, 0, 0, 0, 0].ToSingle());
+            Assert.Equal(1.0f, t[1, 2, 3, 4, 5].ToSingle());
+            t[1, 2, 3, 4, 5] = Float32Tensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3, 4, 5].ToSingle());
         }
 
 
@@ -368,12 +420,12 @@ namespace TorchSharp
         public void GetSetItem6()
         {
             var shape = new long[] { 2, 3, 4, 5, 6, 7 };
-            TorchTensor t = FloatTensor.Ones(shape);
+            TorchTensor t = Float32Tensor.Ones(shape);
             Assert.Equal(shape, t.Shape);
-            Assert.Equal(1.0f, t[0, 0, 0, 0, 0, 0].DataItem<float>());
-            Assert.Equal(1.0f, t[1, 2, 3, 4, 5, 6].DataItem<float>());
-            t[1, 2, 3, 4, 5, 6] = FloatTensor.From(2.0f);
-            Assert.Equal(2.0f, t[1, 2, 3, 4, 5, 6].DataItem<float>());
+            Assert.Equal(1.0f, t[0, 0, 0, 0, 0, 0].ToSingle());
+            Assert.Equal(1.0f, t[1, 2, 3, 4, 5, 6].ToSingle());
+            t[1, 2, 3, 4, 5, 6] = Float32Tensor.From(2.0f);
+            Assert.Equal(2.0f, t[1, 2, 3, 4, 5, 6].ToSingle());
         }
 
         [Fact]
@@ -387,45 +439,78 @@ namespace TorchSharp
         {
             using (var tensor = 1.ToTorchTensor())
             {
-                Assert.Equal(ScalarType.Int, tensor.Type);
-                Assert.Equal(1, tensor.DataItem<int>());
+                Assert.Equal(ScalarType.Int32, tensor.Type);
+                Assert.Equal(1, tensor.ToInt32());
             }
             using (var tensor = ((byte)1).ToTorchTensor())
             {
                 Assert.Equal(ScalarType.Byte, tensor.Type);
-                Assert.Equal(1, tensor.DataItem<byte>());
+                Assert.Equal(1, tensor.ToByte());
             }
             using (var tensor = ((sbyte)-1).ToTorchTensor())
             {
-                Assert.Equal(ScalarType.SByte, tensor.Type);
-                Assert.Equal(-1, tensor.DataItem<sbyte>());
+                Assert.Equal(ScalarType.Int8, tensor.Type);
+                Assert.Equal(-1, tensor.ToSByte());
             }
             using (var tensor = ((short)-1).ToTorchTensor())
             {
-                Assert.Equal(ScalarType.Short, tensor.Type);
-                Assert.Equal(-1, tensor.DataItem<short>());
+                Assert.Equal(ScalarType.Int16, tensor.Type);
+                Assert.Equal(-1, tensor.ToInt16());
             }
             using (var tensor = ((long)-1).ToTorchTensor())
             {
-                Assert.Equal(ScalarType.Long, tensor.Type);
-                Assert.Equal(-1L, tensor.DataItem<short>());
+                Assert.Equal(ScalarType.Int64, tensor.Type);
+                Assert.Equal(-1L, tensor.ToInt64());
             }
             using (var tensor = ((float)-1).ToTorchTensor())
             {
-                Assert.Equal(ScalarType.Float, tensor.Type);
-                Assert.Equal(-1.0f, tensor.DataItem<float>());
+                Assert.Equal(ScalarType.Float32, tensor.Type);
+                Assert.Equal(-1.0f, tensor.ToSingle());
             }
             using (var tensor = ((double)-1).ToTorchTensor())
             {
-                Assert.Equal(ScalarType.Double, tensor.Type);
-                Assert.Equal(-1.0, tensor.DataItem<double>());
+                Assert.Equal(ScalarType.Float64, tensor.Type);
+                Assert.Equal(-1.0, tensor.ToDouble());
+            }
+        }
+
+        [Fact]
+        public void TestScalarToTensor3()
+        {
+            using (var tensor = 1.ToTorchTensor()) {
+                Assert.Equal(ScalarType.Int32, tensor.Type);
+                Assert.Equal(1, (int) tensor);
+            }
+            using (var tensor = ((byte)1).ToTorchTensor()) {
+                Assert.Equal(ScalarType.Byte, tensor.Type);
+                Assert.Equal(1, (byte) tensor);
+            }
+            using (var tensor = ((sbyte)-1).ToTorchTensor()) {
+                Assert.Equal(ScalarType.Int8, tensor.Type);
+                Assert.Equal(-1, (sbyte) tensor);
+            }
+            using (var tensor = ((short)-1).ToTorchTensor()) {
+                Assert.Equal(ScalarType.Int16, tensor.Type);
+                Assert.Equal(-1, (short) tensor);
+            }
+            using (var tensor = ((long)-1).ToTorchTensor()) {
+                Assert.Equal(ScalarType.Int64, tensor.Type);
+                Assert.Equal(-1L, (long) tensor);
+            }
+            using (var tensor = ((float)-1).ToTorchTensor()) {
+                Assert.Equal(ScalarType.Float32, tensor.Type);
+                Assert.Equal(-1.0f, (float) tensor);
+            }
+            using (var tensor = ((double)-1).ToTorchTensor()) {
+                Assert.Equal(ScalarType.Float64, tensor.Type);
+                Assert.Equal(-1.0, (double) tensor);
             }
         }
 
         [Fact]
         public void InitUniform()
         {
-            using (TorchTensor tensor = FloatTensor.Zeros(new long[] { 2, 2 }))
+            using (TorchTensor tensor = Float32Tensor.Zeros(new long[] { 2, 2 }))
             {
                 NN.Init.Uniform(tensor);
             }
@@ -434,10 +519,10 @@ namespace TorchSharp
         [Fact]
         public void TestSparse()
         {
-            using (var i = LongTensor.From(new long[] { 0, 1, 1, 2, 0, 2 }, new long[] { 2, 3 }))
-            using (var v = FloatTensor.From(new float[] { 3, 4, 5 }, new long[] { 3 }))
+            using (var i = Int64Tensor.From(new long[] { 0, 1, 1, 2, 0, 2 }, new long[] { 2, 3 }))
+            using (var v = Float32Tensor.From(new float[] { 3, 4, 5 }, new long[] { 3 }))
             {
-                var sparse = FloatTensor.Sparse(i, v, new long[] { 2, 3 });
+                var sparse = Float32Tensor.Sparse(i, v, new long[] { 2, 3 });
 
                 Assert.True(sparse.IsSparse);
                 Assert.False(i.IsSparse);
@@ -450,7 +535,7 @@ namespace TorchSharp
         [Fact]
         public void CopyCpuToCuda()
         {
-            TorchTensor cpu = FloatTensor.Ones(new long[] { 2, 2 });
+            TorchTensor cpu = Float32Tensor.Ones(new long[] { 2, 2 });
             Assert.Equal("cpu", cpu.DeviceString);
 
             if (Torch.IsCudaAvailable())
@@ -479,7 +564,7 @@ namespace TorchSharp
         {
             if (Torch.IsCudaAvailable())
             {
-                var cuda = FloatTensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA);
+                var cuda = Float32Tensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA);
                 Assert.Equal("cuda:0", cuda.DeviceString);
 
                 var cpu = cuda.Cpu();
@@ -493,16 +578,16 @@ namespace TorchSharp
             }
             else
             {
-                Assert.Throws<InvalidOperationException>(() => { FloatTensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA); });
+                Assert.Throws<InvalidOperationException>(() => { Float32Tensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA); });
             }
         }
 
         [Fact]
         public void TestSquareEuclideanDistance()
         {
-            var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).ToType(ScalarType.Float);
-            var zeros = FloatTensor.Zeros(new long[] { 1, 9 });
-            var ones = FloatTensor.Ones(new long[] { 1, 9 });
+            var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).ToType(ScalarType.Float32);
+            var zeros = Float32Tensor.Zeros(new long[] { 1, 9 });
+            var ones = Float32Tensor.Ones(new long[] { 1, 9 });
             var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
 
             var distanceFromZero = input.Reshape(new long[] { -1, 1, 9 }).Sub(zeros).Pow(2.ToScalar()).Sum(new long[] { 2 });
@@ -515,8 +600,8 @@ namespace TorchSharp
         [Fact]
         public void TestCat()
         {
-            var zeros = FloatTensor.Zeros(new long[] { 1, 9 });
-            var ones = FloatTensor.Ones(new long[] { 1, 9 });
+            var zeros = Float32Tensor.Zeros(new long[] { 1, 9 });
+            var ones = Float32Tensor.Ones(new long[] { 1, 9 });
             var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
 
             var shape = centroids.Shape;
@@ -527,8 +612,8 @@ namespace TorchSharp
         public void TestCatCuda()
         {
             if (Torch.IsCudaAvailable()) {
-                var zeros = FloatTensor.Zeros(new long[] { 1, 9 }).Cuda();
-                var ones = FloatTensor.Ones(new long[] { 1, 9 }).Cuda();
+                var zeros = Float32Tensor.Zeros(new long[] { 1, 9 }).Cuda();
+                var ones = Float32Tensor.Ones(new long[] { 1, 9 }).Cuda();
                 var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
                 var shape = centroids.Shape;
                 Assert.Equal(new long[] { 2, 9 }, shape);
@@ -539,9 +624,9 @@ namespace TorchSharp
         void TestStackGen(DeviceType device)
         {
             {
-                var t1 = FloatTensor.Zeros( new long[] { }, device );
-                var t2 = FloatTensor.Ones(new long[] { }, device);
-                var t3 = FloatTensor.Ones(new long[] { }, device);
+                var t1 = Float32Tensor.Zeros( new long[] { }, device );
+                var t2 = Float32Tensor.Ones(new long[] { }, device);
+                var t3 = Float32Tensor.Ones(new long[] { }, device);
                 var res = new TorchTensor[] { t1, t2, t3 }.Stack(0);
 
                 var shape = res.Shape;
@@ -549,8 +634,8 @@ namespace TorchSharp
                 Assert.Equal(device, res.DeviceType);
             }
             {
-                var t1 = FloatTensor.Zeros(new long[] { 2, 9 }, device);
-                var t2 = FloatTensor.Ones(new long[] { 2, 9 }, device);
+                var t1 = Float32Tensor.Zeros(new long[] { 2, 9 }, device);
+                var t2 = Float32Tensor.Ones(new long[] { 2, 9 }, device);
                 var res = new TorchTensor[] { t1, t2 }.Stack(0);
 
                 var shape = res.Shape;
@@ -576,7 +661,7 @@ namespace TorchSharp
         [Fact]
         public void TestSetGrad()
         {
-            var x = FloatTensor.Random(new long[] { 10, 10 });
+            var x = Float32Tensor.Random(new long[] { 10, 10 });
             Assert.False(x.IsGradRequired);
 
             x.RequiresGrad(true);
@@ -588,7 +673,7 @@ namespace TorchSharp
         [Fact(Skip = "Not working on MacOS (note: may now be working, we need to recheck)")]
         public void TestAutoGradMode()
         {
-            var x = FloatTensor.RandomN(new long[] { 2, 3 }, requiresGrad: true);
+            var x = Float32Tensor.RandomN(new long[] { 2, 3 }, requiresGrad: true);
             using (var mode = new AutoGradMode(false))
             {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
@@ -615,8 +700,8 @@ namespace TorchSharp
         [Fact]
         public void TestSubInPlace()
         {
-            var x = IntTensor.Ones(new long[] { 100, 100 });
-            var y = IntTensor.Ones(new long[] { 100, 100 });
+            var x = Int32Tensor.Ones(new long[] { 100, 100 });
+            var y = Int32Tensor.Ones(new long[] { 100, 100 });
 
             x.SubInPlace(y);
 
@@ -635,7 +720,7 @@ namespace TorchSharp
         public void TestMemoryDisposalZeros()
         {
             for (int i = 0; i < 1024; i++) {
-                var x = DoubleTensor.Zeros(new long[] { 1024, 1024 });
+                var x = Float64Tensor.Zeros(new long[] { 1024, 1024 });
                 x.Dispose();
                 //System.GC.Collect();
             }
@@ -645,7 +730,7 @@ namespace TorchSharp
         public void TestMemoryDisposalOnes()
         {
             for (int i = 0; i < 1024; i++) {
-                var x = DoubleTensor.Ones(new long[] { 1024, 1024 });
+                var x = Float64Tensor.Ones(new long[] { 1024, 1024 });
                 x.Dispose();
             }
         }
@@ -655,7 +740,7 @@ namespace TorchSharp
         {
             for (int i = 0; i < 5; i++) {
                 for (int j = 0; j < 1000 * 100; j++) {
-                    var x = DoubleTensor.From(i * j * 3.1415);
+                    var x = Float64Tensor.From(i * j * 3.1415);
                     x.Dispose();
                 }
                 //System.GC.Collect();
@@ -680,7 +765,7 @@ namespace TorchSharp
         {
             var file = ".saveload.double.ts";
             if (File.Exists(file)) File.Delete(file);
-            var tensor = DoubleTensor.Ones(new long[] { 5, 6 });
+            var tensor = Float64Tensor.Ones(new long[] { 5, 6 });
             tensor.Save(file);
             var tensorLoaded = TorchTensor.Load(file);
             File.Delete(file);
@@ -694,7 +779,7 @@ namespace TorchSharp
         {
             var file = ".saveload.float.ts";
             if (File.Exists(file)) File.Delete(file);
-            var tensor = FloatTensor.Ones(new long[] { 5, 6 });
+            var tensor = Float32Tensor.Ones(new long[] { 5, 6 });
             tensor.Save(file);
             var tensorLoaded = TorchTensor.Load(file);
             File.Delete(file);
@@ -705,165 +790,330 @@ namespace TorchSharp
 
 
         [Fact]
-        public void TestArithmeticOperators()
+        public void TestArithmeticOperatorsFloat16()
         {
-            // scalar-tensor operators
-            TestOneTensor<float, float>(a => a + 0.5f, a => a + 0.5f);
-            TestOneTensor<float, float>(a => 0.5f + a, a => 0.5f + a);
-            TestOneTensor<float, float>(a => a - 0.5f, a => a - 0.5f);
-            TestOneTensor<float, float>(a => a * 0.5f, a => a * 0.5f);
-            TestOneTensor<float, float>(a => 0.5f * a, a => 0.5f * a);
-            TestOneTensor<float, float>(a => a / 0.5f, a => a / 0.5f);
+            // Float16 arange_cuda not available on cuda in LibTorch 1.7.0
+            // Float16 arange_cpu not available on cuda in LibTorch 1.7.0
+            foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var c1 = Float16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c2 = Float16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c3 = Float16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
+                    // scalar-tensor operators
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a + 0.5f, a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f + a, a => 0.5f + a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a - 0.5f, a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a * 0.5f, a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f * a, a => 0.5f * a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a / 0.5f, a => a / 0.5f);
 
-            TestOneTensor<float, float>(a => a.Add(0.5f), a => a + 0.5f);
-            TestOneTensor<float, float>(a => a.Sub(0.5f), a => a - 0.5f);
-            TestOneTensor<float, float>(a => a.Mul(0.5f), a => a * 0.5f);
-            TestOneTensor<float, float>(a => a.Div(0.5f), a => a / 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Add(0.5f), a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Sub(0.5f), a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Mul(0.5f), a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Div(0.5f), a => a / 0.5f);
 
-            TestOneTensorInPlace<float>(a => a.AddInPlace(0.5f), a => a + 0.5f);
-            TestOneTensorInPlace<float>(a => a.SubInPlace(0.5f), a => a - 0.5f);
-            TestOneTensorInPlace<float>(a => a.MulInPlace(0.5f), a => a * 0.5f);
-            TestOneTensorInPlace<float>(a => a.DivInPlace(0.5f), a => a / 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.AddInPlace(0.5f), a => a + 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.SubInPlace(0.5f), a => a - 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.MulInPlace(0.5f), a => a * 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.DivInPlace(0.5f), a => a / 0.5f);
 
-            // tensor-tensor operators
-            TestTwoTensor<float, float>((a, b) => a + b, (a, b) => a + b);
-            TestTwoTensor<float, float>((a, b) => a - b, (a, b) => a - b);
-            TestTwoTensor<float, float>((a, b) => a * b, (a, b) => a * b);
-            TestTwoTensor<float, float>((a, b) => a / b, (a, b) => a / b);
+                    // tensor-tensor operators
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a - b, (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
 
-            TestTwoTensor<float, float>((a, b) => a.Add(b), (a, b) => a + b);
-            TestTwoTensor<float, float>((a, b) => a.Sub(b), (a, b) => a - b);
-            TestTwoTensor<float, float>((a, b) => a.Mul(b), (a, b) => a * b);
-            TestTwoTensor<float, float>((a, b) => a.Div(b), (a, b) => a / b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
 
-            TestTwoTensorInPlace<float>((a, b) => a.AddInPlace(b), (a, b) => a + b);
-            TestTwoTensorInPlace<float>((a, b) => a.SubInPlace(b), (a, b) => a - b);
-            TestTwoTensorInPlace<float>((a, b) => a.MulInPlace(b), (a, b) => a * b);
-            TestTwoTensorInPlace<float>((a, b) => a.DivInPlace(b), (a, b) => a / b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                }
+            }
         }
 
         [Fact]
-        public void TestComparisonOperators()
+        public void TestArithmeticOperatorsBFloat16()
         {
-            // scalar-tensor operators
-            TestOneTensor<float, bool>(a => a == 5.0f, a => a == 5.0f);
-            TestOneTensor<float, bool>(a => a != 5.0f, a => a != 5.0f);
-            TestOneTensorInPlace<float>(a => a.EqInPlace(5.0f), a => a == 5.0f ? 1.0f : 0.0f);
-            TestOneTensorInPlace<float>(a => a.NeInPlace(5.0f), a => a != 5.0f ? 1.0f : 0.0f);
+            // BFloat16 arange_cuda not available on cuda in LibTorch 1.7.0
+            // BFloat16 arange_cpu not available on cuda in LibTorch 1.7.0
+            foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var c1 = BFloat16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c2 = BFloat16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c3 = BFloat16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
+                    // scalar-tensor operators
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a + 0.5f, a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f + a, a => 0.5f + a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a - 0.5f, a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a * 0.5f, a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f * a, a => 0.5f * a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a / 0.5f, a => a / 0.5f);
 
-            TestOneTensor<float, bool>(a => a < 5.0f, a => a < 5.0f);
-            TestOneTensor<float, bool>(a => 5.0f < a, a => 5.0f < a);
-            TestOneTensor<float, bool>(a => a <= 5.0f, a => a <= 5.0f);
-            TestOneTensor<float, bool>(a => 5.0f <= a, a => 5.0f <= a);
-            TestOneTensor<float, bool>(a => a > 5.0f, a => a > 5.0f);
-            TestOneTensor<float, bool>(a => 5.0f > a, a => 5.0f > a);
-            TestOneTensor<float, bool>(a => a >= 5.0f, a => a >= 5.0f);
-            TestOneTensor<float, bool>(a => 5.0f >= a, a => 5.0f >= a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Add(0.5f), a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Sub(0.5f), a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Mul(0.5f), a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Div(0.5f), a => a / 0.5f);
 
-            TestOneTensorInPlace<float>(a => a.LtInPlace(5.0f), a => a < 5.0f ? 1.0f : 0.0f);
-            TestOneTensorInPlace<float>(a => a.LeInPlace(5.0f), a => a <= 5.0f ? 1.0f : 0.0f);
-            TestOneTensorInPlace<float>(a => a.GtInPlace(5.0f), a => a > 5.0f ? 1.0f : 0.0f);
-            TestOneTensorInPlace<float>(a => a.GeInPlace(5.0f), a => a >= 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.AddInPlace(0.5f), a => a + 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.SubInPlace(0.5f), a => a - 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.MulInPlace(0.5f), a => a * 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.DivInPlace(0.5f), a => a / 0.5f);
 
-            TestOneTensor<float, float>(a => a % 5.0f, a => a % 5.0f);
-            TestOneTensorInPlace<float>(a => a.RemainderInPlace(5.0f), a => a % 5.0f);
+                    // tensor-tensor operators
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a - b, (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
 
-            // tensor-tensor operators
-            TestTwoTensor<float, bool>((a, b) => a == b, (a, b) => a == b);
-            TestTwoTensor<float, bool>((a, b) => a != b, (a, b) => a != b);
-            TestTwoTensorInPlace<float>((a, b) => a.EqInPlace(b), (a, b) => a == b ? 1.0f : 0.0f);
-            TestTwoTensorInPlace<float>((a, b) => a.NeInPlace(b), (a, b) => a != b ? 1.0f : 0.0f);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
 
-            TestTwoTensor<float, bool>((a, b) => a < b, (a, b) => a < b);
-            TestTwoTensor<float, bool>((a, b) => a <= b, (a, b) => a <= b);
-            TestTwoTensor<float, bool>((a, b) => a > b, (a, b) => a > b);
-            TestTwoTensor<float, bool>((a, b) => a >= b, (a, b) => a >= b);
-
-            TestTwoTensorInPlace<float>((a, b) => a.LtInPlace(b), (a, b) => a < b ? 1.0f : 0.0f);
-            TestTwoTensorInPlace<float>((a, b) => a.LeInPlace(b), (a, b) => a <= b ? 1.0f : 0.0f);
-            TestTwoTensorInPlace<float>((a, b) => a.GtInPlace(b), (a, b) => a > b ? 1.0f : 0.0f);
-            TestTwoTensorInPlace<float>((a, b) => a.GeInPlace(b), (a, b) => a >= b ? 1.0f : 0.0f);
-
-            TestTwoTensor<float, float>((a, b) => a % b, (a, b) => a % b);
-            TestTwoTensorInPlace<float>((a, b) => a.RemainderInPlace(b), (a, b) => a % b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                }
+            }
         }
 
-        private void TestOneTensor<Tin, Tout>(Func<TorchTensor, TorchTensor> tensorFunc,
+        [Fact]
+        public void TestArithmeticOperatorsFloat32()
+        {
+            foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var c1 = Float32Tensor.Arange(0, 10, 1, deviceType: deviceType);
+                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType);
+                    var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
+                    // scalar-tensor operators
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a + 0.5f, a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f + a, a => 0.5f + a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a - 0.5f, a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a * 0.5f, a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f * a, a => 0.5f * a);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a / 0.5f, a => a / 0.5f);
+
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Add(0.5f), a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Sub(0.5f), a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Mul(0.5f), a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Div(0.5f), a => a / 0.5f);
+
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.AddInPlace(0.5f), a => a + 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.SubInPlace(0.5f), a => a - 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.MulInPlace(0.5f), a => a * 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.DivInPlace(0.5f), a => a / 0.5f);
+
+                    // tensor-tensor operators
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a - b, (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
+
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
+
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestArithmeticOperatorsFloat64()
+        {
+            foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var c1 = Float64Tensor.Arange(0, 10, 1, deviceType: deviceType);
+                    var c2 = Float64Tensor.Arange(10, 0, -1, deviceType: deviceType);
+                    var c3 = Float64Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    Func<TorchTensor, long, long, double> getFunc = (tt, i, j) => tt[i, j].ToDouble(); 
+                    // scalar-tensor operators
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a + 0.5, a => a + 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => 0.5 + a, a => 0.5 + a);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a - 0.5, a => a - 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a * 0.5, a => a * 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => 0.5 * a, a => 0.5 * a);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a / 0.5, a => a / 0.5);
+
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Add(0.5), a => a + 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Sub(0.5), a => a - 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Mul(0.5), a => a * 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Div(0.5), a => a / 0.5);
+
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.AddInPlace(0.5), a => a + 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.SubInPlace(0.5), a => a - 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.MulInPlace(0.5), a => a * 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.DivInPlace(0.5), a => a / 0.5);
+
+                    // tensor-tensor operators
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a - b, (a, b) => a - b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
+
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
+
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestComparisonOperatorsFloat32()
+        {
+            foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
+                if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
+                    var c1 =Float32Tensor.Arange(0, 10, 1, deviceType: deviceType);
+                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType);
+                    var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i, j].ToSingle(); 
+                    Func<TorchTensor, long, long, bool> getFuncBool = (tt, i, j) => tt[i, j].ToBoolean(); 
+                    // scalar-tensor operators
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a == 5.0f, a => a == 5.0f);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a != 5.0f, a => a != 5.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.EqInPlace(5.0f), a => a == 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.NeInPlace(5.0f), a => a != 5.0f ? 1.0f : 0.0f);
+
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a < 5.0f, a => a < 5.0f);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => 5.0f < a, a => 5.0f < a);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a <= 5.0f, a => a <= 5.0f);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => 5.0f <= a, a => 5.0f <= a);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a > 5.0f, a => a > 5.0f);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => 5.0f > a, a => 5.0f > a);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a >= 5.0f, a => a >= 5.0f);
+                    TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => 5.0f >= a, a => 5.0f >= a);
+
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.LtInPlace(5.0f), a => a < 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.LeInPlace(5.0f), a => a <= 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.GtInPlace(5.0f), a => a > 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.GeInPlace(5.0f), a => a >= 5.0f ? 1.0f : 0.0f);
+
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a % 5.0f, a => a % 5.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.RemainderInPlace(5.0f), a => a % 5.0f);
+
+                    // tensor-tensor operators
+                    TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a == b, (a, b) => a == b);
+                    TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a != b, (a, b) => a != b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.EqInPlace(b), (a, b) => a == b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.NeInPlace(b), (a, b) => a != b ? 1.0f : 0.0f);
+
+                    TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a < b, (a, b) => a < b);
+                    TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a <= b, (a, b) => a <= b);
+                    TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a > b, (a, b) => a > b);
+                    TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a >= b, (a, b) => a >= b);
+
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.LtInPlace(b), (a, b) => a < b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.LeInPlace(b), (a, b) => a <= b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.GtInPlace(b), (a, b) => a > b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.GeInPlace(b), (a, b) => a >= b ? 1.0f : 0.0f);
+
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a % b, (a, b) => a % b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.RemainderInPlace(b), (a, b) => a % b);
+                }
+            }
+        }
+
+        private void TestOneTensor<Tin, Tout>(
+            TorchTensor c1,
+            TorchTensor c2,
+            Func<TorchTensor, long, long, Tin> getFuncIn,
+            Func<TorchTensor, long, long, Tout> getFuncOut,
+            Func<TorchTensor, TorchTensor> tensorFunc,
             Func<Tin, Tout> scalarFunc)
         {
-            var c1 = FloatTensor.Arange(0, 10, 1);
-            var c2 = FloatTensor.Ones(new long[] { 10, 10 });
-
             var x = c1 * c2;
             var y = tensorFunc(x);
-
-            var xData = x.Data<Tin>();
-            var yData = y.Data<Tout>();
 
             for (int i = 0; i < 10; i++)
             {
                 for (int j = 0; j < 10; j++)
                 {
-                    Assert.Equal(yData[i + j], scalarFunc(xData[i + j]));
+                    var xv = getFuncIn(x, i, j);
+                    var yv = getFuncOut(y, i, j);
+                    Assert.Equal<Tout>(yv, scalarFunc(xv));
                 }
             }
         }
 
-        private void TestOneTensorInPlace<Tin>(Func<TorchTensor, TorchTensor> tensorFunc,
+        private void TestOneTensorInPlace<Tin>(
+            TorchTensor c1,
+            TorchTensor c2,
+            Func<TorchTensor, long, long, Tin> getFuncIn,
+            Func<TorchTensor, TorchTensor> tensorFunc,
             Func<Tin, Tin> scalarFunc)
         {
-            var c1 = FloatTensor.Arange(0, 10, 1);
-            var c2 = FloatTensor.Ones(new long[] { 10, 10 });
 
             var x = c1 * c2;
             var xClone = x.Clone();
             var y = tensorFunc(x);
 
-            var xData = x.Data<Tin>();
-            var xCloneData = xClone.Data<Tin>();
-            var yData = y.Data<Tin>();
-
-            Assert.True(xData == yData);
             for (int i = 0; i < 10; i++)
             {
                 for (int j = 0; j < 10; j++)
                 {
-                    Assert.Equal(yData[i + j], scalarFunc(xCloneData[i + j]));
+                    var xClonev = getFuncIn(xClone, i, j);
+                    var xv = getFuncIn(x, i, j);
+                    var yv = getFuncIn(y, i, j);
+                    Assert.Equal(yv, scalarFunc(xClonev));
+                    Assert.Equal(yv, xv);
                 }
             }
         }
 
-        private void TestTwoTensor<Tin, Tout>(Func<TorchTensor, TorchTensor, TorchTensor> tensorFunc,
+        private void TestTwoTensor<Tin, Tout>(
+            TorchTensor c1,
+            TorchTensor c2,
+            TorchTensor c3,
+            Func<TorchTensor, long, long, Tin> getFuncIn,
+            Func<TorchTensor, long, long, Tout> getFuncOut,
+            Func<TorchTensor, TorchTensor, TorchTensor> tensorFunc,
             Func<Tin, Tin, Tout> scalarFunc)
         {
-            var c1 = FloatTensor.Arange(0, 10, 1);
-            var c2 = FloatTensor.Arange(10, 0, -1);
-            var c3 = FloatTensor.Ones(new long[] { 10, 10 });
 
             var x = c1 * c3;
             var y = c2 * c3;
 
             var z = tensorFunc(x, y);
 
-            var xData = x.Data<Tin>();
-            var yData = y.Data<Tin>();
-            var zData = z.Data<Tout>();
-
             for (int i = 0; i < 10; i++)
             {
                 for (int j = 0; j < 10; j++)
                 {
-                    Assert.Equal(zData[i + j], scalarFunc(xData[i + j], yData[i + j]));
+                    var xv = getFuncIn(x, i, j);
+                    var yv = getFuncIn(y, i, j);
+                    var zv = getFuncOut(z, i, j);
+                    Assert.Equal(zv, scalarFunc(xv, yv));
                 }
             }
         }
 
-        private void TestTwoTensorInPlace<Tin>(Func<TorchTensor, TorchTensor, TorchTensor> tensorFunc,
+        private void TestTwoTensorInPlace<Tin>(
+            TorchTensor c1,
+            TorchTensor c2,
+            TorchTensor c3,
+            Func<TorchTensor, long, long, Tin> getFuncIn,
+            Func<TorchTensor, TorchTensor, TorchTensor> tensorFunc,
             Func<Tin, Tin, Tin> scalarFunc)
         {
-            var c1 = FloatTensor.Arange(0, 10, 1);
-            var c2 = FloatTensor.Arange(10, 0, -1);
-            var c3 = FloatTensor.Ones(new long[] { 10, 10 });
 
             var x = c1 * c3;
             var xClone = x.Clone();
@@ -881,7 +1131,12 @@ namespace TorchSharp
             {
                 for (int j = 0; j < 10; j++)
                 {
-                    Assert.Equal(zData[i + j], scalarFunc(xCloneData[i + j], yData[i + j]));
+                    var xClonev = getFuncIn(xClone, i, j);
+                    var xv = getFuncIn(x, i, j);
+                    var yv = getFuncIn(y, i, j);
+                    var zv = getFuncIn(z, i, j);
+                    Assert.Equal(zv, scalarFunc(xClonev, yv));
+                    Assert.Equal(zv, xv);
                 }
             }
         }
@@ -889,7 +1144,7 @@ namespace TorchSharp
         [Fact]
         public void TestMul()
         {
-            var x = FloatTensor.Ones(new long[] { 100, 100 });
+            var x = Float32Tensor.Ones(new long[] { 100, 100 });
 
             var y = x.Mul(0.5f.ToScalar());
 
@@ -908,8 +1163,8 @@ namespace TorchSharp
         void TestMmGen(DeviceType device)
         {
             {
-                var x1 = FloatTensor.Ones(new long[] { 1, 2 }, deviceType: device);
-                var x2 = FloatTensor.Ones(new long[] { 2, 1 }, deviceType: device);
+                var x1 = Float32Tensor.Ones(new long[] { 1, 2 }, deviceType: device);
+                var x2 = Float32Tensor.Ones(new long[] { 2, 1 }, deviceType: device);
 
                 var y = x1.Mm(x2).ToDevice(DeviceType.CPU);
 
@@ -919,8 +1174,8 @@ namespace TorchSharp
             }
             //System.Runtime.InteropServices.ExternalException : addmm for CUDA tensors only supports floating - point types.Try converting the tensors with.float() at C:\w\b\windows\pytorch\aten\src\THC / generic / THCTensorMathBlas.cu:453
             if (device == DeviceType.CPU) {
-                var x1 = LongTensor.Ones(new long[] { 1, 2 }, deviceType: device);
-                var x2 = LongTensor.Ones(new long[] { 2, 1 }, deviceType: device);
+                var x1 = Int64Tensor.Ones(new long[] { 1, 2 }, deviceType: device);
+                var x2 = Int64Tensor.Ones(new long[] { 2, 1 }, deviceType: device);
 
                 var y = x1.Mm(x2).ToDevice(DeviceType.CPU);
 
@@ -949,8 +1204,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Sin).ToArray();
-            var res = FloatTensor.From(data).Sin();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Sin();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -958,8 +1213,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cos).ToArray();
-            var res = FloatTensor.From(data).Cos();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Cos();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -967,8 +1222,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Tan).ToArray();
-            var res = FloatTensor.From(data).Tan();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Tan();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -976,8 +1231,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Sinh).ToArray();
-            var res = FloatTensor.From(data).Sinh();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Sinh();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -985,8 +1240,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cosh).ToArray();
-            var res = FloatTensor.From(data).Cosh();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Cosh();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -994,8 +1249,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Tanh).ToArray();
-            var res = FloatTensor.From(data).Tanh();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Tanh();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1003,8 +1258,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Asin).ToArray();
-            var res = FloatTensor.From(data).Asin();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Asin();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1012,8 +1267,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Acos).ToArray();
-            var res = FloatTensor.From(data).Acos();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Acos();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1021,8 +1276,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Atan).ToArray();
-            var res = FloatTensor.From(data).Atan();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Atan();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1030,8 +1285,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(x => MathF.Log(x)).ToArray();
-            var res = FloatTensor.From(data).Log();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Log();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1039,8 +1294,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Log10).ToArray();
-            var res = FloatTensor.From(data).Log10();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Log10();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1048,8 +1303,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(MathF.Floor).ToArray();
-            var res = FloatTensor.From(data).Floor();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Floor();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1057,8 +1312,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(MathF.Ceiling).ToArray();
-            var res = FloatTensor.From(data).Ceil();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Ceil();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1066,14 +1321,14 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(x => MathF.Round(x)).ToArray();
-            var res = FloatTensor.From(data).Round();
-            Assert.True(res.AllClose(FloatTensor.From(expected)));
+            var res = Float32Tensor.From(data).Round();
+            Assert.True(res.AllClose(Float32Tensor.From(expected)));
         }
 
         [Fact]
         public void ExpandTest()
         {
-            TorchTensor ones = FloatTensor.Ones(new long[] { 2 });
+            TorchTensor ones = Float32Tensor.Ones(new long[] { 2 });
             TorchTensor onesExpanded = ones.Expand(new long[] { 3, 2 });
 
             Assert.Equal(onesExpanded.Shape, new long[] { 3, 2 });
@@ -1081,7 +1336,7 @@ namespace TorchSharp
             {
                 for (int j = 0; j < 2; j++)
                 {
-                    Assert.Equal(1.0, onesExpanded[i, j].DataItem<float>());
+                    Assert.Equal(1.0, onesExpanded[i, j].ToSingle());
                 }
             }
         }
@@ -1091,17 +1346,17 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res1 = FloatTensor.From(data).TopK(1);
-            var res1_0 = res1.values[0].DataItem<float>();
-            var index1_0 = res1.indexes[0].DataItem<long>();
+            var res1 = Float32Tensor.From(data).TopK(1);
+            var res1_0 = res1.values[0].ToSingle();
+            var index1_0 = res1.indexes[0].ToInt64();
             Assert.Equal(3.1f, res1_0);
             Assert.Equal(2L, index1_0);
 
-            var res2 = FloatTensor.From(data).TopK(2, sorted: true);
-            var res2_0 = res2.values[0].DataItem<float>();
-            var index2_0 = res2.indexes[0].DataItem<long>();
-            var res2_1 = res2.values[1].DataItem<float>();
-            var index2_1 = res2.indexes[1].DataItem<long>();
+            var res2 = Float32Tensor.From(data).TopK(2, sorted: true);
+            var res2_0 = res2.values[0].ToSingle();
+            var index2_0 = res2.indexes[0].ToInt64();
+            var res2_1 = res2.values[1].ToSingle();
+            var index2_1 = res2.indexes[1].ToInt64();
             Assert.Equal(3.1f, res2_0);
             Assert.Equal(2L, index2_0);
             Assert.Equal(2.0f, res2_1);
@@ -1113,25 +1368,25 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
 
-            var res1 = FloatTensor.From(data).Sum();
-            var res1_0 = res1.DataItem<float>();
+            var res1 = Float32Tensor.From(data).Sum();
+            var res1_0 = res1.ToSingle();
             Assert.Equal(6.0f, res1_0);
 
-            var res2 = FloatTensor.From(data).Sum(type: ScalarType.Double);
-            var res2_0 = res2.DataItem<double>();
+            var res2 = Float32Tensor.From(data).Sum(type: ScalarType.Float64);
+            var res2_0 = res2.ToDouble();
             Assert.Equal(6.0, res2_0);
 
             // summing integers gives long unless type is explicitly specified
             var dataInt32 = new int[] { 1, 2, 3 };
-            var res3 = IntTensor.From(dataInt32).Sum();
-            Assert.Equal(ScalarType.Long, res3.Type);
-            var res3_0 = res3.DataItem<long>();
+            var res3 = Int32Tensor.From(dataInt32).Sum();
+            Assert.Equal(ScalarType.Int64, res3.Type);
+            var res3_0 = res3.ToInt64();
             Assert.Equal(6L, res3_0);
 
             // summing integers gives long unless type is explicitly specified
-            var res4 = IntTensor.From(dataInt32).Sum(type: ScalarType.Int);
-            Assert.Equal(ScalarType.Int, res4.Type);
-            var res4_0 = res4.DataItem<int>();
+            var res4 = Int32Tensor.From(dataInt32).Sum(type: ScalarType.Int32);
+            Assert.Equal(ScalarType.Int32, res4.Type);
+            var res4_0 = res4.ToInt32();
             Assert.Equal(6L, res4_0);
 
         }
@@ -1141,14 +1396,14 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = FloatTensor.From(data).Unbind();
+            var res = Float32Tensor.From(data).Unbind();
             Assert.Equal(3, res.Length);
             Assert.Equal(new long[] { }, res[0].Shape);
             Assert.Equal(new long[] { }, res[1].Shape);
             Assert.Equal(new long[] { }, res[2].Shape);
-            Assert.Equal(1.1f, res[0].DataItem<float>());
-            Assert.Equal(2.0f, res[1].DataItem<float>());
-            Assert.Equal(3.1f, res[2].DataItem<float>());
+            Assert.Equal(1.1f, res[0].ToSingle());
+            Assert.Equal(2.0f, res[1].ToSingle());
+            Assert.Equal(3.1f, res[2].ToSingle());
         }
 
         [Fact]
@@ -1156,46 +1411,49 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = FloatTensor.From(data).SplitWithSizes(new long[] { 2, 1 });
+            var res = Float32Tensor.From(data).SplitWithSizes(new long[] { 2, 1 });
             Assert.Equal(2, res.Length);
             Assert.Equal(new long[] { 2 }, res[0].Shape);
             Assert.Equal(new long[] { 1 }, res[1].Shape);
-            Assert.Equal(1.1f, res[0][0].DataItem<float>());
-            Assert.Equal(2.0f, res[0][1].DataItem<float>());
-            Assert.Equal(3.1f, res[1][0].DataItem<float>());
+            Assert.Equal(1.1f, res[0][0].ToSingle());
+            Assert.Equal(2.0f, res[0][1].ToSingle());
+            Assert.Equal(3.1f, res[1][0].ToSingle());
         }
 
         [Fact]
         public void RandomTest()
         {
-            var res = FloatTensor.Random(new long[] { 2 });
+            var res = Float32Tensor.Random(new long[] { 2 });
             Assert.Equal(new long[] { 2 }, res.Shape);
 
-            var res1 = ShortTensor.RandomIntegers(10, new long[] { 200 });
+            var res1 = Int16Tensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res1.Shape);
 
-            var res2 = IntTensor.RandomIntegers(10, new long[] { 200 });
+            var res2 = Int32Tensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res2.Shape);
 
-            var res3 = LongTensor.RandomIntegers(10, new long[] { 200 });
+            var res3 = Int64Tensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res3.Shape);
 
             var res4 = ByteTensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res4.Shape);
 
-            var res5 = SByteTensor.RandomIntegers(10, new long[] { 200 });
+            var res5 = Int8Tensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res5.Shape);
 
-            var res6 = HalfTensor.RandomIntegers(10, new long[] { 200 });
+            var res6 = Float16Tensor.RandomIntegers(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res6.Shape);
 
-            //var res7 = ComplexHalfTensor.RandomIntegers(10, new long[] { 200 });
+            var res7 = BFloat16Tensor.RandomIntegers(10, new long[] { 200 });
+            Assert.Equal(new long[] { 200 }, res7.Shape);
+
+            //var res7 = ComplexFloat16Tensor.RandomIntegers(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res7.Shape);
 
-            //var res8 = ComplexFloatTensor.RandomIntegers(10, new long[] { 200 });
+            //var res8 = ComplexFloat32Tensor.RandomIntegers(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res8.Shape);
 
-            //var res9 = ComplexDoubleTensor.RandomIntegers(10, new long[] { 200 });
+            //var res9 = ComplexFloat64Tensor.RandomIntegers(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res9.Shape);
         }
 
@@ -1204,11 +1462,11 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = FloatTensor.From(data).Expand(new long[] { 1, 1, 3 }).Squeeze(0).Squeeze(0);
+            var res = Float32Tensor.From(data).Expand(new long[] { 1, 1, 3 }).Squeeze(0).Squeeze(0);
             Assert.Equal(new long[] { 3 }, res.Shape);
-            Assert.Equal(1.1f, res[0].DataItem<float>());
-            Assert.Equal(2.0f, res[1].DataItem<float>());
-            Assert.Equal(3.1f, res[2].DataItem<float>());
+            Assert.Equal(1.1f, res[0].ToSingle());
+            Assert.Equal(2.0f, res[1].ToSingle());
+            Assert.Equal(3.1f, res[2].ToSingle());
         }
 
         [Fact]
@@ -1216,10 +1474,10 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = FloatTensor.From(data).Narrow(0, 1, 2);
+            var res = Float32Tensor.From(data).Narrow(0, 1, 2);
             Assert.Equal(new long[] { 2 }, res.Shape);
-            Assert.Equal(2.0f, res[0].DataItem<float>());
-            Assert.Equal(3.1f, res[1].DataItem<float>());
+            Assert.Equal(2.0f, res[0].ToSingle());
+            Assert.Equal(3.1f, res[1].ToSingle());
         }
 
         [Fact]
@@ -1227,17 +1485,17 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f, 4.0f };
 
-            var res = FloatTensor.From(data).Slice(0, 1, 1, 1);
+            var res = Float32Tensor.From(data).Slice(0, 1, 1, 1);
             Assert.Equal(new long[] { 0 }, res.Shape);
 
-            var res2 = FloatTensor.From(data).Slice(0, 1, 2, 1);
+            var res2 = Float32Tensor.From(data).Slice(0, 1, 2, 1);
             Assert.Equal(new long[] { 1 }, res2.Shape);
-            Assert.Equal(2.0f, res2[0].DataItem<float>());
+            Assert.Equal(2.0f, res2[0].ToSingle());
 
-            var res3 = FloatTensor.From(data).Slice(0, 1, 4, 2);
+            var res3 = Float32Tensor.From(data).Slice(0, 1, 4, 2);
             Assert.Equal(new long[] { 2 }, res3.Shape);
-            Assert.Equal(2.0f, res3[0].DataItem<float>());
-            Assert.Equal(4.0f, res3[1].DataItem<float>());
+            Assert.Equal(2.0f, res3[0].ToSingle());
+            Assert.Equal(4.0f, res3[1].ToSingle());
         }
         [Fact]
         public void Conv1DTest()
@@ -1274,8 +1532,8 @@ namespace TorchSharp
             var t2raw = new float[2 * 4 * 3];
             { for (int i = 0; i < 3; i++) for (int j = 0; j < 4; j++) for (int k = 0; k < 5; k++) { t1raw[i * 4 * 5 + j * 5 + k] = t1[i, j, k]; } }
             { for (int i = 0; i < 2; i++) for (int j = 0; j < 4; j++) for (int k = 0; k < 3; k++) { t2raw[i * 4 * 3 + j * 3 + k] = t2[i, j, k]; } }
-            var t1t = FloatTensor.From(t1raw, new long[] { 3, 4, 5 });
-            var t2t = FloatTensor.From(t2raw, new long[] { 2, 4, 3 });
+            var t1t = Float32Tensor.From(t1raw, new long[] { 3, 4, 5 });
+            var t2t = Float32Tensor.From(t2raw, new long[] { 2, 4, 3 });
             var t3t = t1t.Conv1D(t2t);
 
             // Check the answer

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -890,8 +890,8 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float32Tensor.Arange(0, 10, 1, deviceType: deviceType);
-                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType);
+                    var c1 = Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).Expand(new long[] { 10, 10 });
+                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).Expand(new long[] { 10, 10 });
                     var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
                     // scalar-tensor operators
@@ -936,8 +936,8 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float64Tensor.Arange(0, 10, 1, deviceType: deviceType);
-                    var c2 = Float64Tensor.Arange(10, 0, -1, deviceType: deviceType);
+                    var c1 = Float64Tensor.Arange(0, 10, 1, deviceType: deviceType).Expand(new long[] { 10, 10 });
+                    var c2 = Float64Tensor.Arange(10, 0, -1, deviceType: deviceType).Expand(new long[] { 10, 10 });
                     var c3 = Float64Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, double> getFunc = (tt, i, j) => tt[i, j].ToDouble(); 
                     // scalar-tensor operators
@@ -982,8 +982,8 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 =Float32Tensor.Arange(0, 10, 1, deviceType: deviceType);
-                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType);
+                    var c1 =Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).Expand(new long[] { 10, 10 });
+                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).Expand(new long[] { 10, 10 });
                     var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i, j].ToSingle(); 
                     Func<TorchTensor, long, long, bool> getFuncBool = (tt, i, j) => tt[i, j].ToBoolean(); 

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TestUsesLibTorch>true</TestUsesLibTorch>
     <IsPackable>false</IsPackable>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION

Now we've upgraded to LibTorch 1.7.0 we can get further with bfloat16, float16 support

These are only supported on GPU

This also includes some renaming to give better code clarity now these are supported, e.g. `Int64Tensor` instead of `LongTensor`