### PR TITLE
renaming to match SciSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var loss = Losses.MSE(Reduction.Sum);
 
 for (int i = 0; i < 10; i++)
 {
-    var eval = seq.Forward(x);
+    var eval = seq.forward(x);
     var output = loss(eval, y);
     var lossVal = output.ToSingle();
     Console.WriteLine($"loss = {lossVal}");

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ var lin1 = Linear(1000, 100);
 var lin2 = Linear(100, 10);
 var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
 
-var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, deviceIndex: 0, deviceType: DeviceType.CPU);
-var y = Float32Tensor.RandomN(new long[] { 64, 10 }, deviceIndex: 0, deviceType: DeviceType.CPU);
+var x = Float32Tensor.randn(new long[] { 64, 1000 }, deviceIndex: 0, deviceType: DeviceType.CPU);
+var y = Float32Tensor.randn(new long[] { 64, 10 }, deviceIndex: 0, deviceType: DeviceType.CPU);
 
 double learning_rate = 0.00004f;
 float prevLoss = float.MaxValue;
-var optimizer = Optimizer.Adam(seq.GetParameters(), learning_rate);
-var loss = Losses.MSE(Reduction.Sum);
+var optimizer = Optimizer.Adam(seq.parameters(), learning_rate);
+var loss = Losses.mse_loss(Reduction.Sum);
 
 for (int i = 0; i < 10; i++)
 {
@@ -33,11 +33,11 @@ for (int i = 0; i < 10; i++)
     Console.WriteLine($"loss = {lossVal}");
     prevLoss = lossVal;
 
-    optimizer.ZeroGrad();
+    optimizer.zero_grad();
 
-    output.Backward();
+    output.backward();
 
-    optimizer.Step();
+    optimizer.step();
 }
 ```
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,10 @@ name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd
 
 variables: 
   MyRunNumber:  $[counter('MyRunNumber', 52201)]
-  BuildLibTorchPackages: true
+  
+  # Set this to 'true' to build the libtorch-* packages as part of master branch CI and
+  # push them to the artifacts feed of the Azure CI project
+  BuildLibTorchPackages: false
 
 jobs:
 - template: /build/ci/job-template.yml

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <MajorVersion>0</MajorVersion>
-    <MinorVersion>3</MinorVersion>
+    <MajorVersion>1</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -30,15 +30,15 @@ namespace TorchSharp.Examples
             using (var train = Data.Loader.CIFAR10(_dataLocation, _trainBatchSize))
             using (var test = Data.Loader.CIFAR10(_dataLocation, _testBatchSize, false))
             using (var model = new Model("model", _numClasses))
-            using (var optimizer = NN.Optimizer.Adam(model.GetParameters(), 0.001))
+            using (var optimizer = NN.Optimizer.Adam(model.parameters(), 0.001))
             {
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
                 for (var epoch = 1; epoch <= _epochs; epoch++)
                 {
-                    Train(model, optimizer, NLL(), train, epoch, _trainBatchSize, train.Size());
-                    Test(model, NLL(), test, test.Size());
+                    Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size());
+                    Test(model, nll_loss(), test, test.Size());
                 }
 
                 sw.Stop();
@@ -114,14 +114,14 @@ namespace TorchSharp.Examples
 
             foreach (var (data, target) in dataLoader)
             {
-                optimizer.ZeroGrad();
+                optimizer.zero_grad();
 
                 using (var prediction = model.forward(data))
                 using (var output = loss(LogSoftMax(prediction, 1), target))
                 {
                     output.backward();
 
-                    optimizer.Step();
+                    optimizer.step();
 
                     var predicted = prediction.argmax(1);
                     total += target.shape[0];

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -87,13 +87,13 @@ namespace TorchSharp.Examples
                 RegisterModule ("classify", classifier);
             }
 
-            public override TorchTensor Forward(TorchTensor input)
+            public override TorchTensor forward(TorchTensor input)
             {
-                using (var f = features.Forward(input))
-                using (var avg = avgPool.Forward(f))
+                using (var f = features.forward(input))
+                using (var avg = avgPool.forward(f))
 
-                using (var x = avg.View(new long[] { avg.Shape[0], 256 * 2 * 2 }))
-                    return classifier.Forward(x);
+                using (var x = avg.view(new long[] { avg.shape[0], 256 * 2 * 2 }))
+                    return classifier.forward(x);
             }
         }
 
@@ -116,16 +116,16 @@ namespace TorchSharp.Examples
             {
                 optimizer.ZeroGrad();
 
-                using (var prediction = model.Forward(data))
+                using (var prediction = model.forward(data))
                 using (var output = loss(LogSoftMax(prediction, 1), target))
                 {
-                    output.Backward();
+                    output.backward();
 
                     optimizer.Step();
 
-                    var predicted = prediction.Argmax(1);
-                    total += target.Shape[0];
-                    correct += predicted.Eq(target).Sum().ToInt64();
+                    var predicted = prediction.argmax(1);
+                    total += target.shape[0];
+                    correct += predicted.eq(target).sum().ToInt64();
 
                     if (batchId % _logInterval == 0)
                     {
@@ -153,14 +153,14 @@ namespace TorchSharp.Examples
 
             foreach (var (data, target) in dataLoader)
             {
-                using (var prediction = model.Forward(data))
+                using (var prediction = model.forward(data))
                 using (var output = loss(LogSoftMax(prediction, 1), target))
                 {
                     testLoss += output.ToSingle();
 
-                    var pred = prediction.Argmax(1);
+                    var pred = prediction.argmax(1);
 
-                    correct += pred.Eq(target).Sum().ToInt64();
+                    correct += pred.eq(target).sum().ToInt64();
 
                     data.Dispose();
                     target.Dispose();

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -26,15 +26,15 @@ namespace TorchSharp.Examples
             using (var train = Data.Loader.MNIST(_dataLocation, _trainBatchSize))
             using (var test = Data.Loader.MNIST(_dataLocation, _testBatchSize, false))
             using (var model = new Model("model"))
-            using (var optimizer = NN.Optimizer.SGD(model.GetParameters(), 0.01, 0.5))
+            using (var optimizer = NN.Optimizer.SGD(model.parameters(), 0.01, 0.5))
             {
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
                 for (var epoch = 1; epoch <= _epochs; epoch++)
                 {
-                    Train(model, optimizer, NLL(), train, epoch, _trainBatchSize, train.Size());
-                    Test(model, NLL(reduction: NN.Reduction.Sum), test, test.Size());
+                    Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size());
+                    Test(model, nll_loss(reduction: NN.Reduction.Sum), test, test.Size());
                 }
 
                 sw.Stop();
@@ -96,14 +96,14 @@ namespace TorchSharp.Examples
 
             foreach (var (data, target) in dataLoader)
             {
-                optimizer.ZeroGrad();
+                optimizer.zero_grad();
 
                 using (var prediction = model.forward(data))
                 using (var output = loss(prediction, target))
                 {
                     output.backward();
 
-                    optimizer.Step();
+                    optimizer.step();
 
                     if (batchId % _logInterval == 0)
                     {

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -58,24 +58,24 @@ namespace TorchSharp.Examples
                 RegisterModule("lin2", fc2);
             }
 
-            public override TorchTensor Forward(TorchTensor input)
+            public override TorchTensor forward(TorchTensor input)
             {
-                using (var l11 = conv1.Forward(input))
+                using (var l11 = conv1.forward(input))
                 using (var l12 = MaxPool2D (l11, kernelSize: new long[]{ 2 }))
                 using (var l13 = Relu(l12))
 
-                using (var l21 = conv2.Forward(l13))
+                using (var l21 = conv2.forward(l13))
                 using (var l22 = FeatureAlphaDropout(l21))
                 using (var l23 = MaxPool2D (l22, kernelSize: new long[] { 2 }))
                 using (var l24 = Relu(l23))
 
-                using (var x = l24.View(new long[] { -1, 320 }))
+                using (var x = l24.view(new long[] { -1, 320 }))
 
-                using (var l31 = fc1.Forward(x))
+                using (var l31 = fc1.forward(x))
                 using (var l32 = Relu(l31))
                 using (var l33 = Dropout(l32))
 
-                using (var l41 = fc2.Forward(l33))
+                using (var l41 = fc2.forward(l33))
 
                     return LogSoftMax(l41, 1);
             }
@@ -98,10 +98,10 @@ namespace TorchSharp.Examples
             {
                 optimizer.ZeroGrad();
 
-                using (var prediction = model.Forward(data))
+                using (var prediction = model.forward(data))
                 using (var output = loss(prediction, target))
                 {
-                    output.Backward();
+                    output.backward();
 
                     optimizer.Step();
 
@@ -131,14 +131,14 @@ namespace TorchSharp.Examples
 
             foreach (var (data, target) in dataLoader)
             {
-                using (var prediction = model.Forward(data))
+                using (var prediction = model.forward(data))
                 using (var output = loss(prediction, target))
                 {
                     testLoss += output.ToSingle();
 
-                    var pred = prediction.Argmax(1);
+                    var pred = prediction.argmax(1);
 
-                    correct += pred.Eq(target).Sum().ToInt32(); // Memory leak here
+                    correct += pred.eq(target).sum().ToInt32(); // Memory leak here
 
                     data.Dispose();
                     target.Dispose();

--- a/src/Native/LibTorchSharp/THSJIT.h
+++ b/src/Native/LibTorchSharp/THSJIT.h
@@ -55,7 +55,7 @@
 //// Gets the number of device of the input tensor type.
 //EXPORT_API(const char*) THSJIT_getDimensionedTensorDevice(const JITDimensionedTensorType type);
 //
-//// Forward pass over the input module using the input tensor.
+//// forward pass over the input module using the input tensor.
 //EXPORT_API(Tensor) THSJIT_forward(const JITModule module, const Tensor * tensorPtrs, const int length);
 //
 //// Disposes the module.

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -419,7 +419,7 @@ Tensor THSNN_Sequential_forward(const NNModule module, const Tensor tensor)
     CATCH_TENSOR((*module)->as<torch::nn::Sequential>()->forward(*tensor));
 }
 
-void THSNN_Optimizer_zeroGrad(const Optimizer optimizer)
+void THSNN_Optimizer_zero_grad(const Optimizer optimizer)
 {
     (*optimizer)->zero_grad();
 }

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -64,7 +64,7 @@ EXPORT_API(NNModule) THSNN_Sequential_ctor();
 EXPORT_API(void)     THSNN_Sequential_push_back(const NNModule module, const char* name, const NNAnyModule submodule);
 EXPORT_API(Tensor)   THSNN_Sequential_forward(const NNModule module, const Tensor tensor);
 
-EXPORT_API(void) THSNN_Optimizer_zeroGrad(const Optimizer optimizer);
+EXPORT_API(void) THSNN_Optimizer_zero_grad(const Optimizer optimizer);
 EXPORT_API(void) THSNN_Optimizer_getParameters(const Optimizer optimizer, Tensor* (*allocator)(size_t length));
 EXPORT_API(void) THSNN_Optimizer_step(const Optimizer optimizer);
 EXPORT_API(void) THSNN_Optimizer_dispose(const Optimizer optimizer);

--- a/src/TorchSharp/JIT/Module.cs
+++ b/src/TorchSharp/JIT/Module.cs
@@ -143,7 +143,7 @@
 //        [DllImport("LibTorchSharp")]
 //        private static extern IntPtr THSJIT_forward(Module.HType module, IntPtr tensors, int length);
 
-//        public TorchTensor Forward(params TorchTensor[] tensors)
+//        public TorchTensor forward(params TorchTensor[] tensors)
 //        {
 //            var parray = new PinnedArray<IntPtr>();
 //            IntPtr tensorRefs = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());

--- a/src/TorchSharp/NN/AdaptiveAvgPool2D.cs
+++ b/src/TorchSharp/NN/AdaptiveAvgPool2D.cs
@@ -17,7 +17,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_AdaptiveAvgPool2d_forward (IntPtr module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_AdaptiveAvgPool2d_forward (handle.DangerousGetHandle (), tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -46,7 +46,7 @@ namespace TorchSharp.NN
         static public TorchTensor AdaptiveAvgPool2D (TorchTensor x, long[] kernelSize)
         {
             using (var d = Modules.AdaptiveAvgPool2D (kernelSize)) {
-                return d.Forward (x);
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/AvgPool2D.cs
+++ b/src/TorchSharp/NN/AvgPool2D.cs
@@ -17,7 +17,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_AvgPool2d_forward (IntPtr module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_AvgPool2d_forward (handle.DangerousGetHandle (), tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -46,7 +46,7 @@ namespace TorchSharp.NN
         static public TorchTensor AvgPool2D (TorchTensor x, long[] kernelSize, long[] strides = null)
         {
             using (var d = Modules.AvgPool2D (kernelSize, strides)) {
-                return d.Forward (x);
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Conv2D.cs
+++ b/src/TorchSharp/NN/Conv2D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_Conv2d_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_Conv2d_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -36,7 +36,7 @@ namespace TorchSharp.NN
         static public TorchTensor Conv2D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0)
         {
             using (var d = Modules.Conv2D (inputChannel, outputChannel, kernelSize, stride, padding)) {
-                return d.Forward (x);
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Dropout.cs
+++ b/src/TorchSharp/NN/Dropout.cs
@@ -15,7 +15,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_Dropout_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_Dropout_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -40,7 +40,7 @@ namespace TorchSharp.NN
         static public TorchTensor Dropout (TorchTensor x, double probability = 0.5)
         {
             using (var d = Modules.Dropout (probability)) {
-                return d.Forward (x);
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/FeatureDropout.cs
+++ b/src/TorchSharp/NN/FeatureDropout.cs
@@ -17,7 +17,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_FeatureAlphaDropout_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_FeatureAlphaDropout_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -42,7 +42,7 @@ namespace TorchSharp.NN
         static public TorchTensor FeatureAlphaDropout (TorchTensor x, double probability = 0.5)
         {
             using (var f = Modules.FeatureAlphaDropout (probability)) {
-                return f.Forward (x);
+                return f.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Init.cs
+++ b/src/TorchSharp/NN/Init.cs
@@ -31,7 +31,7 @@ namespace TorchSharp.NN
                 throw new ArgumentException("Fan in and fan out can not be computed for tensor with fewer than 2 dimensions");
             }
 
-            var shape = tensor.Shape;
+            var shape = tensor.shape;
             // Linear
             if (dimensions == 2)
             {
@@ -39,8 +39,8 @@ namespace TorchSharp.NN
             }
             else
             {
-                var numInputFMaps = tensor.Shape[1];
-                var numOutputFMaps = tensor.Shape[0];
+                var numInputFMaps = tensor.shape[1];
+                var numOutputFMaps = tensor.shape[0];
                 var receptiveFieldSize = tensor[0, 0].NumberOfElements;
 
                 return (numInputFMaps * receptiveFieldSize, numOutputFMaps * receptiveFieldSize);

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -21,7 +21,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         extern static IntPtr THSNN_Linear_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_Linear_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -77,7 +77,7 @@ namespace TorchSharp.NN
         static public TorchTensor Linear (TorchTensor x, long inputSize, long outputSize, bool hasBias = true)
         {
             using (var d = Modules.Linear (inputSize, outputSize, hasBias)) {
-                return d.Forward (x);
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/LogSoftMax.cs
+++ b/src/TorchSharp/NN/LogSoftMax.cs
@@ -17,7 +17,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_LogSoftMax_forward (Module.HType handle, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_LogSoftMax_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -42,7 +42,7 @@ namespace TorchSharp.NN
         static public TorchTensor LogSoftMax (TorchTensor x, long dimension)
         {
             using (var l = Modules.LogSoftMax (dimension)) {
-                return l.Forward (x);
+                return l.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -18,7 +18,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_binary_cross_entropy (IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
 
-        public static Loss BCE (TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        public static Loss binary_cross_entropy (TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => {
                 var res = THSNN_binary_cross_entropy (src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction);
@@ -30,7 +30,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_mse_loss (IntPtr srct, IntPtr trgt, long reduction);
 
-        public static Loss MSE (Reduction reduction = Reduction.Mean)
+        public static Loss mse_loss (Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => {
                     var res = THSNN_mse_loss (src.Handle, target.Handle, (long)reduction);
@@ -42,7 +42,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_nll_loss (IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
 
-        public static Loss NLL (TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        public static Loss nll_loss (TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => {
                 var res = THSNN_nll_loss (src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction);
@@ -54,7 +54,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_poisson_loss (IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
 
-        public static Loss PoissonNLL (bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
+        public static Loss poisson_loss (bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => {
                 var res = THSNN_poisson_loss (src.Handle, target.Handle, logInput, full, eps, (long)reduction);

--- a/src/TorchSharp/NN/MaxPool2D.cs
+++ b/src/TorchSharp/NN/MaxPool2D.cs
@@ -17,7 +17,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_MaxPool2d_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_MaxPool2d_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -46,7 +46,7 @@ namespace TorchSharp.NN
         static public TorchTensor MaxPool2D (TorchTensor x, long[] kernelSize, long[] strides = null)
         {
             using (var d = Modules.MaxPool2D (kernelSize, strides)) {
-                return d.Forward (x);
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -168,7 +168,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern void THSNN_Module_get_parameters (HType module, AllocatePinnedArray allocator);
 
-        public virtual TorchTensor[] GetParameters ()
+        public virtual TorchTensor[] parameters ()
         {
             IntPtr[] ptrArray;
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -338,7 +338,7 @@ namespace TorchSharp.NN
             var pparray = paramsPinned.CreateArray (@params);
             var gparray = wGradPinned.CreateArray (withGrads);
 
-            ForwardFunctionC forwardNative = t => (Forward (new TorchTensor (t)).Handle);
+            ForwardFunctionC forwardNative = t => (forward (new TorchTensor (t)).Handle);
             var res = THSNN_custom_module (name, nparray, pparray, gparray, names.Length, forwardNative, out var boxedHandle);
             Torch.CheckForErrors ();
             this.handle = new HType (res, true);
@@ -349,6 +349,6 @@ namespace TorchSharp.NN
         /// Keeps the callback delegate alive
         private ForwardFunctionC forwardNative;
 
-        abstract public TorchTensor Forward (TorchTensor t);
+        abstract public TorchTensor forward (TorchTensor t);
     }
 }

--- a/src/TorchSharp/NN/Optimizer.cs
+++ b/src/TorchSharp/NN/Optimizer.cs
@@ -105,18 +105,18 @@ namespace TorchSharp.NN
         }
 
         [DllImport ("LibTorchSharp")]
-        private static extern void THSNN_Optimizer_zeroGrad (HType module);
+        private static extern void THSNN_Optimizer_zero_grad (HType module);
 
-        public void ZeroGrad ()
+        public void zero_grad ()
         {
-            THSNN_Optimizer_zeroGrad (handle);
+            THSNN_Optimizer_zero_grad (handle);
             Torch.CheckForErrors ();
         }
 
         [DllImport ("LibTorchSharp")]
         private static extern void THSNN_Optimizer_step (HType module);
 
-        public void Step ()
+        public void step ()
         {
             THSNN_Optimizer_step (handle);
             Torch.CheckForErrors ();
@@ -125,7 +125,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern void THSNN_Optimizer_getParameters (HType module, AllocatePinnedArray allocator);
 
-        public IEnumerable<TorchTensor> GetParameters ()
+        public IEnumerable<TorchTensor> parameters ()
         {
             IntPtr[] ptrArray;
 

--- a/src/TorchSharp/NN/Parameter.cs
+++ b/src/TorchSharp/NN/Parameter.cs
@@ -13,7 +13,7 @@ namespace TorchSharp.NN
         {
             Name = name;
             Tensor = parameter;
-            WithGrad = withGrad ?? parameter.IsGradRequired;
+            WithGrad = withGrad ?? parameter.requires_grad;
         }
     };
 }

--- a/src/TorchSharp/NN/ReLu.cs
+++ b/src/TorchSharp/NN/ReLu.cs
@@ -15,7 +15,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_ReLU_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_ReLU_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -45,7 +45,7 @@ namespace TorchSharp.NN
         static public TorchTensor Relu (TorchTensor x, bool inPlace = false)
         {
             using (var m = Modules.Relu (inPlace)) {
-                return m.Forward (x);
+                return m.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_Sequential_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor Forward (TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
             var res = THSNN_Sequential_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -5063,39 +5063,39 @@ namespace TorchSharp.Tensor
             {
                 case bool _ when typeof(T) == typeof(byte):
                     {
-                        return ByteTensor.From(array as byte[], dimensions, requiresGrad); ;
+                        return ByteTensor.from(array as byte[], dimensions, requiresGrad); ;
                     }
                 case bool _ when typeof(T) == typeof(sbyte):
                     {
-                        return Int8Tensor.From(array as sbyte[], dimensions, requiresGrad); ;
+                        return Int8Tensor.from(array as sbyte[], dimensions, requiresGrad); ;
                     }
                 case bool _ when typeof(T) == typeof(short):
                     {
-                        return Int16Tensor.From(array as short[], dimensions, requiresGrad); ;
+                        return Int16Tensor.from(array as short[], dimensions, requiresGrad); ;
                     }
                 case bool _ when typeof(T) == typeof(int):
                     {
-                        return Int32Tensor.From(array as int[], dimensions, requiresGrad);
+                        return Int32Tensor.from(array as int[], dimensions, requiresGrad);
                     }
                 case bool _ when typeof(T) == typeof(long):
                     {
-                        return Int64Tensor.From(array as long[], dimensions, requiresGrad);
+                        return Int64Tensor.from(array as long[], dimensions, requiresGrad);
                     }
                 case bool _ when typeof(T) == typeof(double):
                     {
-                        return Float64Tensor.From(array as double[], dimensions, requiresGrad);
+                        return Float64Tensor.from(array as double[], dimensions, requiresGrad);
                     }
                 case bool _ when typeof(T) == typeof(float):
                     {
-                        return Float32Tensor.From(array as float[], dimensions, requiresGrad);
+                        return Float32Tensor.from(array as float[], dimensions, requiresGrad);
                     }
                 case bool _ when typeof(T) == typeof(bool):
                     {
-                        return BoolTensor.From(array as bool[], dimensions, requiresGrad);
+                        return BoolTensor.from(array as bool[], dimensions, requiresGrad);
                     }
                 //case bool _ when typeof(T) == typeof(System.Numerics.Complex):
                 //    {
-                //        return ComplexFloat64Tensor.From(array as System.Numerics.Complex[], dimensions, requiresGrad);
+                //        return ComplexFloat64Tensor.from(array as System.Numerics.Complex[], dimensions, requiresGrad);
                 //    }
                 default: throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
             }
@@ -5109,19 +5109,19 @@ namespace TorchSharp.Tensor
             }
 
             if (typeof(T) == typeof(byte))
-                return ByteTensor.From((byte)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return ByteTensor.from((byte)(object)scalar, deviceType, deviceIndex, requiresGrad);
             if (typeof(T) == typeof(sbyte))
-                return Int8Tensor.From((sbyte)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return Int8Tensor.from((sbyte)(object)scalar, deviceType, deviceIndex, requiresGrad);
             if (typeof(T) == typeof(short))
-                return Int16Tensor.From((short)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return Int16Tensor.from((short)(object)scalar, deviceType, deviceIndex, requiresGrad);
             if (typeof(T) == typeof(int))
-                return Int32Tensor.From((int)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return Int32Tensor.from((int)(object)scalar, deviceType, deviceIndex, requiresGrad);
             if (typeof(T) == typeof(long))
-                return Int64Tensor.From((long)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return Int64Tensor.from((long)(object)scalar, deviceType, deviceIndex, requiresGrad);
             if (typeof(T) == typeof(double))
-                return Float64Tensor.From((double)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return Float64Tensor.from((double)(object)scalar, deviceType, deviceIndex, requiresGrad);
             if (typeof(T) == typeof(float))
-                return Float32Tensor.From((float)(object)scalar, deviceType, deviceIndex, requiresGrad);
+                return Float32Tensor.from((float)(object)scalar, deviceType, deviceIndex, requiresGrad);
             throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
         }
 

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -48,12 +48,21 @@ namespace TorchSharp.Tensor
             this.handle = handle;
         }
 
+        /// <summary>
+        ///  TBD
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public override bool Equals(object? obj)
         {
-            return (obj is TorchTensor) && this.Equal((obj as TorchTensor)!);
+            return (obj is TorchTensor) && this.Equals((obj as TorchTensor)!);
 
         }
 
+        /// <summary>
+        ///  TBD
+        /// </summary>
+        /// <returns></returns>
         public override int GetHashCode()
         {
             return base.GetHashCode();
@@ -84,10 +93,13 @@ namespace TorchSharp.Tensor
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
         public IntPtr Handle => handle;
 
         [DllImport("LibTorchSharp")]
-        private static extern long THSTensor_ndimension(IntPtr handle);
+        static extern long THSTensor_ndimension(IntPtr handle);
 
         /// <summary>
         ///  Returns the number of dimensions for this tensor
@@ -95,10 +107,10 @@ namespace TorchSharp.Tensor
         public long Dimensions => THSTensor_ndimension(handle);
 
         [DllImport("LibTorchSharp")]
-        private static extern long THSTensor_element_size(IntPtr handle);
+        static extern long THSTensor_element_size(IntPtr handle);
 
         [DllImport("LibTorchSharp")]
-        private static extern long THSTensor_numel(IntPtr handle);
+        static extern long THSTensor_numel(IntPtr handle);
 
         /// <summary>
         ///  Get the number of elements in the tensor.
@@ -111,7 +123,7 @@ namespace TorchSharp.Tensor
         public long ElementSize => THSTensor_element_size(handle);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_data(IntPtr handle);
+        static extern IntPtr THSTensor_data(IntPtr handle);
 
         /// <summary>
         ///  Returns a pointer to the unmanaged data managed by this tensor.
@@ -131,6 +143,11 @@ namespace TorchSharp.Tensor
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         public T DataItem<T>()
         {
             if (NumberOfElements != 1) throw new ArgumentException("Number of elements in the tensor must be 1");
@@ -138,18 +155,70 @@ namespace TorchSharp.Tensor
             return Data<T>()[0];
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public double ReadCpuDouble(long i) => Data<double>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public float ReadCpuSingle(long i) => Data<float>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public int ReadCpuInt32(long i) => Data<int>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public long ReadCpuInt64(long i) => Data<long>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public byte ReadCpuByte(long i) => Data<byte>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public sbyte ReadCpuSByte(long i) => Data<sbyte>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public short ReadCpuInt16(long i) => Data<short>()[(int)i];
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public bool ReadCpuBool(long i) => Data<bool>()[(int)i];
 
         [DllImport("LibTorchSharp")]
-        private static extern float THSTensor_data_idx_float16(IntPtr handle, long i);
+        static extern float THSTensor_data_idx_float16(IntPtr handle, long i);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public float ReadCpuFloat16(long i)
         {
             if (i >= NumberOfElements) {
@@ -159,8 +228,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern float THSTensor_data_idx_bfloat16(IntPtr handle, long i);
+        static extern float THSTensor_data_idx_bfloat16(IntPtr handle, long i);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
         public float ReadCpuBFloat16(long i)
         {
             if (i >= NumberOfElements) {
@@ -170,8 +244,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_item(IntPtr handle);
+        static extern IntPtr THSTensor_item(IntPtr handle);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public TorchScalar ToScalar()
         {
             var res = THSTensor_item(Handle);
@@ -180,9 +258,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_fill_(IntPtr handle, IntPtr value);
+        static extern IntPtr THSTensor_fill_(IntPtr handle, IntPtr value);
 
-        public TorchTensor FillInPlace(TorchScalar value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor fill_(TorchScalar value)
         {
             var res = THSTensor_fill_(handle, value.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -190,11 +273,16 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_get1(IntPtr handle, long i1);
+        static extern IntPtr THSTensor_get1(IntPtr handle, long i1);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set1(IntPtr handle, long i1, IntPtr value);
+        static extern IntPtr THSTensor_set1(IntPtr handle, long i1, IntPtr value);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i1"></param>
+        /// <returns></returns>
         [IndexerName("TensorItems")]
         public TorchTensor this[long i1]
         {
@@ -212,11 +300,17 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_get2(IntPtr handle, long i1, long i2);
+        static extern IntPtr THSTensor_get2(IntPtr handle, long i1, long i2);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set2(IntPtr handle, long i1, long i2, IntPtr value);
+        static extern IntPtr THSTensor_set2(IntPtr handle, long i1, long i2, IntPtr value);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i1"></param>
+        /// <param name="i2"></param>
+        /// <returns></returns>
         [IndexerName("TensorItems")]
         public TorchTensor this[long i1, long i2]
         {
@@ -234,11 +328,18 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_get3(IntPtr handle, long i1, long i2, long i3);
+        static extern IntPtr THSTensor_get3(IntPtr handle, long i1, long i2, long i3);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set3(IntPtr handle, long i1, long i2, long i3, IntPtr value);
+        static extern IntPtr THSTensor_set3(IntPtr handle, long i1, long i2, long i3, IntPtr value);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i1"></param>
+        /// <param name="i2"></param>
+        /// <param name="i3"></param>
+        /// <returns></returns>
         [IndexerName("TensorItems")]
         public TorchTensor this[long i1, long i2, long i3]
         {
@@ -257,11 +358,19 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_get4(IntPtr handle, long i1, long i2, long i3, long i4);
+        static extern IntPtr THSTensor_get4(IntPtr handle, long i1, long i2, long i3, long i4);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set4(IntPtr handle, long i1, long i2, long i3, long i4, IntPtr value);
+        static extern IntPtr THSTensor_set4(IntPtr handle, long i1, long i2, long i3, long i4, IntPtr value);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i1"></param>
+        /// <param name="i2"></param>
+        /// <param name="i3"></param>
+        /// <param name="i4"></param>
+        /// <returns></returns>
         [IndexerName("TensorItems")]
         public TorchTensor this[long i1, long i2, long i3, long i4]
         {
@@ -280,11 +389,20 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_get5(IntPtr handle, long i1, long i2, long i3, long i4, long i5);
+        static extern IntPtr THSTensor_get5(IntPtr handle, long i1, long i2, long i3, long i4, long i5);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
+        static extern IntPtr THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i1"></param>
+        /// <param name="i2"></param>
+        /// <param name="i3"></param>
+        /// <param name="i4"></param>
+        /// <param name="i5"></param>
+        /// <returns></returns>
         [IndexerName("TensorItems")]
         public TorchTensor this[long i1, long i2, long i3, long i4, long i5] {
             get {
@@ -301,11 +419,21 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_get6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6);
+        static extern IntPtr THSTensor_get6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
+        static extern IntPtr THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="i1"></param>
+        /// <param name="i2"></param>
+        /// <param name="i3"></param>
+        /// <param name="i4"></param>
+        /// <param name="i5"></param>
+        /// <param name="i6"></param>
+        /// <returns></returns>
         [IndexerName("TensorItems")]
         public TorchTensor this[long i1, long i2, long i3, long i4, long i5, long i6] {
             get {
@@ -320,15 +448,21 @@ namespace TorchSharp.Tensor
             }
         }
         [DllImport("LibTorchSharp")]
-        private static extern sbyte THSTensor_type(IntPtr handle);
+        static extern sbyte THSTensor_type(IntPtr handle);
 
+        /// <summary>
+        /// 
+        /// </summary>
         public ScalarType Type => (ScalarType)THSTensor_type(handle);
 
         [DllImport("LibTorchSharp")]
         [return: MarshalAs(UnmanagedType.LPStr)]
-        private static extern string THSTensor_device_str(IntPtr handle);
+        static extern string THSTensor_device_str(IntPtr handle);
 
-        public string DeviceString
+        /// <summary>
+        /// 
+        /// </summary>
+        public string device
         {
             get
             {
@@ -341,9 +475,12 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern int THSTensor_device_index(IntPtr handle);
+        static extern int THSTensor_device_index(IntPtr handle);
 
-        public int DeviceIndex {
+        /// <summary>
+        /// 
+        /// </summary>
+        public int device_index {
             get {
                 var res = THSTensor_device_index(handle);
                 Torch.CheckForErrors();
@@ -353,9 +490,12 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern int THSTensor_device_type(IntPtr handle);
+        static extern int THSTensor_device_type(IntPtr handle);
 
-        public DeviceType DeviceType {
+        /// <summary>
+        /// 
+        /// </summary>
+        public DeviceType device_type {
             get {
                 var res = THSTensor_device_type(handle);
                 Torch.CheckForErrors();
@@ -365,8 +505,11 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern bool THSTensor_is_sparse(IntPtr handle);
+        static extern bool THSTensor_is_sparse(IntPtr handle);
 
+        /// <summary>
+        /// 
+        /// </summary>
         public bool IsSparse
         {
             get
@@ -378,9 +521,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type);
+        static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type);
 
-        public TorchTensor ToType(ScalarType type)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public TorchTensor to_type(ScalarType type)
         {
             var res = THSTensor_to_type(handle, (sbyte)type);
             if (res == IntPtr.Zero)
@@ -389,9 +537,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_load([MarshalAs(UnmanagedType.LPStr)] string location);
+        static extern IntPtr THSTensor_load([MarshalAs(UnmanagedType.LPStr)] string location);
 
-        public static TorchTensor Load(string location)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="location"></param>
+        /// <returns></returns>
+        public static TorchTensor load(string location)
         {
             var res = THSTensor_load(location);
             if (res == IntPtr.Zero)
@@ -400,34 +553,53 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_save(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string location);
+        static extern IntPtr THSTensor_save(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string location);
 
-        public void Save(string location)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="location"></param>
+        public void save(string location)
         {
             THSTensor_save(handle, location);
             Torch.CheckForErrors();
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern bool THSTensor_requires_grad(IntPtr handle);
-
-        public bool IsGradRequired => THSTensor_requires_grad(handle);
+        static extern bool THSTensor_requires_grad(IntPtr handle);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_set_requires_grad(IntPtr handle, bool requires_grad);
+        static extern IntPtr THSTensor_set_requires_grad(IntPtr handle, bool requires_grad);
 
-        public TorchTensor RequiresGrad(bool requiresGrad)
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool requires_grad {
+            get { return THSTensor_requires_grad(handle); }
+            set {
+                var res = THSTensor_set_requires_grad(handle, value);
+                if (res == IntPtr.Zero)
+                    Torch.CheckForErrors();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TorchTensor with_requires_grad()
         {
-            var res = THSTensor_set_requires_grad(handle, requiresGrad);
-            if (res == IntPtr.Zero)
-                Torch.CheckForErrors();
-            return new TorchTensor(res);
+            this.requires_grad = true;
+            return this;
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cpu(IntPtr handle);
+        static extern IntPtr THSTensor_cpu(IntPtr handle);
 
-        public TorchTensor Cpu()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor cpu()
         {
             var res = THSTensor_cpu(handle);
             if (res == IntPtr.Zero)
@@ -436,9 +608,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cuda(IntPtr handle);
+        static extern IntPtr THSTensor_cuda(IntPtr handle);
 
-        public TorchTensor Cuda()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor cuda()
         {
             Torch.InitializeDeviceType(DeviceType.CUDA);
             var res = THSTensor_cuda(handle);
@@ -448,9 +624,15 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_to_device(IntPtr handle, int device_type, int device_index);
+        static extern IntPtr THSTensor_to_device(IntPtr handle, int device_type, int device_index);
 
-        public TorchTensor ToDevice(DeviceType deviceType, int deviceIndex = 0)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="deviceType"></param>
+        /// <param name="deviceIndex"></param>
+        /// <returns></returns>
+        public TorchTensor to_device(DeviceType deviceType, int deviceIndex = 0)
         {
             Torch.InitializeDeviceType(deviceType);
             var res = THSTensor_to_device(handle, (int)deviceType, deviceIndex);
@@ -460,12 +642,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern long THSTensor_size(IntPtr handle, long dimension);
+        static extern long THSTensor_size(IntPtr handle, long dimension);
 
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
-        public long GetTensorDimension(int dim)
+        /// <param name="dim"></param>
+        /// <returns></returns>
+        public long size(int dim)
         {
             var res = THSTensor_size(handle, dim);
             Torch.CheckForErrors();
@@ -480,21 +664,24 @@ namespace TorchSharp.Tensor
         ///     for single-dimension arrays, where the dimension is the value of the
         ///     first element.   And so on.
         /// </remarks>
-        public long[] Shape
+        public long[] shape
         {
             get
             {
                 var dims = new long[Dimensions];
                 for (var i = 0; i < dims.Length; i++)
-                    dims[i] = GetTensorDimension(i);
+                    dims[i] = size(i);
 
                 return dims;
             }
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_indices(IntPtr handle);
+        static extern IntPtr THSTensor_indices(IntPtr handle);
 
+        /// <summary>
+        /// 
+        /// </summary>
         public TorchTensor SparseIndices {
             get {
                 var res = THSTensor_indices(handle);
@@ -505,8 +692,11 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_values(IntPtr handle);
+        static extern IntPtr THSTensor_values(IntPtr handle);
 
+        /// <summary>
+        /// 
+        /// </summary>
         public TorchTensor SparseValues {
             get {
                 var res = THSTensor_values(handle);
@@ -517,7 +707,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern long THSTensor_stride(IntPtr handle, long dimension);
+        static extern long THSTensor_stride(IntPtr handle, long dimension);
 
         /// <summary>
         ///  Retrieves the stride of the specified dimension in the tensor.
@@ -530,18 +720,25 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_backward(IntPtr handle);
+        static extern void THSTensor_backward(IntPtr handle);
 
-        public void Backward()
+        /// <summary>
+        /// 
+        /// </summary>
+        public void backward()
         {
             THSTensor_backward(handle);
             Torch.CheckForErrors();
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_to_dense(IntPtr handle);
+        static extern IntPtr THSTensor_to_dense(IntPtr handle);
 
-        public TorchTensor ToDense()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor to_dense()
         {
             var res = THSTensor_to_dense(handle);
             if (res == IntPtr.Zero)
@@ -552,7 +749,11 @@ namespace TorchSharp.Tensor
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_clone(IntPtr handle);
 
-        public TorchTensor Clone()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor clone()
         {
             var res = THSTensor_clone(handle);
             if (res == IntPtr.Zero)
@@ -563,7 +764,11 @@ namespace TorchSharp.Tensor
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_contiguous(IntPtr handle);
 
-        public TorchTensor Contiguous()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor contiguous()
         {
             var res = THSTensor_contiguous(handle);
             if (res == IntPtr.Zero)
@@ -572,9 +777,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_grad(IntPtr handle);
+        static extern IntPtr THSTensor_grad(IntPtr handle);
 
-        public TorchTensor Grad()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor grad()
         {
             var res = THSTensor_grad(handle);
             if (res == IntPtr.Zero)
@@ -583,13 +792,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_index(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength);
+        static extern IntPtr THSTensor_index(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_index_put_scalar_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
+        static extern IntPtr THSTensor_index_put_scalar_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_index_put_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
+        static extern IntPtr THSTensor_index_put_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
         internal void EncodeIndices(TorchTensorIndex[] indices,
             out long[] arrKindAndStarts,
             out long[]? arrStops,
@@ -635,7 +844,12 @@ namespace TorchSharp.Tensor
 
         }
 
-        public TorchTensor Index(TorchTensorIndex[] indices)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="indices"></param>
+        /// <returns></returns>
+        public TorchTensor index(TorchTensorIndex[] indices)
         {
             EncodeIndices(indices, out var arrKindAndStarts, out var arrStops, out var arrSteps, out var arrTensors);
             unsafe {
@@ -652,7 +866,13 @@ namespace TorchSharp.Tensor
 
         }
 
-        public TorchTensor SetIndex(TorchTensorIndex[] indices, TorchTensor value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="indices"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor index_put_(TorchTensorIndex[] indices, TorchTensor value)
         {
             EncodeIndices(indices, out var arrKindAndStarts, out var arrStops, out var arrSteps, out var arrTensors);
             unsafe {
@@ -669,7 +889,13 @@ namespace TorchSharp.Tensor
             }
         }
 
-        public TorchTensor SetIndex(TorchTensorIndex[] indices, TorchScalar value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="indices"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor index_put_(TorchTensorIndex[] indices, TorchScalar value)
         {
             EncodeIndices(indices, out var arrKindAndStarts, out var arrStops, out var arrSteps, out var arrTensors);
             unsafe {
@@ -686,9 +912,15 @@ namespace TorchSharp.Tensor
             }
         }
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_index_select(IntPtr tensor, long dimension, IntPtr index);
+        static extern IntPtr THSTensor_index_select(IntPtr tensor, long dimension, IntPtr index);
 
-        public TorchTensor IndexSelect(long dimension, TorchTensor index)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public TorchTensor index_select(long dimension, TorchTensor index)
         {
             var res = THSTensor_index_select(handle, dimension, index.Handle);
             if (res == IntPtr.Zero)
@@ -697,9 +929,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_reshape(IntPtr tensor, IntPtr shape, int length);
+        static extern IntPtr THSTensor_reshape(IntPtr tensor, IntPtr shape, int length);
 
-        public TorchTensor Reshape(params long[] shape)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="shape"></param>
+        /// <returns></returns>
+        public TorchTensor reshape(params long[] shape)
         {
             unsafe
             {
@@ -714,9 +951,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_squeeze(IntPtr tensor, long dimension);
+        static extern IntPtr THSTensor_squeeze(IntPtr tensor, long dimension);
 
-        public TorchTensor Squeeze(long dimension)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension"></param>
+        /// <returns></returns>
+        public TorchTensor squeeze(long dimension)
         {
             var res = THSTensor_squeeze(handle, dimension);
             if (res == IntPtr.Zero)
@@ -725,9 +967,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_t(IntPtr tensor);
+        static extern IntPtr THSTensor_t(IntPtr tensor);
 
-        public TorchTensor T()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor t()
         {
             var res = THSTensor_t(handle);
             if (res == IntPtr.Zero)
@@ -736,9 +982,15 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_transpose(IntPtr tensor, long dim1, long dim2);
+        static extern IntPtr THSTensor_transpose(IntPtr tensor, long dim1, long dim2);
 
-        public TorchTensor Transpose(long dimension1, long dimension2)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension1"></param>
+        /// <param name="dimension2"></param>
+        /// <returns></returns>
+        public TorchTensor transpose(long dimension1, long dimension2)
         {
             var res = THSTensor_transpose(handle, dimension1, dimension2);
             if (res == IntPtr.Zero)
@@ -747,17 +999,28 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_transpose_(IntPtr tensor, long dim1, long dim2);
+        static extern IntPtr THSTensor_transpose_(IntPtr tensor, long dim1, long dim2);
 
-        public TorchTensor TransposeInPlace(long dimension1, long dimension2)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension1"></param>
+        /// <param name="dimension2"></param>
+        /// <returns></returns>
+        public TorchTensor transpose_(long dimension1, long dimension2)
         {
             return new TorchTensor(THSTensor_transpose_(handle, dimension1, dimension2));
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_view(IntPtr tensor, IntPtr shape, int length);
+        static extern IntPtr THSTensor_view(IntPtr tensor, IntPtr shape, int length);
 
-        public TorchTensor View(params long[] shape)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="shape"></param>
+        /// <returns></returns>
+        public TorchTensor view(params long[] shape)
         {
             unsafe
             {
@@ -772,14 +1035,25 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_add(IntPtr tensor, IntPtr trg, IntPtr alpha);
+        static extern IntPtr THSTensor_add(IntPtr tensor, IntPtr trg, IntPtr alpha);
 
-        public TorchTensor Add(TorchTensor target)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public TorchTensor add(TorchTensor target)
         {
-            return Add(target, 1);
+            return add(target, 1);
         }
 
-        public TorchTensor Add(TorchTensor target, TorchScalar alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor add(TorchTensor target, TorchScalar alpha)
         {
             var res = THSTensor_add(handle, target.Handle, alpha.Handle);
             if (res == IntPtr.Zero)
@@ -789,39 +1063,72 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_add_scalar(IntPtr tensor, IntPtr trg, IntPtr alpha);
+        static extern IntPtr THSTensor_add_scalar(IntPtr tensor, IntPtr trg, IntPtr alpha);
 
-        public TorchTensor Add(TorchScalar scalar)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="scalar"></param>
+        /// <returns></returns>
+        public TorchTensor add(TorchScalar scalar)
         {
-            return Add(scalar, 1);
+            return add(scalar, 1);
         }
-        public TorchTensor Add(TorchScalar scalar, TorchScalar alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="scalar"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor add(TorchScalar scalar, TorchScalar alpha)
         {
             return new TorchTensor(THSTensor_add_scalar(handle, scalar.Handle, alpha.Handle));
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_add_(IntPtr tensor, IntPtr trg, IntPtr alpha);
+        static extern IntPtr THSTensor_add_(IntPtr tensor, IntPtr trg, IntPtr alpha);
 
-        public TorchTensor AddInPlace(TorchTensor target)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public TorchTensor add_(TorchTensor target)
         {
-            return AddInPlace(target, 1);
+            return add_(target, 1);
         }
 
-        public TorchTensor AddInPlace(TorchTensor target, TorchScalar alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor add_(TorchTensor target, TorchScalar alpha)
         {
             return new TorchTensor(THSTensor_add_(handle, target.Handle, alpha.Handle));
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_add_scalar_(IntPtr tensor, IntPtr trg, IntPtr alpha);
+        static extern IntPtr THSTensor_add_scalar_(IntPtr tensor, IntPtr trg, IntPtr alpha);
 
-        public TorchTensor AddInPlace(TorchScalar scalar)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="scalar"></param>
+        /// <returns></returns>
+        public TorchTensor add_(TorchScalar scalar)
         {
-            return AddInPlace(scalar, 1);
+            return add_(scalar, 1);
         }
 
-        public TorchTensor AddInPlace(TorchScalar scalar, TorchScalar alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="scalar"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor add_(TorchScalar scalar, TorchScalar alpha)
         {
             var res = THSTensor_add_scalar_(handle, scalar.Handle, alpha.Handle);
             if (res == IntPtr.Zero)
@@ -830,9 +1137,17 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addbmm(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
+        static extern IntPtr THSTensor_addbmm(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
 
-        public TorchTensor Addbmm(TorchTensor batch1, TorchTensor batch2, float beta = 1, float alpha = 1)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="batch1"></param>
+        /// <param name="batch2"></param>
+        /// <param name="beta"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor addbmm(TorchTensor batch1, TorchTensor batch2, float beta = 1, float alpha = 1)
         {
             var res = THSTensor_addbmm(handle, batch1.Handle, batch2.Handle, beta, alpha);
             if (res == IntPtr.Zero)
@@ -841,9 +1156,17 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addbmm_(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
+        static extern IntPtr THSTensor_addbmm_(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
 
-        public TorchTensor AddbmmInPlace(TorchTensor batch1, TorchTensor batch2, float beta = 1, float alpha = 1)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="batch1"></param>
+        /// <param name="batch2"></param>
+        /// <param name="beta"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor addbmm_(TorchTensor batch1, TorchTensor batch2, float beta = 1, float alpha = 1)
         {
             var res = THSTensor_addbmm_(handle, batch1.Handle, batch2.Handle, beta, alpha);
             if (res == IntPtr.Zero)
@@ -852,9 +1175,16 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addcdiv(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+        static extern IntPtr THSTensor_addcdiv(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
 
-        public TorchTensor Addcdiv(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="tensor1"></param>
+        /// <param name="tensor2"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor addcdiv(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
         {
             var res = THSTensor_addcdiv(handle, tensor1.Handle, tensor2.Handle, value.Handle);
             if (res == IntPtr.Zero)
@@ -863,9 +1193,16 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addcdiv_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+        static extern IntPtr THSTensor_addcdiv_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
 
-        public TorchTensor AddcdivInPlace(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="tensor1"></param>
+        /// <param name="tensor2"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor addcdiv_(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
         {
             var res = THSTensor_addcdiv_(handle, tensor1.Handle, tensor2.Handle, value.Handle);
             if (res == IntPtr.Zero)
@@ -874,9 +1211,16 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addcmul(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+        static extern IntPtr THSTensor_addcmul(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
 
-        public TorchTensor Addcmul(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="tensor1"></param>
+        /// <param name="tensor2"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor addcmul(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
         {
             var res = THSTensor_addcmul(handle, tensor1.Handle, tensor2.Handle, value.Handle);
             if (res == IntPtr.Zero)
@@ -885,9 +1229,16 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addcmul_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+        static extern IntPtr THSTensor_addcmul_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
 
-        public TorchTensor AddcmulInPlace(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="tensor1"></param>
+        /// <param name="tensor2"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public TorchTensor addcmul_(TorchTensor tensor1, TorchTensor tensor2, TorchScalar value)
         {
             var res = THSTensor_addcmul_(handle, tensor1.Handle, tensor2.Handle, value.Handle);
             if (res == IntPtr.Zero)
@@ -897,9 +1248,17 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addmm(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
+        static extern IntPtr THSTensor_addmm(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
 
-        public TorchTensor Addmm(TorchTensor mat1, TorchTensor mat2, float beta, float alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mat1"></param>
+        /// <param name="mat2"></param>
+        /// <param name="beta"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor addmm(TorchTensor mat1, TorchTensor mat2, float beta, float alpha)
         {
             var res = THSTensor_addmm(handle, mat1.Handle, mat2.Handle, beta, alpha);
             if (res == IntPtr.Zero)
@@ -908,9 +1267,17 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addmm_(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
+        static extern IntPtr THSTensor_addmm_(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
 
-        public TorchTensor AddmmInPlace(TorchTensor mat1, TorchTensor mat2, float beta, float alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mat1"></param>
+        /// <param name="mat2"></param>
+        /// <param name="beta"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor addmm_(TorchTensor mat1, TorchTensor mat2, float beta, float alpha)
         {
             var res = THSTensor_addmm_(handle, mat1.Handle, mat2.Handle, beta, alpha);
             if (res == IntPtr.Zero)
@@ -919,9 +1286,17 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addmv(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
+        static extern IntPtr THSTensor_addmv(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
 
-        public TorchTensor Addmv(TorchTensor mat1, TorchTensor vec2, float beta, float alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mat1"></param>
+        /// <param name="vec2"></param>
+        /// <param name="beta"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor addmv(TorchTensor mat1, TorchTensor vec2, float beta, float alpha)
         {
             var res = THSTensor_addmv(handle, mat1.Handle, vec2.Handle, beta, alpha);
             if (res == IntPtr.Zero)
@@ -930,9 +1305,17 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_addmv_(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
+        static extern IntPtr THSTensor_addmv_(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
 
-        public TorchTensor AddmvInPlace(TorchTensor mat1, TorchTensor vec2, float beta, float alpha)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mat1"></param>
+        /// <param name="vec2"></param>
+        /// <param name="beta"></param>
+        /// <param name="alpha"></param>
+        /// <returns></returns>
+        public TorchTensor addmv_(TorchTensor mat1, TorchTensor vec2, float beta, float alpha)
         {
             var res = THSTensor_addmv_(handle, mat1.Handle, vec2.Handle, beta, alpha);
             if (res == IntPtr.Zero)
@@ -941,9 +1324,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_all(IntPtr tensor);
+        static extern IntPtr THSTensor_all(IntPtr tensor);
 
-        public TorchTensor All()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor all()
         {
             var res = THSTensor_all(handle);
             if (res == IntPtr.Zero)
@@ -952,9 +1339,15 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+        static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
 
-        public TorchTensor All(long dimension, bool keepDim = false)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension"></param>
+        /// <param name="keepDim"></param>
+        /// <returns></returns>
+        public TorchTensor all(long dimension, bool keepDim = false)
         {
             var res = THSTensor_all_along_dimension(handle, dimension, keepDim);
             if (res == IntPtr.Zero)
@@ -963,9 +1356,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_any(IntPtr tensor);
+        static extern IntPtr THSTensor_any(IntPtr tensor);
 
-        public TorchTensor Any()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor any()
         {
             var res = THSTensor_any(handle);
             if (res == IntPtr.Zero)
@@ -974,9 +1371,15 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+        static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
 
-        public TorchTensor Any(long dimension, bool keepDim = false)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension"></param>
+        /// <param name="keepDim"></param>
+        /// <returns></returns>
+        public TorchTensor any(long dimension, bool keepDim = false)
         {
             var res = THSTensor_any_along_dimension(handle, dimension, keepDim);
             if (res == IntPtr.Zero)
@@ -985,9 +1388,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_argmax(IntPtr tensor);
+        static extern IntPtr THSTensor_argmax(IntPtr tensor);
 
-        public TorchTensor Argmax()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor argmax()
         {
             var res = THSTensor_argmax(handle);
             if (res == IntPtr.Zero)
@@ -996,9 +1403,15 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_argmax_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+        static extern IntPtr THSTensor_argmax_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
 
-        public TorchTensor Argmax(long dimension, bool keepDim = false)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension"></param>
+        /// <param name="keepDim"></param>
+        /// <returns></returns>
+        public TorchTensor argmax(long dimension, bool keepDim = false)
         {
             var res = THSTensor_argmax_along_dimension(handle, dimension, keepDim);
             if (res == IntPtr.Zero)
@@ -1007,9 +1420,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_argmin(IntPtr tensor);
+        static extern IntPtr THSTensor_argmin(IntPtr tensor);
 
-        public TorchTensor Argmin()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor argmin()
         {
             var res = THSTensor_argmin(handle);
             if (res == IntPtr.Zero)
@@ -1018,9 +1435,15 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_argmin_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+        static extern IntPtr THSTensor_argmin_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
 
-        public TorchTensor Argmin(long dimension, bool keepDim = false)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dimension"></param>
+        /// <param name="keepDim"></param>
+        /// <returns></returns>
+        public TorchTensor argmin(long dimension, bool keepDim = false)
         {
             var res = THSTensor_argmin_along_dimension(handle, dimension, keepDim);
             if (res == IntPtr.Zero)
@@ -1029,9 +1452,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cos(IntPtr tensor);
+        static extern IntPtr THSTensor_cos(IntPtr tensor);
 
-        public TorchTensor Cos()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor cos()
         {
             var res = THSTensor_cos(handle);
             if (res == IntPtr.Zero)
@@ -1040,9 +1467,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cos_(IntPtr tensor);
+        static extern IntPtr THSTensor_cos_(IntPtr tensor);
 
-        public TorchTensor CosInPlace()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor cos_()
         {
             var res = THSTensor_cos_(handle);
             if (res == IntPtr.Zero)
@@ -1051,9 +1482,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sin(IntPtr tensor);
+        static extern IntPtr THSTensor_sin(IntPtr tensor);
 
-        public TorchTensor Sin()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor sin()
         {
             var res = THSTensor_sin(handle);
             if (res == IntPtr.Zero)
@@ -1062,9 +1497,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sin_(IntPtr tensor);
+        static extern IntPtr THSTensor_sin_(IntPtr tensor);
 
-        public TorchTensor SinInPlace()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor sin_()
         {
             var res = THSTensor_sin_(handle);
             if (res == IntPtr.Zero)
@@ -1073,9 +1512,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_tan(IntPtr tensor);
+        static extern IntPtr THSTensor_tan(IntPtr tensor);
 
-        public TorchTensor Tan()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor tan()
         {
             var res = THSTensor_tan(handle);
             if (res == IntPtr.Zero)
@@ -1084,9 +1527,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_tan_(IntPtr tensor);
+        static extern IntPtr THSTensor_tan_(IntPtr tensor);
 
-        public TorchTensor TanInPlace()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor tan_()
         {
             var res = THSTensor_tan_(handle);
             if (res == IntPtr.Zero)
@@ -1095,25 +1542,37 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_angle(IntPtr tensor);
+        static extern IntPtr THSTensor_angle(IntPtr tensor);
 
-        public TorchTensor Angle()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor angle()
         {
             return new TorchTensor(THSTensor_angle(handle));
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_asin(IntPtr tensor);
+        static extern IntPtr THSTensor_asin(IntPtr tensor);
 
-        public TorchTensor Asin()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor asin()
         {
             return new TorchTensor(THSTensor_asin(handle));
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_asin_(IntPtr tensor);
+        static extern IntPtr THSTensor_asin_(IntPtr tensor);
 
-        public TorchTensor AsinInPlace()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor asin_()
         {
             var res = THSTensor_asin_(handle);
             if (res == IntPtr.Zero)
@@ -1122,9 +1581,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_acos(IntPtr tensor);
+        static extern IntPtr THSTensor_acos(IntPtr tensor);
 
-        public TorchTensor Acos()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor acos()
         {
             var res = THSTensor_acos(handle);
             if (res == IntPtr.Zero)
@@ -1133,9 +1596,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_acos_(IntPtr tensor);
+        static extern IntPtr THSTensor_acos_(IntPtr tensor);
 
-        public TorchTensor AcosInPlace()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor acos_()
         {
             var res = THSTensor_acos_(handle);
             if (res == IntPtr.Zero)
@@ -1144,9 +1611,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_atan(IntPtr tensor);
+        static extern IntPtr THSTensor_atan(IntPtr tensor);
 
-        public TorchTensor Atan()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TorchTensor atan()
         {
             var res = THSTensor_atan(handle);
             if (res == IntPtr.Zero)
@@ -1155,9 +1626,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_atan_(IntPtr tensor);
+        static extern IntPtr THSTensor_atan_(IntPtr tensor);
 
-        public TorchTensor AtanInPlace()
+        public TorchTensor atan_()
         {
             var res = THSTensor_atan_(handle);
             if (res == IntPtr.Zero)
@@ -1166,9 +1637,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_atan2(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_atan2(IntPtr tensor, IntPtr other);
 
-        public TorchTensor Atan2(TorchTensor other)
+        public TorchTensor atan2(TorchTensor other)
         {
             var res = THSTensor_atan2(handle, other.Handle);
             if (res == IntPtr.Zero)
@@ -1177,9 +1648,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_atan2_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_atan2_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor Atan2InPlace(TorchTensor other)
+        public TorchTensor atan2_(TorchTensor other)
         {
             var res = THSTensor_atan2_(handle, other.Handle);
             if (res == IntPtr.Zero)
@@ -1188,7 +1659,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sinh(IntPtr tensor);
+        static extern IntPtr THSTensor_sinh(IntPtr tensor);
 
         public TorchTensor Sinh()
         {
@@ -1199,9 +1670,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sinh_(IntPtr tensor);
+        static extern IntPtr THSTensor_sinh_(IntPtr tensor);
 
-        public TorchTensor SinhInPlace()
+        public TorchTensor Sinh_()
         {
             var res = THSTensor_sinh_(handle);
             if (res == IntPtr.Zero)
@@ -1210,9 +1681,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cosh(IntPtr tensor);
+        static extern IntPtr THSTensor_cosh(IntPtr tensor);
 
-        public TorchTensor Cosh()
+        public TorchTensor cosh()
         {
             var res = THSTensor_cosh(handle);
             if (res == IntPtr.Zero)
@@ -1221,9 +1692,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cosh_(IntPtr tensor);
+        static extern IntPtr THSTensor_cosh_(IntPtr tensor);
 
-        public TorchTensor CoshInPlace()
+        public TorchTensor cosh_()
         {
             var res = THSTensor_cosh_(handle);
             if (res == IntPtr.Zero)
@@ -1232,9 +1703,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_tanh(IntPtr tensor);
+        static extern IntPtr THSTensor_tanh(IntPtr tensor);
 
-        public TorchTensor Tanh()
+        public TorchTensor tanh()
         {
             var res = THSTensor_tanh(handle);
             if (res == IntPtr.Zero)
@@ -1243,9 +1714,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_tanh_(IntPtr tensor);
+        static extern IntPtr THSTensor_tanh_(IntPtr tensor);
 
-        public TorchTensor TanhInPlace()
+        public TorchTensor tanh_()
         {
             var res = THSTensor_tanh_(handle);
             if (res == IntPtr.Zero)
@@ -1254,9 +1725,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_floor(IntPtr tensor);
+        static extern IntPtr THSTensor_floor(IntPtr tensor);
 
-        public TorchTensor Floor()
+        public TorchTensor floor()
         {
             var res = THSTensor_floor(handle);
             if (res == IntPtr.Zero)
@@ -1265,9 +1736,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_floor_(IntPtr tensor);
+        static extern IntPtr THSTensor_floor_(IntPtr tensor);
 
-        public TorchTensor FloorInPlace()
+        public TorchTensor floor_()
         {
             var res = THSTensor_floor_(handle);
             if (res == IntPtr.Zero)
@@ -1276,9 +1747,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_digamma(IntPtr tensor);
+        static extern IntPtr THSTensor_digamma(IntPtr tensor);
 
-        public TorchTensor Digamma()
+        public TorchTensor digamma()
         {
             var res = THSTensor_digamma(handle);
             if (res == IntPtr.Zero)
@@ -1287,9 +1758,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_digamma_(IntPtr tensor);
+        static extern IntPtr THSTensor_digamma_(IntPtr tensor);
 
-        public TorchTensor DigammaInPlace()
+        public TorchTensor digamma_()
         {
             var res = THSTensor_digamma_(handle);
             if (res == IntPtr.Zero)
@@ -1298,9 +1769,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lgamma(IntPtr tensor);
+        static extern IntPtr THSTensor_lgamma(IntPtr tensor);
 
-        public TorchTensor Lgamma()
+        public TorchTensor lgamma()
         {
             var res = THSTensor_lgamma(handle);
             if (res == IntPtr.Zero)
@@ -1309,9 +1780,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lgamma_(IntPtr tensor);
+        static extern IntPtr THSTensor_lgamma_(IntPtr tensor);
 
-        public TorchTensor LgammaInPlace()
+        public TorchTensor lgamma_()
         {
             var res = THSTensor_lgamma_(handle);
             if (res == IntPtr.Zero)
@@ -1320,9 +1791,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mvlgamma(IntPtr tensor, long p);
+        static extern IntPtr THSTensor_mvlgamma(IntPtr tensor, long p);
 
-        public TorchTensor Mvlgamma(long p)
+        public TorchTensor mvlgamma(long p)
         {
             var res = THSTensor_mvlgamma(handle, p);
             if (res == IntPtr.Zero)
@@ -1331,9 +1802,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mvlgamma_(IntPtr tensor, long p);
+        static extern IntPtr THSTensor_mvlgamma_(IntPtr tensor, long p);
 
-        public TorchTensor MvlgammaInPlace(long p)
+        public TorchTensor mvlgamma_(long p)
         {
             var res = THSTensor_mvlgamma_(handle, p);
             if (res == IntPtr.Zero)
@@ -1342,9 +1813,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_polygamma(IntPtr tensor, long p);
+        static extern IntPtr THSTensor_polygamma(IntPtr tensor, long p);
 
-        public TorchTensor Polygamma(long p)
+        public TorchTensor polygamma(long p)
         {
             var res = THSTensor_polygamma(handle, p);
             if (res == IntPtr.Zero)
@@ -1353,9 +1824,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_polygamma_(IntPtr tensor, long p);
+        static extern IntPtr THSTensor_polygamma_(IntPtr tensor, long p);
 
-        public TorchTensor PolygammaInPlace(long p)
+        public TorchTensor polygamma_(long p)
         {
             var res = THSTensor_polygamma_(handle, p);
             if (res == IntPtr.Zero)
@@ -1364,9 +1835,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ceil(IntPtr tensor);
+        static extern IntPtr THSTensor_ceil(IntPtr tensor);
 
-        public TorchTensor Ceil()
+        public TorchTensor ceil()
         {
             var res = THSTensor_ceil(handle);
             if (res == IntPtr.Zero)
@@ -1375,9 +1846,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ceil_(IntPtr tensor);
+        static extern IntPtr THSTensor_ceil_(IntPtr tensor);
 
-        public TorchTensor CeilInPlace()
+        public TorchTensor ceil_()
         {
             var res = THSTensor_ceil_(handle);
             if (res == IntPtr.Zero)
@@ -1386,9 +1857,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sign(IntPtr tensor);
+        static extern IntPtr THSTensor_sign(IntPtr tensor);
 
-        public TorchTensor Sign()
+        public TorchTensor sign()
         {
             var res = THSTensor_sign(handle);
             if (res == IntPtr.Zero)
@@ -1397,9 +1868,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sign_(IntPtr tensor);
+        static extern IntPtr THSTensor_sign_(IntPtr tensor);
 
-        public TorchTensor SignInPlace()
+        public TorchTensor sign_()
         {
             var res = THSTensor_sign_(handle);
             if (res == IntPtr.Zero)
@@ -1408,9 +1879,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_softplus(IntPtr tensor);
+        static extern IntPtr THSTensor_softplus(IntPtr tensor);
 
-        public TorchTensor Softplus()
+        public TorchTensor softplus()
         {
             var res = THSTensor_softplus(handle);
             if (res == IntPtr.Zero)
@@ -1419,9 +1890,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_relu(IntPtr tensor);
+        static extern IntPtr THSTensor_relu(IntPtr tensor);
 
-        public TorchTensor Relu()
+        public TorchTensor relu()
         {
             var res = THSTensor_relu(handle);
             if (res == IntPtr.Zero)
@@ -1430,9 +1901,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_relu_(IntPtr tensor);
+        static extern IntPtr THSTensor_relu_(IntPtr tensor);
 
-        public TorchTensor ReluInPlace()
+        public TorchTensor relu_()
         {
             var res = THSTensor_relu_(handle);
             if (res == IntPtr.Zero)
@@ -1441,9 +1912,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_relu6(IntPtr tensor);
+        static extern IntPtr THSTensor_relu6(IntPtr tensor);
 
-        public TorchTensor Relu6()
+        public TorchTensor relu6()
         {
             var res = THSTensor_relu6(handle);
             if (res == IntPtr.Zero)
@@ -1452,9 +1923,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_relu6_(IntPtr tensor);
+        static extern IntPtr THSTensor_relu6_(IntPtr tensor);
 
-        public TorchTensor Relu6InPlace()
+        public TorchTensor relu6_()
         {
             var res = THSTensor_relu6_(handle);
             if (res == IntPtr.Zero)
@@ -1463,9 +1934,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_celu(IntPtr tensor);
+        static extern IntPtr THSTensor_celu(IntPtr tensor);
 
-        public TorchTensor Celu()
+        public TorchTensor celu()
         {
             var res = THSTensor_celu(handle);
             if (res == IntPtr.Zero)
@@ -1474,9 +1945,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_celu_(IntPtr tensor);
+        static extern IntPtr THSTensor_celu_(IntPtr tensor);
 
-        public TorchTensor CeluInPlace()
+        public TorchTensor celu_()
         {
             var res = THSTensor_celu_(handle);
             if (res == IntPtr.Zero)
@@ -1485,9 +1956,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_elu(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
+        static extern IntPtr THSTensor_elu(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
 
-        public TorchTensor Elu(TorchScalar alpha, TorchScalar scale, TorchScalar input_scale)
+        public TorchTensor elu(TorchScalar alpha, TorchScalar scale, TorchScalar input_scale)
         {
             var res = THSTensor_elu(handle, alpha.Handle, scale.Handle, input_scale.Handle);
             if (res == IntPtr.Zero)
@@ -1496,9 +1967,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_elu_(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
+        static extern IntPtr THSTensor_elu_(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
 
-        public TorchTensor EluInPlace(TorchScalar alpha, TorchScalar scale, TorchScalar input_scale)
+        public TorchTensor elu_(TorchScalar alpha, TorchScalar scale, TorchScalar input_scale)
         {
             var res = THSTensor_elu_(handle, alpha.Handle, scale.Handle, input_scale.Handle);
             if (res == IntPtr.Zero)
@@ -1507,9 +1978,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gelu(IntPtr tensor);
+        static extern IntPtr THSTensor_gelu(IntPtr tensor);
 
-        public TorchTensor Gelu()
+        public TorchTensor gelu()
         {
             var res = THSTensor_gelu(handle);
             if (res == IntPtr.Zero)
@@ -1518,9 +1989,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_hardsigmoid(IntPtr tensor);
+        static extern IntPtr THSTensor_hardsigmoid(IntPtr tensor);
 
-        public TorchTensor Hardsigmoid()
+        public TorchTensor hardsigmoid()
         {
             var res = THSTensor_hardsigmoid(handle);
             if (res == IntPtr.Zero)
@@ -1529,9 +2000,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_hardsigmoid_(IntPtr tensor);
+        static extern IntPtr THSTensor_hardsigmoid_(IntPtr tensor);
 
-        public TorchTensor HardsigmoidInPlace()
+        public TorchTensor hardsigmoid_()
         {
             var res = THSTensor_hardsigmoid_(handle);
             if (res == IntPtr.Zero)
@@ -1540,9 +2011,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_hardswish(IntPtr tensor);
+        static extern IntPtr THSTensor_hardswish(IntPtr tensor);
 
-        public TorchTensor Hardswish()
+        public TorchTensor hardswish()
         {
             var res = THSTensor_hardswish(handle);
             if (res == IntPtr.Zero)
@@ -1551,9 +2022,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_hardswish_(IntPtr tensor);
+        static extern IntPtr THSTensor_hardswish_(IntPtr tensor);
 
-        public TorchTensor HardswishInPlace()
+        public TorchTensor hardswish_()
         {
             var res = THSTensor_hardswish_(handle);
             if (res == IntPtr.Zero)
@@ -1562,9 +2033,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_hardtanh(IntPtr tensor, IntPtr min, IntPtr max);
+        static extern IntPtr THSTensor_hardtanh(IntPtr tensor, IntPtr min, IntPtr max);
 
-        public TorchTensor Hardtanh(TorchScalar min, TorchScalar max)
+        public TorchTensor hardtanh(TorchScalar min, TorchScalar max)
         {
             var res = THSTensor_hardtanh(handle, min.Handle, max.Handle);
             if (res == IntPtr.Zero)
@@ -1573,9 +2044,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_hardtanh_(IntPtr tensor, IntPtr min, IntPtr max);
+        static extern IntPtr THSTensor_hardtanh_(IntPtr tensor, IntPtr min, IntPtr max);
 
-        public TorchTensor HardtanhInPlace(TorchScalar min, TorchScalar max)
+        public TorchTensor hardtanh_(TorchScalar min, TorchScalar max)
         {
             var res = THSTensor_hardtanh_(handle, min.Handle, max.Handle);
             if (res == IntPtr.Zero)
@@ -1584,9 +2055,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_leaky_relu(IntPtr tensor, IntPtr negative_slope);
+        static extern IntPtr THSTensor_leaky_relu(IntPtr tensor, IntPtr negative_slope);
 
-        public TorchTensor LeakyRelu(TorchScalar negative_slope)
+        public TorchTensor leaky_relu(TorchScalar negative_slope)
         {
             var res = THSTensor_leaky_relu(handle, negative_slope.Handle);
             if (res == IntPtr.Zero)
@@ -1595,9 +2066,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_leaky_relu_(IntPtr tensor, IntPtr negative_slope);
+        static extern IntPtr THSTensor_leaky_relu_(IntPtr tensor, IntPtr negative_slope);
 
-        public TorchTensor LeakyReluInPlace(TorchScalar negative_slope)
+        public TorchTensor leaky_relu_(TorchScalar negative_slope)
         {
             var res = THSTensor_leaky_relu_(handle, negative_slope.Handle);
             if (res == IntPtr.Zero)
@@ -1606,9 +2077,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_round(IntPtr tensor);
+        static extern IntPtr THSTensor_round(IntPtr tensor);
 
-        public TorchTensor Round()
+        public TorchTensor round()
         {
             var res = THSTensor_round(handle);
             if (res == IntPtr.Zero)
@@ -1617,9 +2088,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_round_(IntPtr tensor);
+        static extern IntPtr THSTensor_round_(IntPtr tensor);
 
-        public TorchTensor RoundInPlace()
+        public TorchTensor round_()
         {
             var res = THSTensor_round_(handle);
             if (res == IntPtr.Zero)
@@ -1628,9 +2099,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_selu(IntPtr tensor);
+        static extern IntPtr THSTensor_selu(IntPtr tensor);
 
-        public TorchTensor Selu()
+        public TorchTensor selu()
         {
             var res = THSTensor_selu(handle);
             if (res == IntPtr.Zero)
@@ -1639,9 +2110,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_selu_(IntPtr tensor);
+        static extern IntPtr THSTensor_selu_(IntPtr tensor);
 
-        public TorchTensor SeluInPlace()
+        public TorchTensor selu_()
         {
             var res = THSTensor_selu_(handle);
             if (res == IntPtr.Zero)
@@ -1651,9 +2122,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_silu(IntPtr tensor);
+        static extern IntPtr THSTensor_silu(IntPtr tensor);
 
-        public TorchTensor Silu()
+        public TorchTensor silu()
         {
             var res = THSTensor_silu(handle);
             if (res == IntPtr.Zero)
@@ -1662,9 +2133,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_silu_(IntPtr tensor);
+        static extern IntPtr THSTensor_silu_(IntPtr tensor);
 
-        public TorchTensor SiluInPlace()
+        public TorchTensor silu_()
         {
             var res = THSTensor_silu_(handle);
             if (res == IntPtr.Zero)
@@ -1673,9 +2144,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_abs(IntPtr tensor);
+        static extern IntPtr THSTensor_abs(IntPtr tensor);
 
-        public TorchTensor Abs()
+        public TorchTensor abs()
         {
             var res = THSTensor_abs(handle);
             if (res == IntPtr.Zero)
@@ -1684,9 +2155,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_abs_(IntPtr tensor);
+        static extern IntPtr THSTensor_abs_(IntPtr tensor);
 
-        public TorchTensor AbsInPlace()
+        public TorchTensor abs_()
         {
             var res = THSTensor_abs_(handle);
             if (res == IntPtr.Zero)
@@ -1695,9 +2166,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log_sigmoid(IntPtr tensor);
+        static extern IntPtr THSTensor_log_sigmoid(IntPtr tensor);
 
-        public TorchTensor LogSigmoid()
+        public TorchTensor log_sigmoid()
         {
             var res = THSTensor_log_sigmoid(handle);
             if (res == IntPtr.Zero)
@@ -1706,9 +2177,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logcumsumexp(IntPtr tensor, long dim);
+        static extern IntPtr THSTensor_logcumsumexp(IntPtr tensor, long dim);
 
-        public TorchTensor LogCumulativeSumExp(long dim)
+        public TorchTensor logcumsumexp(long dim)
         {
             var res = THSTensor_logcumsumexp(handle, dim);
             if (res == IntPtr.Zero)
@@ -1717,9 +2188,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log10(IntPtr tensor);
+        static extern IntPtr THSTensor_log10(IntPtr tensor);
 
-        public TorchTensor Log10()
+        public TorchTensor log10()
         {
             var res = THSTensor_log10(handle);
             if (res == IntPtr.Zero)
@@ -1728,9 +2199,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log10_(IntPtr tensor);
+        static extern IntPtr THSTensor_log10_(IntPtr tensor);
 
-        public TorchTensor Log10InPlace()
+        public TorchTensor log10_()
         {
             var res = THSTensor_log10_(handle);
             if (res == IntPtr.Zero)
@@ -1739,9 +2210,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lerp(IntPtr tensor, IntPtr end, IntPtr weight);
+        static extern IntPtr THSTensor_lerp(IntPtr tensor, IntPtr end, IntPtr weight);
 
-        public TorchTensor Lerp(TorchTensor end, TorchTensor weight)
+        public TorchTensor lerp(TorchTensor end, TorchTensor weight)
         {
             var res = THSTensor_lerp(handle, end.Handle, weight.Handle);
             if (res == IntPtr.Zero)
@@ -1750,9 +2221,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lerp_(IntPtr tensor, IntPtr end, IntPtr weight);
+        static extern IntPtr THSTensor_lerp_(IntPtr tensor, IntPtr end, IntPtr weight);
 
-        public TorchTensor LerpInPlace(TorchTensor end, TorchTensor weight)
+        public TorchTensor lerp_(TorchTensor end, TorchTensor weight)
         {
             var res = THSTensor_lerp_(handle, end.Handle, weight.Handle);
             if (res == IntPtr.Zero)
@@ -1761,9 +2232,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log1p(IntPtr tensor);
+        static extern IntPtr THSTensor_log1p(IntPtr tensor);
 
-        public TorchTensor Log1p()
+        public TorchTensor log1p()
         {
             var res = THSTensor_log1p(handle);
             if (res == IntPtr.Zero)
@@ -1772,9 +2243,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log1p_(IntPtr tensor);
+        static extern IntPtr THSTensor_log1p_(IntPtr tensor);
 
-        public TorchTensor Log1pInPlace()
+        public TorchTensor log1p_()
         {
             var res = THSTensor_log1p_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1782,9 +2253,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sqrt(IntPtr tensor);
+        static extern IntPtr THSTensor_sqrt(IntPtr tensor);
 
-        public TorchTensor Sqrt()
+        public TorchTensor sqrt()
         {
             var res = THSTensor_sqrt(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1792,9 +2263,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sqrt_(IntPtr tensor);
+        static extern IntPtr THSTensor_sqrt_(IntPtr tensor);
 
-        public TorchTensor SqrtInPlace()
+        public TorchTensor sqrt_()
         {
             var res = THSTensor_sqrt_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1802,9 +2273,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_rsqrt(IntPtr tensor);
+        static extern IntPtr THSTensor_rsqrt(IntPtr tensor);
 
-        public TorchTensor Rsqrt()
+        public TorchTensor rsqrt()
         {
             var res = THSTensor_rsqrt(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1812,9 +2283,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_rsqrt_(IntPtr tensor);
+        static extern IntPtr THSTensor_rsqrt_(IntPtr tensor);
 
-        public TorchTensor RsqrtInPlace()
+        public TorchTensor rsqrt_()
         {
             var res = THSTensor_rsqrt_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1823,13 +2294,13 @@ namespace TorchSharp.Tensor
 
         public static TorchTensor operator -(TorchTensor tensor)
         {
-            return tensor.Neg();
+            return tensor.neg();
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_neg(IntPtr tensor);
+        static extern IntPtr THSTensor_neg(IntPtr tensor);
 
-        public TorchTensor Neg()
+        public TorchTensor neg()
         {
             var res = THSTensor_neg(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1837,9 +2308,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_neg_(IntPtr tensor);
+        static extern IntPtr THSTensor_neg_(IntPtr tensor);
 
-        public TorchTensor NegInPlace()
+        public TorchTensor neg_()
         {
             var res = THSTensor_neg_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1847,10 +2318,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_baddbmm(IntPtr batch1, IntPtr batch2, IntPtr mat, float beta,
+        static extern IntPtr THSTensor_baddbmm(IntPtr batch1, IntPtr batch2, IntPtr mat, float beta,
             float alpha);
 
-        public TorchTensor Baddbmm(TorchTensor batch2, TorchTensor mat, float beta = 1, float alpha = 1)
+        public TorchTensor baddbmm(TorchTensor batch2, TorchTensor mat, float beta = 1, float alpha = 1)
         {
             var res = THSTensor_baddbmm(handle, batch2.Handle, mat.Handle, beta, alpha);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1858,9 +2329,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bmm(IntPtr batch1, IntPtr batch2);
+        static extern IntPtr THSTensor_bmm(IntPtr batch1, IntPtr batch2);
 
-        public TorchTensor Bmm(TorchTensor batch2)
+        public TorchTensor bmm(TorchTensor batch2)
         {
             var res = THSTensor_bmm(handle, batch2.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1868,12 +2339,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bincount(IntPtr tensor, IntPtr weights, long minlength);
+        static extern IntPtr THSTensor_bincount(IntPtr tensor, IntPtr weights, long minlength);
 
         /// <summary>
         /// Count the frequency of each value in an array of non-negative ints.
         /// </summary>
-        public TorchTensor Bincount(TorchTensor? weights, long minlength = 0)
+        public TorchTensor bincount(TorchTensor? weights, long minlength = 0)
         {
             var weightsHandle = (weights is null ? IntPtr.Zero : weights.Handle);
             var res = THSTensor_bincount(handle, weightsHandle, minlength);
@@ -1882,9 +2353,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_and(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_bitwise_and(IntPtr tensor, IntPtr other);
 
-        public TorchTensor BitwiseAnd(TorchTensor other)
+        public TorchTensor bitwise_and(TorchTensor other)
         {
             var res = THSTensor_bitwise_and(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1892,9 +2363,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_and_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_bitwise_and_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor BitwiseAndInPlace(TorchTensor other)
+        public TorchTensor bitwise_and_(TorchTensor other)
         {
             var res = THSTensor_bitwise_and_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1902,9 +2373,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_not(IntPtr tensor);
+        static extern IntPtr THSTensor_bitwise_not(IntPtr tensor);
 
-        public TorchTensor BitwiseNot()
+        public TorchTensor bitwise_not()
         {
             var res = THSTensor_bitwise_not(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1912,9 +2383,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_not_(IntPtr tensor);
+        static extern IntPtr THSTensor_bitwise_not_(IntPtr tensor);
 
-        public TorchTensor BitwiseNotInPlace(TorchTensor other)
+        public TorchTensor bitwise_not_(TorchTensor other)
         {
             var res = THSTensor_bitwise_not_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1922,9 +2393,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_or(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_bitwise_or(IntPtr tensor, IntPtr other);
 
-        public TorchTensor BitwiseOr(TorchTensor other)
+        public TorchTensor bitwise_or(TorchTensor other)
         {
             var res = THSTensor_bitwise_or(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1932,9 +2403,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_or_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_bitwise_or_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor BitwiseOrInPlace(TorchTensor other)
+        public TorchTensor bitwise_or_(TorchTensor other)
         {
             var res = THSTensor_bitwise_or_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1942,9 +2413,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_xor(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_bitwise_xor(IntPtr tensor, IntPtr other);
 
-        public TorchTensor BitwiseXor(TorchTensor other)
+        public TorchTensor bitwise_xor(TorchTensor other)
         {
             var res = THSTensor_bitwise_xor(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1952,9 +2423,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bitwise_xor_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_bitwise_xor_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor BitwiseXorInPlace(TorchTensor other)
+        public TorchTensor BitwiseXor_(TorchTensor other)
         {
             var res = THSTensor_bitwise_xor_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1962,9 +2433,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_and(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_logical_and(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LogicalAnd(TorchTensor other)
+        public TorchTensor logical_and(TorchTensor other)
         {
             var res = THSTensor_logical_and(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1972,9 +2443,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_and_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_logical_and_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LogicalAndInPlace(TorchTensor other)
+        public TorchTensor logical_and_(TorchTensor other)
         {
             var res = THSTensor_logical_and_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1982,9 +2453,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_not(IntPtr tensor);
+        static extern IntPtr THSTensor_logical_not(IntPtr tensor);
 
-        public TorchTensor LogicalNot()
+        public TorchTensor logical_not()
         {
             var res = THSTensor_logical_not(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -1992,9 +2463,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_not_(IntPtr tensor);
+        static extern IntPtr THSTensor_logical_not_(IntPtr tensor);
 
-        public TorchTensor LogicalNotInPlace(TorchTensor other)
+        public TorchTensor logical_not_(TorchTensor other)
         {
             var res = THSTensor_logical_not_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2002,9 +2473,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_or(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_logical_or(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LogicalOr(TorchTensor other)
+        public TorchTensor logical_or(TorchTensor other)
         {
             var res = THSTensor_logical_or(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2012,9 +2483,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_or_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_logical_or_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LogicalOrInPlace(TorchTensor other)
+        public TorchTensor logical_or_(TorchTensor other)
         {
             var res = THSTensor_logical_or_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2022,9 +2493,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_xor(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_logical_xor(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LogicalXor(TorchTensor other)
+        public TorchTensor logical_xor(TorchTensor other)
         {
             var res = THSTensor_logical_xor(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2032,9 +2503,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_logical_xor_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_logical_xor_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LogicalXorInPlace(TorchTensor other)
+        public TorchTensor logical_xor_(TorchTensor other)
         {
             var res = THSTensor_logical_xor_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2042,9 +2513,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cholesky(IntPtr input, bool upper);
+        static extern IntPtr THSTensor_cholesky(IntPtr input, bool upper);
 
-        public TorchTensor Cholesky(bool upper = false)
+        public TorchTensor cholesky(bool upper = false)
         {
             var res = THSTensor_cholesky(handle, upper);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2052,9 +2523,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cholesky_inverse(IntPtr input, bool upper);
+        static extern IntPtr THSTensor_cholesky_inverse(IntPtr input, bool upper);
 
-        public TorchTensor CholeskyInverse(bool upper = false)
+        public TorchTensor cholesky_inverse(bool upper = false)
         {
             var res = THSTensor_cholesky_inverse(handle, upper);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2062,7 +2533,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cholesky_solve(IntPtr input, IntPtr input2, bool upper);
+        static extern IntPtr THSTensor_cholesky_solve(IntPtr input, IntPtr input2, bool upper);
 
         public TorchTensor CholeskySolve(TorchTensor input2, bool upper = false)
         {
@@ -2072,9 +2543,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_clamp(IntPtr input, IntPtr min, IntPtr max);
+        static extern IntPtr THSTensor_clamp(IntPtr input, IntPtr min, IntPtr max);
 
-        public TorchTensor Clamp(TorchScalar min, TorchScalar max)
+        public TorchTensor clamp(TorchScalar min, TorchScalar max)
         {
             var res = THSTensor_clamp(handle, min.Handle, max.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2082,9 +2553,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_clamp_(IntPtr input, IntPtr min, IntPtr max);
+        static extern IntPtr THSTensor_clamp_(IntPtr input, IntPtr min, IntPtr max);
 
-        public TorchTensor ClampInPlace(TorchScalar min, TorchScalar max)
+        public TorchTensor clamp_(TorchScalar min, TorchScalar max)
         {
             var res = THSTensor_clamp_(handle, min.Handle, max.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2092,9 +2563,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_clamp_max(IntPtr input, IntPtr max);
+        static extern IntPtr THSTensor_clamp_max(IntPtr input, IntPtr max);
 
-        public TorchTensor ClampMax(TorchScalar max)
+        public TorchTensor clamp_max(TorchScalar max)
         {
             var res = THSTensor_clamp_max(handle, max.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2102,9 +2573,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_clamp_max_(IntPtr input, IntPtr max);
+        static extern IntPtr THSTensor_clamp_max_(IntPtr input, IntPtr max);
 
-        public TorchTensor ClampMaxInPlace(TorchScalar max)
+        public TorchTensor clamp_max_(TorchScalar max)
         {
             var res = THSTensor_clamp_max_(handle, max.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2112,9 +2583,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_clamp_min(IntPtr input, IntPtr min);
+        static extern IntPtr THSTensor_clamp_min(IntPtr input, IntPtr min);
 
-        public TorchTensor ClampMin(TorchScalar min)
+        public TorchTensor clamp_min(TorchScalar min)
         {
             var res = THSTensor_clamp_min(handle, min.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2122,9 +2593,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_clamp_min_(IntPtr input, IntPtr min);
+        static extern IntPtr THSTensor_clamp_min_(IntPtr input, IntPtr min);
 
-        public TorchTensor ClampMinInPlace(TorchScalar min)
+        public TorchTensor clamp_min_(TorchScalar min)
         {
             var res = THSTensor_clamp_min_(handle, min.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2132,13 +2603,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cross(IntPtr input, IntPtr other, long dim);
+        static extern IntPtr THSTensor_cross(IntPtr input, IntPtr other, long dim);
 
         /// <summary>
         /// Returns the cross product of vectors in dimension dim of input and other.
         /// input and other must have the same size, and the size of their dim dimension should be 3.
         /// </summary>
-        public TorchTensor Cross(TorchScalar other, long dim)
+        public TorchTensor cross(TorchScalar other, long dim)
         {
             var res = THSTensor_cross(handle, other.Handle, dim);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2146,9 +2617,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
+        static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
 
-        public (TorchTensor values, TorchTensor indexes) CumulativeMax(long dimension)
+        public (TorchTensor values, TorchTensor indexes) cummax(long dimension)
         {
             IntPtr[] ptrArray;
 
@@ -2162,9 +2633,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_cummin(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
+        static extern void THSTensor_cummin(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
 
-        public (TorchTensor values, TorchTensor indexes) CumulativeMin(long dimension)
+        public (TorchTensor values, TorchTensor indexes) cummin(long dimension)
         {
             IntPtr[] ptrArray;
 
@@ -2178,9 +2649,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cumsum(IntPtr tensor, long dimension, bool has_type, sbyte scalar_type);
+        static extern IntPtr THSTensor_cumsum(IntPtr tensor, long dimension, bool has_type, sbyte scalar_type);
 
-        public TorchTensor CumulativeSum(long dimension, ScalarType? type = null)
+        public TorchTensor cumsum(long dimension, ScalarType? type = null)
         {
             var res = THSTensor_cumsum(handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2188,9 +2659,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cumprod(IntPtr tensor, long dimension, bool has_type, sbyte scalar_type);
+        static extern IntPtr THSTensor_cumprod(IntPtr tensor, long dimension, bool has_type, sbyte scalar_type);
 
-        public TorchTensor CumulativeProd(long dimension, ScalarType? type = null)
+        public TorchTensor cumprod(long dimension, ScalarType? type = null)
         {
             var res = THSTensor_cumprod(handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2199,9 +2670,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_div(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_div(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Div(TorchTensor target)
+        public TorchTensor div(TorchTensor target)
         {
             var res = THSTensor_div(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2209,9 +2680,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_div_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_div_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Div(TorchScalar target)
+        public TorchTensor div(TorchScalar target)
         {
             var res = THSTensor_div_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2219,9 +2690,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_div_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_div_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor DivInPlace(TorchTensor target)
+        public TorchTensor div_(TorchTensor target)
         {
             var res = THSTensor_div_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2229,9 +2700,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_div_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_div_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor DivInPlace(TorchScalar target)
+        public TorchTensor div_(TorchScalar target)
         {
             var res = THSTensor_div_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2240,9 +2711,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_erf(IntPtr tensor);
+        static extern IntPtr THSTensor_erf(IntPtr tensor);
 
-        public TorchTensor Erf()
+        public TorchTensor erf()
         {
             var res = THSTensor_erf(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2250,9 +2721,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_erf_(IntPtr tensor);
+        static extern IntPtr THSTensor_erf_(IntPtr tensor);
 
-        public TorchTensor ErfInPlace()
+        public TorchTensor erf_()
         {
             var res = THSTensor_erf_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2260,9 +2731,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_erfc(IntPtr tensor);
+        static extern IntPtr THSTensor_erfc(IntPtr tensor);
 
-        public TorchTensor Erfc()
+        public TorchTensor erfc()
         {
             var res = THSTensor_erfc(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2270,9 +2741,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_erfc_(IntPtr tensor);
+        static extern IntPtr THSTensor_erfc_(IntPtr tensor);
 
-        public TorchTensor ErfcInPlace()
+        public TorchTensor erfc_()
         {
             var res = THSTensor_erfc_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2280,9 +2751,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_erfinv(IntPtr tensor);
+        static extern IntPtr THSTensor_erfinv(IntPtr tensor);
 
-        public TorchTensor Erfinv()
+        public TorchTensor erfinv()
         {
             var res = THSTensor_erfinv(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2290,9 +2761,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_erfinv_(IntPtr tensor);
+        static extern IntPtr THSTensor_erfinv_(IntPtr tensor);
 
-        public TorchTensor ErfinvInPlace()
+        public TorchTensor erfinv_()
         {
             var res = THSTensor_erfinv_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2300,9 +2771,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_eq(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_eq(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Eq(TorchTensor target)
+        public TorchTensor eq(TorchTensor target)
         {
             var res = THSTensor_eq(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2310,9 +2781,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_eq_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_eq_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor EqInPlace(TorchTensor target)
+        public TorchTensor eq_(TorchTensor target)
         {
             var res = THSTensor_eq_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2320,9 +2791,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_eq_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_eq_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Eq(TorchScalar target)
+        public TorchTensor eq(TorchScalar target)
         {
             var res = THSTensor_eq_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2330,9 +2801,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_eq_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_eq_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor EqInPlace(TorchScalar target)
+        public TorchTensor eq_(TorchScalar target)
         {
             var res = THSTensor_eq_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2340,9 +2811,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern bool THSTensor_equal(IntPtr tensor, IntPtr trg);
+        static extern bool THSTensor_equal(IntPtr tensor, IntPtr trg);
 
-        public bool Equal(TorchTensor target)
+        public bool Equals(TorchTensor target)
         {
             var res = THSTensor_equal(handle, target.Handle);
             Torch.CheckForErrors();
@@ -2350,9 +2821,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern bool THSTensor_allclose(IntPtr tensor, IntPtr trg, double rtol, double atol, bool equal_nan);
+        static extern bool THSTensor_allclose(IntPtr tensor, IntPtr trg, double rtol, double atol, bool equal_nan);
 
-        public bool AllClose(TorchTensor target, double rtol = 1e-05, double atol = 1e-08, bool equal_nan = false)
+        public bool allclose(TorchTensor target, double rtol = 1e-05, double atol = 1e-08, bool equal_nan = false)
         {
             var res = THSTensor_allclose(handle, target.Handle, rtol, atol, equal_nan);
             Torch.CheckForErrors();
@@ -2360,9 +2831,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_exp(IntPtr tensor);
+        static extern IntPtr THSTensor_exp(IntPtr tensor);
 
-        public TorchTensor Exp()
+        public TorchTensor exp()
         {
             var res = THSTensor_exp(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2370,9 +2841,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_exp_(IntPtr tensor);
+        static extern IntPtr THSTensor_exp_(IntPtr tensor);
 
-        public TorchTensor ExpInPlace()
+        public TorchTensor exp_()
         {
             var res = THSTensor_exp_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2380,9 +2851,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_expm1(IntPtr tensor);
+        static extern IntPtr THSTensor_expm1(IntPtr tensor);
 
-        public TorchTensor ExpMinusOne()
+        public TorchTensor expm1()
         {
             var res = THSTensor_expm1(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2390,9 +2861,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_expm1_(IntPtr tensor);
+        static extern IntPtr THSTensor_expm1_(IntPtr tensor);
 
-        public TorchTensor ExpMinusOneInPlace()
+        public TorchTensor expm1_()
         {
             var res = THSTensor_expm1_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2400,7 +2871,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_fft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
+        static extern IntPtr THSTensor_fft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
 
         public TorchTensor fft(long? n, long dim = -1, string norm = "backward")
         {
@@ -2410,7 +2881,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ifft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
+        static extern IntPtr THSTensor_ifft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
 
         public TorchTensor ifft(long? n, long dim = -1, string norm = "backward")
         {
@@ -2420,7 +2891,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
+        static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
 
         public TorchTensor irfft(long? n, long dim = -1, string norm = "backward")
         {
@@ -2430,7 +2901,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_rfft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
+        static extern IntPtr THSTensor_rfft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
 
         public TorchTensor rfft(long? n, long dim = -1, string norm = "backward")
         {
@@ -2440,9 +2911,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_frac(IntPtr tensor);
+        static extern IntPtr THSTensor_frac(IntPtr tensor);
 
-        public TorchTensor Frac()
+        public TorchTensor frac()
         {
             var res = THSTensor_frac(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2450,9 +2921,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_frac_(IntPtr tensor);
+        static extern IntPtr THSTensor_frac_(IntPtr tensor);
 
-        public TorchTensor FracInPlace()
+        public TorchTensor frac_()
         {
             var res = THSTensor_frac_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2460,9 +2931,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gcd(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_gcd(IntPtr tensor, IntPtr other);
 
-        public TorchTensor Gcd(TorchTensor other)
+        public TorchTensor gcd(TorchTensor other)
         {
             var res = THSTensor_gcd(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2470,9 +2941,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gcd_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_gcd_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor GcdInPlace(TorchTensor other)
+        public TorchTensor gcd_(TorchTensor other)
         {
             var res = THSTensor_gcd_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2480,9 +2951,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ge(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ge(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Ge(TorchTensor target)
+        public TorchTensor ge(TorchTensor target)
         {
             var res = THSTensor_ge(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2490,9 +2961,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ge_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ge_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor GeInPlace(TorchTensor target)
+        public TorchTensor ge_(TorchTensor target)
         {
             var res = THSTensor_ge_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2500,9 +2971,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ge_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ge_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Ge(TorchScalar target)
+        public TorchTensor ge(TorchScalar target)
         {
             var res = THSTensor_ge_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2510,9 +2981,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ge_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ge_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor GeInPlace(TorchScalar target)
+        public TorchTensor ge_(TorchScalar target)
         {
             var res = THSTensor_ge_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2520,9 +2991,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gt(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_gt(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Gt(TorchTensor target)
+        public TorchTensor gt(TorchTensor target)
         {
             var res = THSTensor_gt(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2530,9 +3001,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gt_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_gt_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor GtInPlace(TorchTensor target)
+        public TorchTensor gt_(TorchTensor target)
         {
             var res = THSTensor_gt_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2540,9 +3011,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gt_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_gt_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Gt(TorchScalar target)
+        public TorchTensor gt(TorchScalar target)
         {
             var res = THSTensor_gt_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2550,9 +3021,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_gt_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_gt_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor GtInPlace(TorchScalar target)
+        public TorchTensor gt_(TorchScalar target)
         {
             var res = THSTensor_gt_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2560,9 +3031,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lcm(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_lcm(IntPtr tensor, IntPtr other);
 
-        public TorchTensor Lcm(TorchTensor other)
+        public TorchTensor lcm(TorchTensor other)
         {
             var res = THSTensor_lcm(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2570,9 +3041,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lcm_(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_lcm_(IntPtr tensor, IntPtr other);
 
-        public TorchTensor LcmInPlace(TorchTensor other)
+        public TorchTensor lcm_(TorchTensor other)
         {
             var res = THSTensor_lcm_(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2580,9 +3051,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_le(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_le(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Le(TorchTensor target)
+        public TorchTensor le(TorchTensor target)
         {
             var res = THSTensor_le(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2590,9 +3061,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_le_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_le_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor LeInPlace(TorchTensor target)
+        public TorchTensor le_(TorchTensor target)
         {
             var res = THSTensor_le_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2600,9 +3071,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_le_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_le_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Le(TorchScalar target)
+        public TorchTensor le(TorchScalar target)
         {
             var res = THSTensor_le_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2610,9 +3081,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_le_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_le_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor LeInPlace(TorchScalar target)
+        public TorchTensor le_(TorchScalar target)
         {
             var res = THSTensor_le_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2620,9 +3091,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log(IntPtr tensor);
+        static extern IntPtr THSTensor_log(IntPtr tensor);
 
-        public TorchTensor Log()
+        public TorchTensor log()
         {
             var res = THSTensor_log(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2630,9 +3101,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log_(IntPtr tensor);
+        static extern IntPtr THSTensor_log_(IntPtr tensor);
 
-        public TorchTensor LogInPlace()
+        public TorchTensor log_()
         {
             var res = THSTensor_log_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2640,9 +3111,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lt(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_lt(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Lt(TorchTensor target)
+        public TorchTensor lt(TorchTensor target)
         {
             var res = THSTensor_lt(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2650,9 +3121,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lt_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_lt_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor LtInPlace(TorchTensor target)
+        public TorchTensor lt_(TorchTensor target)
         {
             var res = THSTensor_lt_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2660,9 +3131,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lt_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_lt_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Lt(TorchScalar target)
+        public TorchTensor lt(TorchScalar target)
         {
             var res = THSTensor_lt_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2670,9 +3141,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_lt_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_lt_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor LtInPlace(TorchScalar target)
+        public TorchTensor lt_(TorchScalar target)
         {
             var res = THSTensor_lt_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2680,9 +3151,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_matmul(IntPtr tensor, IntPtr target);
+        static extern IntPtr THSTensor_matmul(IntPtr tensor, IntPtr target);
 
-        public TorchTensor MatMul(TorchTensor target)
+        public TorchTensor matmul(TorchTensor target)
         {
             var res = THSTensor_matmul(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2690,10 +3161,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_topk(IntPtr tensor, AllocatePinnedArray allocator, int k,
+        static extern void THSTensor_topk(IntPtr tensor, AllocatePinnedArray allocator, int k,
             long dimension, bool largest, bool sorted);
 
-        public (TorchTensor values, TorchTensor indexes) TopK(int k, int dimension = -1, bool largest = true, bool sorted = true)
+        public (TorchTensor values, TorchTensor indexes) topk(int k, int dimension = -1, bool largest = true, bool sorted = true)
         {
             IntPtr[] ptrArray;
 
@@ -2708,9 +3179,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_unbind(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
+        static extern void THSTensor_unbind(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
 
-        public TorchTensor[] Unbind(int dimension = 0)
+        public TorchTensor[] unbind(int dimension = 0)
         {
             IntPtr[] ptrArray;
 
@@ -2726,9 +3197,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dimension);
+        static extern void THSTensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dimension);
 
-        public TorchTensor[] SplitWithSize(long size, int dimension = 0)
+        public TorchTensor[] split_with_size(long size, int dimension = 0)
         {
             IntPtr[] ptrArray;
 
@@ -2742,9 +3213,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dimension);
+        static extern void THSTensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dimension);
 
-        public TorchTensor[] SplitWithSizes(long[] sizes, int dimension = 0)
+        public TorchTensor[] split_with_sizes(long[] sizes, int dimension = 0)
         {
             IntPtr[] ptrArray;
 
@@ -2765,9 +3236,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_max(IntPtr tensor);
+        static extern IntPtr THSTensor_max(IntPtr tensor);
 
-        public TorchTensor Max()
+        public TorchTensor max()
         {
             var res = THSTensor_max(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2776,9 +3247,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_max_elementwise(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_max_elementwise(IntPtr tensor, IntPtr other);
 
-        public TorchTensor Max(TorchTensor other)
+        public TorchTensor max(TorchTensor other)
         {
             var res = THSTensor_max_elementwise(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2786,10 +3257,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_max_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dimension,
+        static extern void THSTensor_max_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dimension,
             bool keep_dim);
 
-        public (TorchTensor values, TorchTensor indexes) Max(long dimension, bool keepDim = false)
+        public (TorchTensor values, TorchTensor indexes) max(long dimension, bool keepDim = false)
         {
             IntPtr[] ptrArray;
 
@@ -2804,9 +3275,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mean(IntPtr tensor);
+        static extern IntPtr THSTensor_mean(IntPtr tensor);
 
-        public TorchTensor Mean()
+        public TorchTensor mean()
         {
             var res = THSTensor_mean(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2814,9 +3285,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
+        static extern IntPtr THSTensor_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
 
-        public TorchTensor Mean(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
+        public TorchTensor mean(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
         {
             unsafe {
                 fixed (long* pdims = dimensions) {
@@ -2828,9 +3299,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_median(IntPtr tensor);
+        static extern IntPtr THSTensor_median(IntPtr tensor);
 
-        public TorchTensor Median()
+        public TorchTensor median()
         {
             var res = THSTensor_median(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2838,9 +3309,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_min(IntPtr tensor);
+        static extern IntPtr THSTensor_min(IntPtr tensor);
 
-        public TorchTensor Min()
+        public TorchTensor min()
         {
             var res = THSTensor_min(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2848,9 +3319,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_min_elementwise(IntPtr tensor, IntPtr other);
+        static extern IntPtr THSTensor_min_elementwise(IntPtr tensor, IntPtr other);
 
-        public TorchTensor Min(TorchTensor other)
+        public TorchTensor min(TorchTensor other)
         {
             var res = THSTensor_min_elementwise(handle, other.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2858,10 +3329,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_min_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dimension,
+        static extern void THSTensor_min_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dimension,
             bool keep_dim);
 
-        public (TorchTensor values, TorchTensor indexes) Min(long dimension, bool keepDim = false)
+        public (TorchTensor values, TorchTensor indexes) min(long dimension, bool keepDim = false)
         {
             IntPtr[] ptrArray;
 
@@ -2875,9 +3346,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mm(IntPtr tensor, IntPtr target);
+        static extern IntPtr THSTensor_mm(IntPtr tensor, IntPtr target);
 
-        public TorchTensor Mm(TorchTensor target)
+        public TorchTensor mm(TorchTensor target)
         {
             var res = THSTensor_mm(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2885,9 +3356,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mul(IntPtr tensor, IntPtr target);
+        static extern IntPtr THSTensor_mul(IntPtr tensor, IntPtr target);
 
-        public TorchTensor Mul(TorchTensor target)
+        public TorchTensor mul(TorchTensor target)
         {
             var res = THSTensor_mul(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2895,9 +3366,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mul_scalar(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_mul_scalar(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor Mul(TorchScalar scalar)
+        public TorchTensor mul(TorchScalar scalar)
         {
             var res = THSTensor_mul_scalar(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2905,9 +3376,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mul_(IntPtr tensor, IntPtr target);
+        static extern IntPtr THSTensor_mul_(IntPtr tensor, IntPtr target);
 
-        public TorchTensor MulInPlace(TorchTensor target)
+        public TorchTensor mul_(TorchTensor target)
         {
             var res = THSTensor_mul_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2915,9 +3386,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_mul_scalar_(IntPtr tensor, IntPtr target);
+        static extern IntPtr THSTensor_mul_scalar_(IntPtr tensor, IntPtr target);
 
-        public TorchTensor MulInPlace(TorchScalar target)
+        public TorchTensor mul_(TorchScalar target)
         {
             var res = THSTensor_mul_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2925,9 +3396,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ne(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ne(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Ne(TorchTensor target)
+        public TorchTensor ne(TorchTensor target)
         {
             var res = THSTensor_ne(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2935,9 +3406,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ne_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ne_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor NeInPlace(TorchTensor target)
+        public TorchTensor ne_(TorchTensor target)
         {
             var res = THSTensor_ne_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2945,9 +3416,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ne_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ne_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Ne(TorchScalar target)
+        public TorchTensor ne(TorchScalar target)
         {
             var res = THSTensor_ne_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2955,9 +3426,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_ne_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_ne_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor NeInPlace(TorchScalar target)
+        public TorchTensor ne_(TorchScalar target)
         {
             var res = THSTensor_ne_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2965,9 +3436,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_dist(IntPtr tensor, IntPtr other, float p);
+        static extern IntPtr THSTensor_dist(IntPtr tensor, IntPtr other, float p);
 
-        public TorchTensor Dist(TorchTensor other, float p = 2.0f)
+        public TorchTensor dist(TorchTensor other, float p = 2.0f)
         {
             var res = THSTensor_dist(handle, other.Handle, p);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2975,9 +3446,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_norm(IntPtr tensor, float p);
+        static extern IntPtr THSTensor_norm(IntPtr tensor, float p);
 
-        public TorchTensor Norm(float p = 2.0f)
+        public TorchTensor norm(float p = 2.0f)
         {
             var res = THSTensor_norm(handle, p);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2985,9 +3456,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_norm_along_dimension(IntPtr tensor, int dimension, bool keepdim, float p);
+        static extern IntPtr THSTensor_norm_along_dimension(IntPtr tensor, int dimension, bool keepdim, float p);
 
-        public TorchTensor Norm(int dimension, bool keepdim = false, float p = 2.0f)
+        public TorchTensor norm(int dimension, bool keepdim = false, float p = 2.0f)
         {
             var res = THSTensor_norm_along_dimension(handle, dimension, keepdim, p);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -2995,9 +3466,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_pow(IntPtr tensor, IntPtr exponent);
+        static extern IntPtr THSTensor_pow(IntPtr tensor, IntPtr exponent);
 
-        public TorchTensor Pow(TorchTensor exponent)
+        public TorchTensor pow(TorchTensor exponent)
         {
             var res = THSTensor_pow(handle, exponent.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3005,9 +3476,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_pow_(IntPtr tensor, IntPtr exponent);
+        static extern IntPtr THSTensor_pow_(IntPtr tensor, IntPtr exponent);
 
-        public TorchTensor PowInPlace(TorchTensor exponent)
+        public TorchTensor pow_(TorchTensor exponent)
         {
             var res = THSTensor_pow_(handle, exponent.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3015,9 +3486,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_pow_scalar(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_pow_scalar(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor Pow(TorchScalar scalar)
+        public TorchTensor pow(TorchScalar scalar)
         {
             var res = THSTensor_pow_scalar(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3025,9 +3496,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_pow_scalar_(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_pow_scalar_(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor PowInPlace(TorchScalar scalar)
+        public TorchTensor pow_(TorchScalar scalar)
         {
             var res = THSTensor_pow_scalar_(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3035,9 +3506,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_prelu(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_prelu(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Prelu(TorchTensor target)
+        public TorchTensor prelu(TorchTensor target)
         {
             var res = THSTensor_prelu(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3045,9 +3516,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_remainder(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_remainder(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Remainder(TorchTensor target)
+        public TorchTensor remainder(TorchTensor target)
         {
             var res = THSTensor_remainder(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3055,9 +3526,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_remainder_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_remainder_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor RemainderInPlace(TorchTensor target)
+        public TorchTensor remainder_(TorchTensor target)
         {
             var res = THSTensor_remainder_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3065,9 +3536,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_remainder_scalar(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_remainder_scalar(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor Remainder(TorchScalar scalar)
+        public TorchTensor remainder(TorchScalar scalar)
         {
             var res = THSTensor_remainder_scalar(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3076,9 +3547,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_remainder_scalar_(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_remainder_scalar_(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor RemainderInPlace(TorchScalar scalar)
+        public TorchTensor remainder_(TorchScalar scalar)
         {
             var res = THSTensor_remainder_scalar_(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3087,9 +3558,9 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_fmod(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_fmod(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Fmod(TorchTensor target)
+        public TorchTensor fmod(TorchTensor target)
         {
             var res = THSTensor_fmod(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3097,9 +3568,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_fmod_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_fmod_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor FmodInPlace(TorchTensor target)
+        public TorchTensor fmod_(TorchTensor target)
         {
             var res = THSTensor_fmod_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3107,9 +3578,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_fmod_scalar(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_fmod_scalar(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor Fmod(TorchScalar scalar)
+        public TorchTensor fmod(TorchScalar scalar)
         {
             var res = THSTensor_fmod_scalar(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3117,9 +3588,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_fmod_scalar_(IntPtr tensor, IntPtr scalar);
+        static extern IntPtr THSTensor_fmod_scalar_(IntPtr tensor, IntPtr scalar);
 
-        public TorchTensor FmodInPlace(TorchScalar scalar)
+        public TorchTensor fmod_(TorchScalar scalar)
         {
             var res = THSTensor_fmod_scalar_(handle, scalar.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3127,9 +3598,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_renorm(IntPtr tensor, float p, long dim, float maxnorm);
+        static extern IntPtr THSTensor_renorm(IntPtr tensor, float p, long dim, float maxnorm);
 
-        public TorchTensor Renorm(TorchScalar scalar, float p, long dim, float maxnorm)
+        public TorchTensor renorm(TorchScalar scalar, float p, long dim, float maxnorm)
         {
             var res = THSTensor_renorm(handle, p, dim, maxnorm);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3137,9 +3608,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sigmoid(IntPtr tensor);
+        static extern IntPtr THSTensor_sigmoid(IntPtr tensor);
 
-        public TorchTensor Sigmoid()
+        public TorchTensor sigmoid()
         {
             var res = THSTensor_sigmoid(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3147,9 +3618,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sigmoid_(IntPtr tensor);
+        static extern IntPtr THSTensor_sigmoid_(IntPtr tensor);
 
-        public TorchTensor SigmoidInPlace()
+        public TorchTensor sigmoid_()
         {
             var res = THSTensor_sigmoid_(handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3157,9 +3628,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sub(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_sub(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Sub(TorchTensor target)
+        public TorchTensor sub(TorchTensor target)
         {
             var res = THSTensor_sub(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3167,9 +3638,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sub_scalar(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_sub_scalar(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor Sub(TorchScalar target)
+        public TorchTensor sub(TorchScalar target)
         {
             var res = THSTensor_sub_scalar(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3177,9 +3648,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sub_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_sub_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor SubInPlace(TorchTensor target)
+        public TorchTensor sub_(TorchTensor target)
         {
             var res = THSTensor_sub_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3187,9 +3658,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sub_scalar_(IntPtr tensor, IntPtr trg);
+        static extern IntPtr THSTensor_sub_scalar_(IntPtr tensor, IntPtr trg);
 
-        public TorchTensor SubInPlace(TorchScalar target)
+        public TorchTensor sub_(TorchScalar target)
         {
             var res = THSTensor_sub_scalar_(handle, target.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3197,12 +3668,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sum(IntPtr tensor, bool has_type, sbyte scalar_type);
+        static extern IntPtr THSTensor_sum(IntPtr tensor, bool has_type, sbyte scalar_type);
 
         /// <summary>
         /// Returns the sum of all elements in the :attr:`input` tensor.
         /// </summary>
-        public TorchTensor Sum(ScalarType? type = null)
+        public TorchTensor sum(ScalarType? type = null)
         {
             var res = THSTensor_sum(handle, type.HasValue, (sbyte)type.GetValueOrDefault());
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3210,12 +3681,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_sum_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
+        static extern IntPtr THSTensor_sum_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
 
         /// <summary>
         ///  Returns the sum of each row of the input tensor in the given dimensions.
         /// </summary>
-        public TorchTensor Sum(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
+        public TorchTensor sum(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
         {
             unsafe
             {
@@ -3229,9 +3700,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bernoulli(IntPtr tensor, double p);
+        static extern IntPtr THSTensor_bernoulli(IntPtr tensor, double p);
 
-        public TorchTensor Bernoulli(double p)
+        public TorchTensor bernoulli(double p)
         {
             var res = THSTensor_bernoulli(handle, p);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3239,9 +3710,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_bernoulli_(IntPtr tensor, double p);
+        static extern IntPtr THSTensor_bernoulli_(IntPtr tensor, double p);
 
-        public TorchTensor BernoulliInPlace(double p)
+        public TorchTensor bernoulli_(double p)
         {
             var res = THSTensor_bernoulli_(handle, p);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3249,9 +3720,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_cauchy_(IntPtr tensor, double median, double sigma);
+        static extern IntPtr THSTensor_cauchy_(IntPtr tensor, double median, double sigma);
 
-        public TorchTensor CauchyInPlace(double median = 0.0, double sigma = 1.0)
+        public TorchTensor cauchy_(double median = 0.0, double sigma = 1.0)
         {
             var res = THSTensor_cauchy_(handle, median, sigma);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3259,9 +3730,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_exponential_(IntPtr tensor, double lambd);
+        static extern IntPtr THSTensor_exponential_(IntPtr tensor, double lambd);
 
-        public TorchTensor ExponentialInPlace(double lambd = 1.0)
+        public TorchTensor exponential_(double lambd = 1.0)
         {
             var res = THSTensor_exponential_(handle, lambd);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3269,45 +3740,45 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_geometric_(IntPtr tensor, double p);
+        static extern IntPtr THSTensor_geometric_(IntPtr tensor, double p);
 
-        public TorchTensor GeometricInPlace(double p)
+        public TorchTensor geometric_(double p)
         {
             var res = THSTensor_geometric_(handle, p);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(res);
         }
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_log_normal_(IntPtr tensor, double mean, double std);
+        static extern IntPtr THSTensor_log_normal_(IntPtr tensor, double mean, double std);
 
-        public TorchTensor LogNormalInPlace(double mean = 1.0, double std = 2.0)
+        public TorchTensor log_normal_(double mean = 1.0, double std = 2.0)
         {
             var res = THSTensor_log_normal_(handle, mean, std);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(res);
         }
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_normal_(IntPtr tensor, double mean, double std);
+        static extern IntPtr THSTensor_normal_(IntPtr tensor, double mean, double std);
 
-        public TorchTensor NormalInPlace(double mean = 0.0, double std = 1.0)
+        public TorchTensor normal_(double mean = 0.0, double std = 1.0)
         {
             var res = THSTensor_normal_(handle, mean, std);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(res);
         }
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_uniform_(IntPtr tensor, double from, double to);
+        static extern IntPtr THSTensor_uniform_(IntPtr tensor, double from, double to);
 
-        public TorchTensor UniformInPlace(double from = 0.0, double to = 1.0)
+        public TorchTensor uniform_(double from = 0.0, double to = 1.0)
         {
             var res = THSTensor_uniform_(handle, from, to);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(res);
         }
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_multinomial(IntPtr tensor, double num_samples, bool replacement);
+        static extern IntPtr THSTensor_multinomial(IntPtr tensor, double num_samples, bool replacement);
 
-        public TorchTensor Multinomial(double num_samples, bool replacement = false)
+        public TorchTensor multinomial(double num_samples, bool replacement = false)
         {
             var res = THSTensor_multinomial(handle, num_samples, replacement);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3320,7 +3791,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Returns a new view of the tensor with singleton dimensions expanded to a larger size.
         /// </summary>
-        public TorchTensor Expand(long[] sizes, bool isImplicit = false)
+        public TorchTensor expand(long[] sizes, bool isImplicit = false)
         {
             unsafe
             {
@@ -3339,7 +3810,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to be filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        public TorchTensor RandomNInPlace(long[] sizes)
+        public TorchTensor randn_out(long[] sizes)
         {
             unsafe {
                 fixed (long* psizes = sizes) {
@@ -3356,7 +3827,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to be filled with random values taken from a uniform distribution in [0, 1).
         /// </summary>
-        public TorchTensor RandInPlace(long[] sizes)
+        public TorchTensor rand_out(long[] sizes)
         {
             unsafe {
                 fixed (long* psizes = sizes) {
@@ -3372,7 +3843,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to be filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        public TorchTensor RandomIntegersInPlace(long high, long[] sizes)
+        public TorchTensor randint_out(long high, long[] sizes)
         {
             unsafe {
                 fixed (long* psizes = sizes) {
@@ -3388,7 +3859,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to be a 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        public TorchTensor RandomPermutationInPlace(long n)
+        public TorchTensor randperm_out(long n)
         {
             var res = THSTensor_randperm_out(n, handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3402,7 +3873,7 @@ namespace TorchSharp.Tensor
         ///  Mutates the tensor to be filled with with values from interval [start, end) and
 		/// common difference step, starting from start.
         /// </summary>
-        public TorchTensor ArangeInPlace(TorchScalar start, TorchScalar stop, TorchScalar step)
+        public TorchTensor arange_out(TorchScalar start, TorchScalar stop, TorchScalar step)
         {
             var res = THSTensor_arange_out(start.Handle, stop.Handle, step.Handle, handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3415,7 +3886,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to have the given size with all values set to 1
         /// </summary>
-        public TorchTensor Permute(long[] permutation)
+        public TorchTensor permute(long[] permutation)
         {
             unsafe {
                 fixed (long* pPermutation = permutation) {
@@ -3432,7 +3903,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to have the given size with all values set to 1
         /// </summary>
-        public TorchTensor OnesInPlace(long[] sizes)
+        public TorchTensor ones_out(long[] sizes)
         {
             unsafe {
                 fixed (long* psizes = sizes) {
@@ -3449,7 +3920,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Mutates the tensor to have the given size with all values set to 0
         /// </summary>
-        public TorchTensor ZerosInPlace(long[] sizes)
+        public TorchTensor zeros_out(long[] sizes)
         {
             unsafe {
                 fixed (long* psizes = sizes) {
@@ -3468,7 +3939,7 @@ namespace TorchSharp.Tensor
         ///  value in src, its output index is specified by its index in src for dimension != dim and by the #
         ///  corresponding value in index for dimension = dim.
         /// </summary>
-        public TorchTensor Scatter(long dimension, TorchTensor index, TorchTensor src)
+        public TorchTensor scatter(long dimension, TorchTensor index, TorchTensor src)
         {
             var res = THSTensor_scatter(handle, dimension, index.Handle, src.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3481,7 +3952,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         /// Gathers values along an axis specified by dim.
         /// </summary>
-        public TorchTensor Gather(long dimension, TorchTensor index)
+        public TorchTensor gather(long dimension, TorchTensor index)
         {
             var res = THSTensor_gather(handle, dimension, index.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3494,7 +3965,7 @@ namespace TorchSharp.Tensor
         /// <summary>
         ///  Reverse the order of a n-D tensor along given axis in dims.
         /// </summary>
-        public TorchTensor Flip(long[] sizes)
+        public TorchTensor flip(long[] sizes)
         {
             unsafe
             {
@@ -3515,7 +3986,7 @@ namespace TorchSharp.Tensor
         /// dimension is input from start to start + length. The
         /// returned tensor and the input tensor share the same underlying storage.
         /// </summary>
-        public TorchTensor Narrow(long dimension, long start, long length)
+        public TorchTensor narrow(long dimension, long start, long length)
         {
             var res = THSTensor_narrow(handle, dimension, start, length);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -3530,24 +4001,50 @@ namespace TorchSharp.Tensor
         /// dimension is input from start to finish-1. The
         /// returned tensor and the input tensor share the same underlying storage.
         /// </summary>
-        public TorchTensor Slice(long dimension, long start, long finish, long step)
+        public TorchTensor slice(long dimension, long start, long finish, long step)
         {
             var res = THSTensor_slice(handle, dimension, start, finish, step);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor(res);
         }
 
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_unsqueeze(IntPtr tensor, long dimension);
+        /// <summary>
+        ///  Returns a new tensor with a dimension of size one inserted at the specified position.
+        ///  The returned tensor shares the same underlying data with this tensor.
+        /// </summary>
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_conv1d(IntPtr input, IntPtr weight, IntPtr bias,
+        static extern IntPtr THSTensor_unsqueeze(IntPtr tensor, long dimension);
+
+        public TorchTensor unsqueeze(long dimension)
+        {
+            var res = THSTensor_unsqueeze(handle, dimension);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_einsum([MarshalAs(UnmanagedType.LPStr)] string location, IntPtr tensors, int len);
+
+        public static TorchTensor einsum(string equation, params TorchTensor[] tensors)
+        {
+            using (var parray = new PinnedArray<IntPtr>()) {
+                IntPtr tensorsRef = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());
+
+                var res = THSTensor_einsum(equation, tensorsRef, parray.Array.Length);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_conv1d(IntPtr input, IntPtr weight, IntPtr bias,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 long groups);
 
-        public TorchTensor Conv1D(TorchTensor weight, TorchTensor? bias = null, 
+        public TorchTensor conv1d(TorchTensor weight, TorchTensor? bias = null, 
             long? stride = null,
             long? padding = null,
             long? dilation = null,
@@ -3575,13 +4072,13 @@ namespace TorchSharp.Tensor
 
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_conv2d(IntPtr input, IntPtr weight, IntPtr bias,
+        static extern IntPtr THSTensor_conv2d(IntPtr input, IntPtr weight, IntPtr bias,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 long groups);
 
-        public TorchTensor Conv2D(TorchTensor weight, TorchTensor? bias = null,
+        public TorchTensor conv2d(TorchTensor weight, TorchTensor? bias = null,
             long[]? strides = null,
             long[]? padding = null,
             long[]? dilation = null,
@@ -3608,13 +4105,13 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_conv3d(IntPtr input, IntPtr weight, IntPtr bias,
+        static extern IntPtr THSTensor_conv3d(IntPtr input, IntPtr weight, IntPtr bias,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 long groups);
 
-        public TorchTensor Conv3D(TorchTensor weight, TorchTensor? bias = null,
+        public TorchTensor conv3d(TorchTensor weight, TorchTensor? bias = null,
             long[]? strides = null,
             long[]? padding = null,
             long[]? dilation = null,
@@ -3641,14 +4138,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_conv_transpose1d(IntPtr input, IntPtr weight, IntPtr bias,
+        static extern IntPtr THSTensor_conv_transpose1d(IntPtr input, IntPtr weight, IntPtr bias,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr outputPadding, int outputPaddingLength,
                 IntPtr dilation, int dilationLength,
                 long groups);
 
-        public TorchTensor ConvTranspose1D(TorchTensor weight, TorchTensor? bias = null,
+        public TorchTensor conv_transpose1d(TorchTensor weight, TorchTensor? bias = null,
             long? stride = null,
             long? padding = null,
             long? outputPadding = null,
@@ -3678,14 +4175,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_conv_transpose2d(IntPtr input, IntPtr weight, IntPtr bias,
+        static extern IntPtr THSTensor_conv_transpose2d(IntPtr input, IntPtr weight, IntPtr bias,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr outputPadding, int outputPaddingLength,
                 IntPtr dilation, int dilationLength,
                 long groups);
 
-        public TorchTensor ConvTranspose2D(TorchTensor weight, TorchTensor? bias = null,
+        public TorchTensor conv_transpose2d(TorchTensor weight, TorchTensor? bias = null,
             long[]? strides = null,
             long[]? padding = null,
             long[]? outputPadding = null,
@@ -3715,14 +4212,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_conv_transpose3d(IntPtr input, IntPtr weight, IntPtr bias,
+        static extern IntPtr THSTensor_conv_transpose3d(IntPtr input, IntPtr weight, IntPtr bias,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr outputPadding, int outputPaddingLength,
                 IntPtr dilation, int dilationLength,
                 long groups);
 
-        public TorchTensor ConvTranspose3D(TorchTensor weight, TorchTensor? bias = null,
+        public TorchTensor conv_transpose3d(TorchTensor weight, TorchTensor? bias = null,
             long[]? strides = null,
             long[]? padding = null,
             long[]? outputPadding = null,
@@ -3752,14 +4249,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_max_pool1d(IntPtr input,
+        static extern IntPtr THSTensor_max_pool1d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 bool ceil_mode);
 
-        public TorchTensor MaxPool1D(long kernelSize, long? stride = null,
+        public TorchTensor max_pool1d(long kernelSize, long? stride = null,
             long? padding = null, long? dilation = null, bool ceil_mode = false)
         {
             var kernelSizes = new long[] { kernelSize };
@@ -3784,14 +4281,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_max_pool1d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+        static extern void THSTensor_max_pool1d_with_indices(IntPtr input, AllocatePinnedArray allocator,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 bool ceil_mode);
 
-        public (TorchTensor output, TorchTensor indices) MaxPool1DWithIndices(long kernelSize, long? stride = null,
+        public (TorchTensor output, TorchTensor indices) max_pool1d_with_indices(long kernelSize, long? stride = null,
             long? padding = null, long? dilation = null, bool ceil_mode = false)
         {
             var kernelSizes = new long[] { kernelSize };
@@ -3819,14 +4316,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_max_pool2d(IntPtr input,
+        static extern IntPtr THSTensor_max_pool2d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 bool ceil_mode);
 
-        public TorchTensor MaxPool2D(long[] kernelSize, long[]? strides = null,
+        public TorchTensor max_pool2d(long[] kernelSize, long[]? strides = null,
             long[]? padding = null, long[]? dilation = null, bool ceil_mode = false)
         {
             strides = strides ?? kernelSize.Select(x => 1L).ToArray();
@@ -3850,14 +4347,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_max_pool2d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+        static extern void THSTensor_max_pool2d_with_indices(IntPtr input, AllocatePinnedArray allocator,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 bool ceil_mode);
 
-        public (TorchTensor output, TorchTensor indices) MaxPool2DWithIndices(long[] kernelSize, long[]? strides = null,
+        public (TorchTensor output, TorchTensor indices) max_pool2d_with_indices(long[] kernelSize, long[]? strides = null,
             long[]? padding = null, long[]? dilation = null, bool ceil_mode = false)
         {
             strides = strides ?? kernelSize.Select(x => 1L).ToArray();
@@ -3884,14 +4381,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_max_pool3d(IntPtr input,
+        static extern IntPtr THSTensor_max_pool3d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 bool ceil_mode);
 
-        public TorchTensor MaxPool3D(long[] kernelSize, long[]? strides = null,
+        public TorchTensor max_pool3d(long[] kernelSize, long[]? strides = null,
             long[]? padding = null, long[]? dilation = null, bool ceil_mode = false)
         {
             strides = strides ?? kernelSize.Select(x => 1L).ToArray();
@@ -3915,14 +4412,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern void THSTensor_max_pool3d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+        static extern void THSTensor_max_pool3d_with_indices(IntPtr input, AllocatePinnedArray allocator,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 IntPtr dilation, int dilationLength,
                 bool ceil_mode);
 
-        public (TorchTensor output, TorchTensor indices) MaxPool3DWithIndices(long[] kernelSize, long[]? strides = null,
+        public (TorchTensor output, TorchTensor indices) max_pool3d_with_indices(long[] kernelSize, long[]? strides = null,
             long[]? padding = null, long[]? dilation = null, bool ceil_mode = false)
         {
             strides = strides ?? kernelSize.Select(x => 1L).ToArray();
@@ -3949,9 +4446,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_maxunpool2d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength);
+        static extern IntPtr THSTensor_maxunpool2d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength);
 
-        public TorchTensor MaxUnpool2D(TorchTensor indices, long[] outputSize)
+        public TorchTensor maxunpool2d(TorchTensor indices, long[] outputSize)
         {
             unsafe {
                 fixed (long* poutputSize = outputSize) {
@@ -3964,10 +4461,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_maxunpool3d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength, IntPtr strides, int stridesLength,
+        static extern IntPtr THSTensor_maxunpool3d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength, IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength);
 
-        public TorchTensor MaxUnpool3D(TorchTensor indices, long[] outputSize, long[] strides, long[] padding)
+        public TorchTensor maxunpool3d(TorchTensor indices, long[] outputSize, long[] strides, long[] padding)
         {
             unsafe {
                 fixed (long* poutputSize = outputSize, pstrides = strides, ppadding = padding) {
@@ -3982,14 +4479,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_avg_pool1d(IntPtr input,
+        static extern IntPtr THSTensor_avg_pool1d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 bool ceil_mode,
                 bool count_include_pad);
 
-        public TorchTensor AvgPool1D(long kernelSize, long? stride = null,
+        public TorchTensor avg_pool1d(long kernelSize, long? stride = null,
             long? padding = null, bool ceil_mode = false, bool count_include_pad = true)
         {
             var kernelSizes = new long[] { kernelSize };
@@ -4011,14 +4508,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_avg_pool2d(IntPtr input,
+        static extern IntPtr THSTensor_avg_pool2d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 bool ceil_mode,
                 bool count_include_pad);
 
-        public TorchTensor AvgPool2D(long[] kernelSizes,
+        public TorchTensor avg_pool2d(long[] kernelSizes,
             long[]? strides = null,
             long[]? paddings = null,
             bool ceil_mode = false,
@@ -4042,14 +4539,14 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_avg_pool3d(IntPtr input,
+        static extern IntPtr THSTensor_avg_pool3d(IntPtr input,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
                 bool ceil_mode,
                 bool count_include_pad);
 
-        public TorchTensor AvgPool3D(long[] kernelSizes,
+        public TorchTensor avg_pool3d(long[] kernelSizes,
             long[]? strides = null,
             long[]? paddings = null,
             bool ceil_mode = false,
@@ -4073,7 +4570,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_avg_pool2d_backward(IntPtr gradOutput, IntPtr originalInput,
+        static extern IntPtr THSTensor_avg_pool2d_backward(IntPtr gradOutput, IntPtr originalInput,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
@@ -4081,7 +4578,7 @@ namespace TorchSharp.Tensor
                 bool count_include_pad,
                 long divisorOverride);
 
-        public TorchTensor AvgPool2DBackward(TorchTensor originalInput,
+        public TorchTensor avg_pool2d_backward(TorchTensor originalInput,
             long[] kernelSizes,
             long[]? strides = null,
             long[]? paddings = null,
@@ -4108,7 +4605,7 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_avg_pool3d_backward(IntPtr gradOutput, IntPtr originalInput,
+        static extern IntPtr THSTensor_avg_pool3d_backward(IntPtr gradOutput, IntPtr originalInput,
                 IntPtr kernelSize, int kernelSizeLength,
                 IntPtr strides, int stridesLength,
                 IntPtr padding, int paddingLength,
@@ -4116,7 +4613,7 @@ namespace TorchSharp.Tensor
                 bool count_include_pad,
                 long divisorOverride);
 
-        public TorchTensor AvgPool3DBackward(TorchTensor originalInput,
+        public TorchTensor avg_pool3d_backward(TorchTensor originalInput,
             long[] kernelSizes,
             long[]? strides = null,
             long[]? paddings = null,
@@ -4143,10 +4640,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_adaptive_avg_pool1d(IntPtr input,
+        static extern IntPtr THSTensor_adaptive_avg_pool1d(IntPtr input,
                 IntPtr outputSize, int outputSizeLength);
 
-        public TorchTensor AdaptiveAvgPool1D(long outputSize)
+        public TorchTensor adaptive_avg_pool1d(long outputSize)
         {
             var outputSizes = new long[] { outputSize };
             unsafe {
@@ -4160,10 +4657,10 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_adaptive_avg_pool2d(IntPtr input,
+        static extern IntPtr THSTensor_adaptive_avg_pool2d(IntPtr input,
                 IntPtr outputSize, int outputSizeLength);
 
-        public TorchTensor AdaptiveAvgPool2D(long[] outputSizes)
+        public TorchTensor adaptive_avg_pool2d(long[] outputSizes)
         {
             unsafe {
                 fixed (long* poutputSize = outputSizes) {
@@ -4176,9 +4673,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_adaptive_avg_pool3d(IntPtr input, IntPtr outputSize, int outputSizeLength);
+        static extern IntPtr THSTensor_adaptive_avg_pool3d(IntPtr input, IntPtr outputSize, int outputSizeLength);
 
-        public TorchTensor AdaptiveAvgPool3D(long[] outputSizes)
+        public TorchTensor adaptive_avg_pool3d(long[] outputSizes)
         {
             unsafe {
                 fixed (long* poutputSize = outputSizes) {
@@ -4191,9 +4688,9 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_adaptive_avg_pool3d_backward(IntPtr gradOutput, IntPtr originalInput);
+        static extern IntPtr THSTensor_adaptive_avg_pool3d_backward(IntPtr gradOutput, IntPtr originalInput);
 
-        public TorchTensor AdaptiveAvgPool3DBackward(TorchTensor originalInput)
+        public TorchTensor adaptive_avg_pool3d_backward(TorchTensor originalInput)
         {
             var res = THSTensor_adaptive_avg_pool3d_backward(handle, originalInput.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -4201,11 +4698,11 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_upsample_nearest1d(IntPtr input,
+        static extern IntPtr THSTensor_upsample_nearest1d(IntPtr input,
                 IntPtr outputSize, int outputSizeLength,
                 IntPtr scaleFactors, int scaleFactorsLength);
 
-        public TorchTensor UpSampleNearest1D(long? outputSize, double? scaleFactor)
+        public TorchTensor upsample_nearest1d(long? outputSize, double? scaleFactor)
         {
             var outputSizes = outputSize.HasValue ? new long[] { outputSize.Value } : null;
             var outputSizesLength = outputSize.HasValue ? 1 : 0;
@@ -4226,12 +4723,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_upsample_nearest1d_backward(IntPtr grad_output,
+        static extern IntPtr THSTensor_upsample_nearest1d_backward(IntPtr grad_output,
                 IntPtr outputSize, int outputSizeLength,
                 IntPtr inputSize, int inputSizeLength,
                 IntPtr scaleFactors, int scaleFactorsLength);
 
-        public TorchTensor UpSampleNearest1DBackward(long? outputSize, long inputSize, double? scaleFactor)
+        public TorchTensor upsample_nearest1d_backward(long? outputSize, long inputSize, double? scaleFactor)
         {
             var outputSizes = outputSize.HasValue ? new long[] { outputSize.Value } : null;
             var outputSizesLength = outputSize.HasValue ? 1 : 0;
@@ -4254,11 +4751,11 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_upsample_nearest2d(IntPtr input,
+        static extern IntPtr THSTensor_upsample_nearest2d(IntPtr input,
                 IntPtr outputSize, int outputSizeLength,
                 IntPtr scaleFactors, int scaleFactorsLength);
 
-        public TorchTensor UpSampleNearest2D(long[]? outputSizes = null, double[]? scaleFactors = null)
+        public TorchTensor upsample_nearest2d(long[]? outputSizes = null, double[]? scaleFactors = null)
         {
             var outputSizesLength = outputSizes == null ?  0 : outputSizes.Length;
             var scaleFactorsLength = scaleFactors == null ? 0 : scaleFactors.Length;
@@ -4277,12 +4774,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_upsample_nearest2d_backward(IntPtr grad_output,
+        static extern IntPtr THSTensor_upsample_nearest2d_backward(IntPtr grad_output,
                 IntPtr outputSize, int outputSizeLength,
                 IntPtr inputSize, int inputSizeLength,
                 IntPtr scaleFactors, int scaleFactorsLength);
 
-        public TorchTensor UpSampleNearest2DBackward(long[] inputSizes, long[]? outputSizes = null, double[]? scaleFactors = null)
+        public TorchTensor upsample_nearest2d_backward(long[] inputSizes, long[]? outputSizes = null, double[]? scaleFactors = null)
         {
             var outputSizesLength = outputSizes == null ? 0 : outputSizes.Length;
             var scaleFactorsLength = scaleFactors == null ? 0 : scaleFactors.Length;
@@ -4302,12 +4799,12 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_upsample_nearest3d_backward(IntPtr grad_output,
+        static extern IntPtr THSTensor_upsample_nearest3d_backward(IntPtr grad_output,
                 IntPtr outputSize, int outputSizeLength,
                 IntPtr inputSize, int inputSizeLength,
                 IntPtr scaleFactors, int scaleFactorsLength);
 
-        public TorchTensor UpSampleNearest3DBackward(long[] inputSizes, long[]? outputSizes = null, double[]? scaleFactors = null)
+        public TorchTensor upsample_nearest3d_backward(long[] inputSizes, long[]? outputSizes = null, double[]? scaleFactors = null)
         {
             var outputSizesLength = outputSizes == null ? 0 : outputSizes.Length;
             var scaleFactorsLength = scaleFactors == null ? 0 : scaleFactors.Length;
@@ -4327,11 +4824,11 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSTensor_upsample_nearest3d(IntPtr input,
+        static extern IntPtr THSTensor_upsample_nearest3d(IntPtr input,
                 IntPtr outputSize, int outputSizeLength,
                 IntPtr scaleFactors, int scaleFactorsLength);
 
-        public TorchTensor UpSampleNearest3D(long[]? outputSizes = null, double[]? scaleFactors = null)
+        public TorchTensor upsample_nearest3d(long[]? outputSizes = null, double[]? scaleFactors = null)
         {
             var outputSizesLength = outputSizes == null ? 0 : outputSizes.Length;
             var scaleFactorsLength = scaleFactors == null ? 0 : scaleFactors.Length;
@@ -4350,168 +4847,156 @@ namespace TorchSharp.Tensor
         }
 
 
-        /// <summary>
-        ///  Returns a new tensor with a dimension of size one inserted at the specified position.
-        ///  The returned tensor shares the same underlying data with this tensor.
-        /// </summary>
-
-        public TorchTensor Unsqueeze(long dimension)
-        {
-            var res = THSTensor_unsqueeze(handle, dimension);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
         // Operators overloading
 
         public static TorchTensor operator ==(TorchTensor left, TorchTensor right)
         {
-            return left.Eq(right);
+            return left.eq(right);
         }
 
         public static TorchTensor operator ==(TorchTensor left, TorchScalar right)
         {
-            return left.Eq(right);
+            return left.eq(right);
         }
 
         public static TorchTensor operator ==(TorchScalar left, TorchTensor right)
         {
-            return right.Eq(left);
+            return right.eq(left);
         }
 
         public static TorchTensor operator !=(TorchTensor left, TorchTensor right)
         {
-            return left.Ne(right);
+            return left.ne(right);
         }
 
         public static TorchTensor operator !=(TorchTensor left, TorchScalar right)
         {
-            return left.Ne(right);
+            return left.ne(right);
         }
 
         public static TorchTensor operator !=(TorchScalar left, TorchTensor right)
         {
-            return right.Ne(left);
+            return right.ne(left);
         }
 
         public static TorchTensor operator +(TorchTensor left, TorchTensor right)
         {
-            return left.Add(right);
+            return left.add(right);
         }
 
         public static TorchTensor operator +(TorchTensor left, TorchScalar right)
         {
-            return left.Add(right);
+            return left.add(right);
         }
 
         public static TorchTensor operator +(TorchScalar left, TorchTensor right)
         {
-            return right.Add(left);
+            return right.add(left);
         }
 
         public static TorchTensor operator *(TorchTensor left, TorchTensor right)
         {
-            return left.Mul(right);
+            return left.mul(right);
         }
 
         public static TorchTensor operator *(TorchTensor left, TorchScalar right)
         {
-            return left.Mul(right);
+            return left.mul(right);
         }
 
         public static TorchTensor operator *(TorchScalar left, TorchTensor right)
         {
-            return right.Mul(left);
+            return right.mul(left);
         }
 
         public static TorchTensor operator -(TorchTensor left, TorchTensor right)
         {
-            return left.Sub(right);
+            return left.sub(right);
         }
 
         public static TorchTensor operator -(TorchTensor left, TorchScalar right)
         {
-            return left.Sub(right);
+            return left.sub(right);
         }
 
         public static TorchTensor operator /(TorchTensor left, TorchTensor right)
         {
-            return left.Div(right);
+            return left.div(right);
         }
 
         public static TorchTensor operator /(TorchTensor left, TorchScalar right)
         {
-            return left.Div(right);
+            return left.div(right);
         }
 
         public static TorchTensor operator %(TorchTensor left, TorchTensor right)
         {
-            return left.Remainder(right);
+            return left.remainder(right);
         }
 
         public static TorchTensor operator %(TorchTensor left, TorchScalar right)
         {
-            return left.Remainder(right);
+            return left.remainder(right);
         }
 
         public static TorchTensor operator <(TorchTensor left, TorchTensor right)
         {
-            return left.Lt(right);
+            return left.lt(right);
         }
 
         public static TorchTensor operator <(TorchTensor left, TorchScalar right)
         {
-            return left.Lt(right);
+            return left.lt(right);
         }
 
         public static TorchTensor operator <(TorchScalar left, TorchTensor right)
         {
-            return right.Gt(left);
+            return right.gt(left);
         }
 
         public static TorchTensor operator <=(TorchTensor left, TorchTensor right)
         {
-            return left.Le(right);
+            return left.le(right);
         }
 
         public static TorchTensor operator <=(TorchTensor left, TorchScalar right)
         {
-            return left.Le(right);
+            return left.le(right);
         }
 
         public static TorchTensor operator <=(TorchScalar left, TorchTensor right)
         {
-            return right.Ge(left);
+            return right.ge(left);
         }
 
         public static TorchTensor operator >(TorchTensor left, TorchTensor right)
         {
-            return left.Gt(right);
+            return left.gt(right);
         }
 
         public static TorchTensor operator >(TorchTensor left, TorchScalar right)
         {
-            return left.Gt(right);
+            return left.gt(right);
         }
 
         public static TorchTensor operator >(TorchScalar left, TorchTensor right)
         {
-            return right.Lt(left);
+            return right.lt(left);
         }
 
         public static TorchTensor operator >=(TorchTensor left, TorchTensor right)
         {
-            return left.Ge(right);
+            return left.ge(right);
         }
 
         public static TorchTensor operator >=(TorchTensor left, TorchScalar right)
         {
-            return left.Ge(right);
+            return left.ge(right);
         }
 
         public static TorchTensor operator >=(TorchScalar left, TorchTensor right)
         {
-            return right.Le(left);
+            return right.le(left);
         }
 
         /// <summary>
@@ -4528,13 +5013,13 @@ namespace TorchSharp.Tensor
             var sb = new StringBuilder("[");
             for (var i = 0; i < n; i++)
             {
-                sb.Append(GetTensorDimension(i));
+                sb.Append(size(i));
                 if (i + 1 < n)
                     sb.Append("x");
             }
 
             sb.Append("]");
-            sb.Append($", device = {DeviceString}");
+            sb.Append($", device = {device}");
             return sb.ToString();
         }
 
@@ -4640,17 +5125,15 @@ namespace TorchSharp.Tensor
             throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
         }
 
+
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_cat(IntPtr tensor, int len, long dim);
-
-        public static TorchTensor Cat(this TorchTensor[] tensors, long dimension)
+        public static TorchTensor cat(this TorchTensor[] tensors, long dimension)
         {
-            if (tensors.Length == 0)
-            {
+            if (tensors.Length == 0) {
                 throw new ArgumentException(nameof(tensors));
             }
-            if (tensors.Length == 1)
-            {
+            if (tensors.Length == 1) {
                 return tensors[0];
             }
 
@@ -4664,26 +5147,12 @@ namespace TorchSharp.Tensor
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_stack(IntPtr tensor, int len, long dim);
 
-        public static TorchTensor Stack(this TorchTensor[] tensors, long dimension)
+        public static TorchTensor stack(this TorchTensor[] tensors, long dimension)
         {
             using (var parray = new PinnedArray<IntPtr>()) {
                 IntPtr tensorsRef = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());
 
                 var res = THSTensor_stack(tensorsRef, parray.Array.Length, dimension);
-                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new TorchTensor(res);
-            }
-        }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_einsum([MarshalAs(UnmanagedType.LPStr)] string location, IntPtr tensors, int len);
-
-        public static TorchTensor Einsum(string equation, params TorchTensor[] tensors)
-        {
-            using (var parray = new PinnedArray<IntPtr>()) {
-                IntPtr tensorsRef = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());
-
-                var res = THSTensor_einsum(equation, tensorsRef, parray.Array.Length);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(res);
             }

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -28,7 +28,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -48,7 +48,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -68,7 +68,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -94,7 +94,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -120,7 +120,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -146,7 +146,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -169,7 +169,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newByteScalar(byte scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(byte scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(byte scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newByteScalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -180,7 +180,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(byte[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(byte[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -206,15 +206,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(byte[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(byte[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -254,7 +254,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -274,7 +274,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -294,7 +294,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -320,7 +320,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -346,7 +346,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -372,7 +372,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -395,7 +395,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newInt8Scalar(sbyte scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(sbyte scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(sbyte scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newInt8Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -406,7 +406,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(sbyte[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(sbyte[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -432,15 +432,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(sbyte[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(sbyte[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -480,7 +480,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -500,7 +500,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -520,7 +520,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -546,7 +546,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -572,7 +572,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -598,7 +598,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -621,7 +621,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newInt16Scalar(short scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(short scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(short scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newInt16Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -632,7 +632,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(short[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(short[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -658,15 +658,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(short[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(short[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -706,7 +706,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -726,7 +726,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -746,7 +746,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -772,7 +772,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -798,7 +798,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -824,7 +824,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -847,7 +847,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newInt32Scalar(int scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(int scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(int scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newInt32Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -858,7 +858,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(int[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(int[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -884,15 +884,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(int[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(int[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -932,7 +932,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -952,7 +952,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -972,7 +972,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -998,7 +998,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1024,7 +1024,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1050,7 +1050,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1073,7 +1073,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newInt64Scalar(long scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(long scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(long scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newInt64Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -1084,7 +1084,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newInt64(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
 
-        public static TorchTensor From(long[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(long[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -1110,15 +1110,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(long[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(long[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1158,7 +1158,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1178,7 +1178,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1198,7 +1198,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1224,7 +1224,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1250,7 +1250,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1276,7 +1276,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1301,7 +1301,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
         /// </summary>
-        static public TorchTensor Random(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor rand(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1327,7 +1327,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        static public TorchTensor RandomN(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randn(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1350,7 +1350,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newFloat16Scalar(float scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newFloat16Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -1361,7 +1361,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newFloat16(IntPtr rawArray, IntPtr dataArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
 
-        public static TorchTensor From(float[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(float[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = new Int16[rawArray.Length];
             unsafe
@@ -1390,15 +1390,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(float[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(float[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1438,7 +1438,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1458,7 +1458,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1478,7 +1478,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1504,7 +1504,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1530,7 +1530,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1556,7 +1556,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1581,7 +1581,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
         /// </summary>
-        static public TorchTensor Random(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor rand(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1607,7 +1607,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        static public TorchTensor RandomN(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randn(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1630,7 +1630,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newBFloat16Scalar(float scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newBFloat16Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -1641,7 +1641,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newBFloat16(IntPtr rawArray, IntPtr dataArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, bool requiresGrad);
 
-        public static TorchTensor From(float[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(float[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = new Int16[rawArray.Length];
             unsafe
@@ -1670,15 +1670,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(float[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(float[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1718,7 +1718,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1738,7 +1738,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1758,7 +1758,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1784,7 +1784,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1810,7 +1810,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1836,7 +1836,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1861,7 +1861,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
         /// </summary>
-        static public TorchTensor Random(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor rand(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1887,7 +1887,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        static public TorchTensor RandomN(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randn(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1910,7 +1910,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newFloat32Scalar(float scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(float scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newFloat32Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -1921,7 +1921,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(float[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(float[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -1947,15 +1947,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(float[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(float[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -1995,7 +1995,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2015,7 +2015,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2035,7 +2035,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2061,7 +2061,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2087,7 +2087,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2113,7 +2113,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2138,7 +2138,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
         /// </summary>
-        static public TorchTensor Random(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor rand(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2164,7 +2164,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        static public TorchTensor RandomN(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randn(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2187,7 +2187,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newFloat64Scalar(double scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(double scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(double scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newFloat64Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -2198,7 +2198,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(double[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(double[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -2224,15 +2224,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(double[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(double[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2272,7 +2272,7 @@ namespace TorchSharp.Tensor {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2292,7 +2292,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2312,7 +2312,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2338,7 +2338,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2364,7 +2364,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2390,7 +2390,7 @@ namespace TorchSharp.Tensor {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -2413,7 +2413,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newBoolScalar(bool scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(bool scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(bool scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_newBoolScalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -2424,7 +2424,7 @@ namespace TorchSharp.Tensor {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 
-        public static TorchTensor From(bool[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(bool[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
             var dataArray = rawArray;
             unsafe
@@ -2450,15 +2450,15 @@ namespace TorchSharp.Tensor {
             }
         }
         
-        public static TorchTensor From(bool[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(bool[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -35,7 +35,7 @@ foreach (var type in TorchTypeDef.Types) {
         /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
 		/// common difference step, starting from start
         /// </summary>
-        static public TorchTensor Arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor arange(TorchScalar start, TorchScalar stop, TorchScalar step, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -55,7 +55,7 @@ foreach (var type in TorchTypeDef.Types) {
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
-        static public TorchTensor RandomPermutation(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randperm(long n, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -75,7 +75,7 @@ foreach (var type in TorchTypeDef.Types) {
         /// <summary>
         ///  Create a new tensor filled with zeros
         /// </summary>
-        static public TorchTensor Zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor zeros(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -101,7 +101,7 @@ foreach (var type in TorchTypeDef.Types) {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor ones(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -127,7 +127,7 @@ foreach (var type in TorchTypeDef.Types) {
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static public TorchTensor Empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor empty(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -153,7 +153,7 @@ foreach (var type in TorchTypeDef.Types) {
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
         /// </summary>
-        static public TorchTensor RandomIntegers(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randint(long max, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -181,7 +181,7 @@ if (type.IsFloatingPoint) {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a uniform distribution in [0, 1).
         /// </summary>
-        static public TorchTensor Random(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor rand(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -207,7 +207,7 @@ if (type.IsFloatingPoint) {
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
         /// </summary>
-        static public TorchTensor RandomN(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        static public TorchTensor randn(long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 
@@ -231,7 +231,7 @@ if (type.IsFloatingPoint) {
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new<#=type.Name#>Scalar(<#=type.Storage#> scalar, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor From(<#=type.Storage#> scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor from(<#=type.Storage#> scalar, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
             var handle = THSTensor_new<#=type.Name#>Scalar(scalar, (int) deviceType, deviceIndex, requiresGrad);
@@ -256,7 +256,7 @@ if (type.IsInt64) {
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, long[] dimensions, int numDimensions, sbyte type, bool requiresGrad);
 <# } #>
 
-        public static TorchTensor From(<#=type.Storage#>[] rawArray, long[] dimensions, bool requiresGrad = false)
+        public static TorchTensor from(<#=type.Storage#>[] rawArray, long[] dimensions, bool requiresGrad = false)
         {
 <#
 if (type.IsFloat16 || type.IsBFloat16) {
@@ -319,15 +319,15 @@ if (type.IsInt64) {
             }
         }
         
-        public static TorchTensor From(<#=type.Storage#>[] rawArray, bool requiresGrad = false)
+        public static TorchTensor from(<#=type.Storage#>[] rawArray, bool requiresGrad = false)
         {
-            return From(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
+            return from(rawArray, new long[] { (long)rawArray.Length }, requiresGrad);
         }
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
-        public static TorchTensor Sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
+        public static TorchTensor sparse(TorchTensor indices, TorchTensor values, long[] size, DeviceType deviceType = DeviceType.CPU, int deviceIndex = 0, bool requiresGrad = false)
         {
             Torch.InitializeDeviceType (deviceType);
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -46,7 +46,7 @@ namespace TorchSharp
         public void TestSetGetBiasInLinear()
         {
             var lin = Linear(1000, 100, true);
-            var bias = Float32Tensor.Ones (new long[] { 1000 });
+            var bias = Float32Tensor.ones (new long[] { 1000 });
             lin.Bias = bias;
             Assert.True(!(lin.Bias is null));
 
@@ -102,7 +102,7 @@ namespace TorchSharp
             var lin = Linear(1000, 100, true);
             var bias = lin.Bias!;
             var weight = lin.Weight.t();
-            var input = Float32Tensor.RandomN(new long[] { 1, 1000 });
+            var input = Float32Tensor.randn(new long[] { 1, 1000 });
             var forward = lin.forward(input);
             var matmul = input.matmul(weight).add(bias);
 
@@ -123,7 +123,7 @@ namespace TorchSharp
             Assert.False(!(lin.Bias is null));
 
             var weight = lin.Weight.transpose(0, 1);
-            var input = Float32Tensor.RandomN(new long[] { 1, 1000 });
+            var input = Float32Tensor.randn(new long[] { 1, 1000 });
             var forward = lin.forward(input);
             var matmul = input.matmul(weight);
 
@@ -141,7 +141,7 @@ namespace TorchSharp
         public void TestLinearEditBias()
         {
             var lin = Linear(1000, 100, true);
-            var bias = Float32Tensor.RandomN(new long[] { 100 });
+            var bias = Float32Tensor.randn(new long[] { 100 });
             lin.Bias = bias;
 
             for (int i = 0; i < 100; i++)
@@ -154,8 +154,8 @@ namespace TorchSharp
         public void TestLinearEditWeightsAndBias()
         {
             var lin = Linear(1000, 1000, true);
-            var bias = Float32Tensor.RandomN(new long[] { 100 });
-            var weights = Float32Tensor.RandomN(new long[] { 100, 1000 });
+            var bias = Float32Tensor.randn(new long[] { 100 });
+            var weights = Float32Tensor.randn(new long[] { 100, 1000 });
 
             lin.Bias = bias;
             lin.Weight = weights;
@@ -174,8 +174,8 @@ namespace TorchSharp
         public void TestLinearEditWeightsAndBiasGetParameters()
         {
             var lin = Linear(1000, 1000, true);
-            var bias = Float32Tensor.RandomN(new long[] { 100 });
-            var weights = Float32Tensor.RandomN(new long[] { 1000, 1000 });
+            var bias = Float32Tensor.randn(new long[] { 100 });
+            var weights = Float32Tensor.randn(new long[] { 1000, 1000 });
             lin.Bias = bias;
             lin.Weight = weights;
 
@@ -204,7 +204,7 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 64, 1000 }, requiresGrad: true);
             var eval = seq.forward(x);
         }
 
@@ -236,8 +236,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 });
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
 
             var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -249,8 +249,8 @@ namespace TorchSharp
         [Fact]
         public void TestPoissonNLLLoss()
         {
-            using (TorchTensor input = Float32Tensor.From(new float[] { 0.5f, 1.5f, 2.5f }))
-            using (TorchTensor target = Float32Tensor.From(new float[] { 1f, 2f, 3f }))
+            using (TorchTensor input = Float32Tensor.from(new float[] { 0.5f, 1.5f, 2.5f }))
+            using (TorchTensor target = Float32Tensor.from(new float[] { 1f, 2f, 3f }))
             {
                 var componentWiseLoss = ((TorchTensor)input.exp()) - target * input;
                 Assert.True(componentWiseLoss.Equals(PoissonNLL(reduction: NN.Reduction.None)(input, target)));
@@ -262,8 +262,8 @@ namespace TorchSharp
         [Fact]
         public void TestPoissonNLLLoss2()
         {
-            using (TorchTensor input = Float32Tensor.Random(new long[] { 5, 2 }))
-            using (TorchTensor target = Float32Tensor.Random(new long[] { 5, 2 }))
+            using (TorchTensor input = Float32Tensor.rand(new long[] { 5, 2 }))
+            using (TorchTensor target = Float32Tensor.rand(new long[] { 5, 2 }))
             {
                 var outTensor = PoissonNLL(true, true)(input, target);
             }
@@ -273,8 +273,8 @@ namespace TorchSharp
         [Fact(Skip = "Not working on Mac and Ubuntu (note: may now be working, we need to recheck)")]
         public void TestErrorHandling()
         {
-            using (TorchTensor input = Float32Tensor.From(new float[] { 0.5f, 1.5f }))
-            using (TorchTensor target = Float32Tensor.From(new float[] { 1f, 2f, 3f }))
+            using (TorchTensor input = Float32Tensor.from(new float[] { 0.5f, 1.5f }))
+            using (TorchTensor target = Float32Tensor.from(new float[] { 1f, 2f, 3f }))
             {
                 Assert.Throws<ExternalException>(() => PoissonNLL()(input, target));
             }
@@ -291,8 +291,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -313,8 +313,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -339,8 +339,8 @@ namespace TorchSharp
                 ("relu1", Relu()),
                 ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
@@ -359,7 +359,7 @@ namespace TorchSharp
         [Fact]
         public void TestGrad2()
         {
-            var y = Float32Tensor.RandomN(new long[] { 32, 1 });
+            var y = Float32Tensor.randn(new long[] { 32, 1 });
             var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).to_type(ScalarType.Float32);
             var inputs = new TorchTensor[] { input };
             var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).to_type(ScalarType.Float32).with_requires_grad();
@@ -389,7 +389,7 @@ namespace TorchSharp
         [Fact]
         public void TestSetGrad()
         {
-            var x = Float32Tensor.Random(new long[] { 10, 10 });
+            var x = Float32Tensor.rand(new long[] { 10, 10 });
             Assert.False(x.requires_grad);
 
             x.requires_grad = true;
@@ -441,8 +441,8 @@ namespace TorchSharp
             var psF = modF.GetParameters();
             Assert.Equal(4, psF.Length);
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 64, 1000 }, requiresGrad: true);
+            var y = Float32Tensor.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             modT.Train();
 
@@ -486,7 +486,7 @@ namespace TorchSharp
         [Fact(Skip = "Not working on MacOS (note: may now be working, we need to recheck)")]
         public void TestAutoGradMode()
         {
-            var x = Float32Tensor.RandomN(new long[] { 2, 3 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 2, 3 }, requiresGrad: true);
             using (var mode = new AutoGradMode(false))
             {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
@@ -548,7 +548,7 @@ namespace TorchSharp
         [Fact]
         public void TestCustomModule()
         {
-            var module = new TestModule("test", Float32Tensor.RandomN(new long[] { 2, 2 }), true);
+            var module = new TestModule("test", Float32Tensor.randn(new long[] { 2, 2 }), true);
             var name = module.GetName();
             Assert.NotNull(name);
             Assert.Equal("test", name);
@@ -562,7 +562,7 @@ namespace TorchSharp
         [Fact]
         public void TestCustomModuleWithInPlaceModification()
         {
-            var param = Float32Tensor.RandomN(new long[] { 1000, 100 });
+            var param = Float32Tensor.randn(new long[] { 1000, 100 });
             var module = new TestModule("test", param, true);
 
             Assert.Equal(1000, module.GetParameter("test").shape[0]);
@@ -603,8 +603,8 @@ namespace TorchSharp
             var lin2 = Linear(100, 10);
             var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 });
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
 
             float learning_rate = 0.00004f;
             float prevLoss = float.MaxValue;
@@ -660,8 +660,8 @@ namespace TorchSharp
             var lin2 = Linear(100, 10);
             var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
 
-            var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
-            var y = Float32Tensor.RandomN(new long[] { 64, 10 });
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
 
             double learning_rate = 0.00004f;
             float prevLoss = float.MaxValue;
@@ -767,7 +767,7 @@ namespace TorchSharp
         [Fact]
         public void AvgPool2DObjectInitialized()
         {
-            TorchTensor ones = Float32Tensor.Ones(new long[] { 2, 2, 2 });
+            TorchTensor ones = Float32Tensor.ones(new long[] { 2, 2, 2 });
             var obj = AvgPool2D(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
         }
@@ -775,19 +775,19 @@ namespace TorchSharp
         [Fact]
         public void AvgPool2DTensor()
         {
-            TorchTensor ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2 });
+            TorchTensor ones = Float32Tensor.ones(new long[] { 4, 2, 2, 2 });
             var obj = ones.avg_pool2d(new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
-            Assert.Equal(Float32Tensor.Ones(new long[] { 4, 2, 1, 1 }), obj);
+            Assert.Equal(Float32Tensor.ones(new long[] { 4, 2, 1, 1 }), obj);
         }
 
 
         [Fact]
         public void AvgPool2DBackwardTensor()
         {
-            var ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2 });
+            var ones = Float32Tensor.ones(new long[] { 4, 2, 2, 2 });
             var kernelSize = new long[] { 2, 2 };
-            var avg = Float32Tensor.Ones(new long[] { 4, 2, 1, 1 });
+            var avg = Float32Tensor.ones(new long[] { 4, 2, 1, 1 });
             var res = avg.avg_pool2d_backward(ones, kernelSize) * 4.0;
 
             var ones0000 = ones[0, 0, 0, 0].ToSingle();
@@ -801,9 +801,9 @@ namespace TorchSharp
         [Fact]
         public void AvgPool3DBackwardTensor()
         {
-            var ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2, 2 });
+            var ones = Float32Tensor.ones(new long[] { 4, 2, 2, 2, 2 });
             var kernelSize = new long[] { 2, 2, 2 };
-            var avg = Float32Tensor.Ones(new long[] { 4, 2, 1, 1, 1 });
+            var avg = Float32Tensor.ones(new long[] { 4, 2, 1, 1, 1 });
             var res = avg.avg_pool3d_backward(ones, kernelSize) * 8.0;
 
             var ones0000 = ones[0, 0, 0, 0, 0].ToSingle();
@@ -816,9 +816,9 @@ namespace TorchSharp
         [Fact]
         public void AvgPool3DBackwardTensorExplicitDivisor()
         {
-            var ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2, 2 });
+            var ones = Float32Tensor.ones(new long[] { 4, 2, 2, 2, 2 });
             var kernelSize = new long[] { 2, 2, 2 };
-            var avg = Float32Tensor.Ones(new long[] { 4, 2, 1, 1, 1 });
+            var avg = Float32Tensor.ones(new long[] { 4, 2, 1, 1, 1 });
             var res = avg.avg_pool3d_backward(ones, kernelSize, divisorOverride: 6) * 6.0;
 
             var ones0000 = ones[0, 0, 0, 0, 0].ToSingle();
@@ -831,7 +831,7 @@ namespace TorchSharp
         [Fact]
         public void MaxPool2DObjectInitialized()
         {
-            TorchTensor ones = Float32Tensor.Ones(new long[] { 2, 2, 2 });
+            TorchTensor ones = Float32Tensor.ones(new long[] { 2, 2, 2 });
             var obj = MaxPool2D(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
         }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -58,11 +58,11 @@ namespace TorchSharp
         {
             var lin = Linear(1000, 100, true);
 
-            Assert.Equal(2, lin.Weight.Shape.Length);
-            Assert.Equal(100, lin.Weight.Shape[0]);
-            Assert.Equal(1000, lin.Weight.Shape[1]);
-            Assert.True(1 == lin.Bias?.Shape.Length);
-            Assert.Equal(100, lin.Bias?.Shape[0]);
+            Assert.Equal(2, lin.Weight.shape.Length);
+            Assert.Equal(100, lin.Weight.shape[0]);
+            Assert.Equal(1000, lin.Weight.shape[1]);
+            Assert.True(1 == lin.Bias?.shape.Length);
+            Assert.Equal(100, lin.Bias?.shape[0]);
         }
 
         [Fact]
@@ -89,11 +89,11 @@ namespace TorchSharp
             var lin = Linear(1000, 100, true);
             var weight = lin.GetParameter("weight");
             var bias = lin.GetParameter("bias");
-            Assert.Equal(2, weight.Shape.Length);
-            Assert.Equal(100, weight.Shape[0]);
-            Assert.Equal(1000, weight.Shape[1]);
-            Assert.True(1 == bias.Shape.Length);
-            Assert.Equal(100, bias.Shape[0]);
+            Assert.Equal(2, weight.shape.Length);
+            Assert.Equal(100, weight.shape[0]);
+            Assert.Equal(1000, weight.shape[1]);
+            Assert.True(1 == bias.shape.Length);
+            Assert.Equal(100, bias.shape[0]);
         }
 
         [Fact]
@@ -101,14 +101,14 @@ namespace TorchSharp
         {
             var lin = Linear(1000, 100, true);
             var bias = lin.Bias!;
-            var weight = lin.Weight.T();
+            var weight = lin.Weight.t();
             var input = Float32Tensor.RandomN(new long[] { 1, 1000 });
-            var forward = lin.Forward(input);
-            var matmul = input.MatMul(weight).Add(bias);
+            var forward = lin.forward(input);
+            var matmul = input.matmul(weight).add(bias);
 
-            Assert.Equal(forward.Shape.Length, matmul.Shape.Length);
-            Assert.Equal(forward.Shape[0], matmul.Shape[0]);
-            Assert.Equal(forward.Shape[1], matmul.Shape[1]);
+            Assert.Equal(forward.shape.Length, matmul.shape.Length);
+            Assert.Equal(forward.shape[0], matmul.shape[0]);
+            Assert.Equal(forward.shape[1], matmul.shape[1]);
 
             for (int i = 0; i < 100; i++)
             {
@@ -122,14 +122,14 @@ namespace TorchSharp
             var lin = Linear(1000, 100, false);
             Assert.False(!(lin.Bias is null));
 
-            var weight = lin.Weight.Transpose(0, 1);
+            var weight = lin.Weight.transpose(0, 1);
             var input = Float32Tensor.RandomN(new long[] { 1, 1000 });
-            var forward = lin.Forward(input);
-            var matmul = input.MatMul(weight);
+            var forward = lin.forward(input);
+            var matmul = input.matmul(weight);
 
-            Assert.Equal(forward.Shape.Length, matmul.Shape.Length);
-            Assert.Equal(forward.Shape[0], matmul.Shape[0]);
-            Assert.Equal(forward.Shape[1], matmul.Shape[1]);
+            Assert.Equal(forward.shape.Length, matmul.shape.Length);
+            Assert.Equal(forward.shape[0], matmul.shape[0]);
+            Assert.Equal(forward.shape[1], matmul.shape[1]);
 
             for (int i = 0; i < 100; i++)
             {
@@ -160,9 +160,9 @@ namespace TorchSharp
             lin.Bias = bias;
             lin.Weight = weights;
 
-            Assert.Equal(lin.Weight.Shape.Length, weights.Shape.Length);
-            Assert.Equal(lin.Weight.Shape[0], weights.Shape[0]);
-            Assert.Equal(lin.Weight.Shape[1], weights.Shape[1]);
+            Assert.Equal(lin.Weight.shape.Length, weights.shape.Length);
+            Assert.Equal(lin.Weight.shape[0], weights.shape[0]);
+            Assert.Equal(lin.Weight.shape[1], weights.shape[1]);
 
             for (int i = 0; i < 100; i++)
             {
@@ -181,9 +181,9 @@ namespace TorchSharp
 
             var parameters = lin.GetParameters().ToArray();
 
-            Assert.Equal(lin.Weight.Shape.Length, parameters[0].Shape.Length);
-            Assert.Equal(lin.Weight.Shape[0], parameters[0].Shape[0]);
-            Assert.Equal(lin.Weight.Shape[1], parameters[0].Shape[1]);
+            Assert.Equal(lin.Weight.shape.Length, parameters[0].shape.Length);
+            Assert.Equal(lin.Weight.shape[0], parameters[0].shape[0]);
+            Assert.Equal(lin.Weight.shape[1], parameters[0].shape[1]);
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace TorchSharp
                 ("lin2", lin2));
 
             var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
-            var eval = seq.Forward(x);
+            var eval = seq.forward(x);
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace TorchSharp
             var x = Float32Tensor.RandomN(new long[] { 64, 1000 });
             var y = Float32Tensor.RandomN(new long[] { 64, 10 });
 
-            var eval = seq.Forward(x);
+            var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
             var output = loss(eval, y);
 
@@ -252,10 +252,10 @@ namespace TorchSharp
             using (TorchTensor input = Float32Tensor.From(new float[] { 0.5f, 1.5f, 2.5f }))
             using (TorchTensor target = Float32Tensor.From(new float[] { 1f, 2f, 3f }))
             {
-                var componentWiseLoss = ((TorchTensor)input.Exp()) - target * input;
-                Assert.True(componentWiseLoss.Equal(PoissonNLL(reduction: NN.Reduction.None)(input, target)));
-                Assert.True(componentWiseLoss.Sum().Equal(PoissonNLL(reduction: NN.Reduction.Sum)(input, target)));
-                Assert.True(componentWiseLoss.Mean().Equal(PoissonNLL(reduction: NN.Reduction.Mean)(input, target)));
+                var componentWiseLoss = ((TorchTensor)input.exp()) - target * input;
+                Assert.True(componentWiseLoss.Equals(PoissonNLL(reduction: NN.Reduction.None)(input, target)));
+                Assert.True(componentWiseLoss.sum().Equals(PoissonNLL(reduction: NN.Reduction.Sum)(input, target)));
+                Assert.True(componentWiseLoss.mean().Equals(PoissonNLL(reduction: NN.Reduction.Mean)(input, target)));
             }
         }
 
@@ -294,13 +294,13 @@ namespace TorchSharp
             var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
             var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
-            var eval = seq.Forward(x);
+            var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
             var output = loss(eval, y);
 
             seq.ZeroGrad();
 
-            output.Backward();
+            output.backward();
         }
 
         [Fact]
@@ -316,13 +316,13 @@ namespace TorchSharp
             var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
             var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
-            var eval = seq.Forward(x);
+            var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
             var output = loss(eval, y);
 
             seq.ZeroGrad();
 
-            output.Backward();
+            output.backward();
 
             foreach (var parm in seq.GetParameters())
             {
@@ -342,17 +342,17 @@ namespace TorchSharp
             var x = Float32Tensor.RandomN(new long[] { 64, 1000 }, requiresGrad: true);
             var y = Float32Tensor.RandomN(new long[] { 64, 10 }, requiresGrad: true);
 
-            var eval = seq.Forward(x);
+            var eval = seq.forward(x);
             var loss = MSE(NN.Reduction.Sum);
             var output = loss(eval, y);
 
             seq.ZeroGrad();
 
-            output.Backward();
+            output.backward();
 
             foreach (var parm in seq.GetParameters())
             {
-                var grad = parm.Grad();
+                var grad = parm.grad();
             }
         }
 
@@ -360,42 +360,42 @@ namespace TorchSharp
         public void TestGrad2()
         {
             var y = Float32Tensor.RandomN(new long[] { 32, 1 });
-            var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).ToType(ScalarType.Float32);
+            var input = new double[] { -2.75, 0.77, -0.61, 0.14, 1.39, 0.38, -0.53, -0.5, -2.13, -0.39, 0.46, -0.61, -0.37, -0.12, 0.55, -1, 0.84, -0.02, 1.3, -0.24, -0.5, -2.12, -0.85, -0.91, 1.81, 0.02, -0.78, -1.41, -1.09, -0.65, 0.9, -0.37, -0.22, 0.28, 1.05, -0.24, 0.3, -0.99, 0.19, 0.32, -0.95, -1.19, -0.63, 0.75, 0.16, 0.15, 0.3, -0.69, 0.2, -0.4, -0.67, 0.18, -1.43, -0.61, -0.78, -0.11, -1.07, -1.71, -0.45, -0.6, 0.05, -1.59, 1.24, 0.62, 0.01, 1.35, -0.9, -1.25, 1.62, -1.45, 0.92, 1.51, -0.19, -1.33, -0.01, -0.13, 0.1, -1.34, 1.23, 0.57, -0.24, 0.5, 0.71, -0.15, -1.37, -1.03, 1.8, 1.4, -0.63, 0.8, -0.97, -0.64, 0.51, 0.52, 0.95, 0.86, 0.43, 0.73, -1.38, -0.56, 0.44, 1.2, -1.45, -0.07, 1.88, 1.57, 0.38, -2.2, -0.56, -1.52, -0.17, 1.38, -1.02, -1.61, -0.13, -0.44, -0.37, 0.23, 1.75, 0.83, -0.02, -1.91, -0.23, -0.47, -1.41, -1.01, -0.91, -0.56, -1.72, 1.47, 0.31, 0.24, 0.48, 2.06, 0.07, -0.96, 1.03, -0.4, -0.64, -0.85, 0.42, -0.33, 0.85, -0.11, -1.24, -0.71, -1.04, -0.37, -0.37, 0.84, -0.9, -1.63, -2.91, -0.71, 0.09, 1.64, -1.1, -1.05, 0.51, 0.57, 0.19, 0.36, 1.36, 1.45, 0.35, -1.66, -0.65, 0.47, 1.95, -0.32, 0.19, -2.06, 0.5, 1.03, 0.94, -0.65, -2.94, 0.41, 1.13, 0.95, -0.02, 1.12, 0.19, 0.66, -0.77, -0.39, 0.59, -1.58, -0.67, 0.88, 0.26, -0.63, 0.49, 1.38, 1.48, -0.55, 0.4, 0.65, 0.19, 0.25, 0.03, -0.31, 0.75, 2.16, -1.36, 0.05, 0.22, 0.65, 1.28, 0.42, 1.35, -0.08, 1.1, 0.25, 0.44, 1.06, -1.78, 0.47, 1.38, 0.43, -1.56, 0.14, -0.22, 1.48, 0.04, 0.33, 0.1, 0.2, -0.99, 1.04, 0.61, -0.4, 0.96, 0.4, 0.5, 0.1, 0.02, 0.01, 0.22, 1.45, -0.77, 0.69, 0.95, 0.96, -0.09, -0.26, 0.22, -1.61, 1.86, -0.06, -0.34, -0.35, 0.55, -1.08, 1.29, 0.92, 0.16, 0.55, -0.01, 0.2, -0.61, -0.28, -2.17, -0.46, 1.63, 1.61, 0.64, 0.32, -0.75, 0.33, 0.3, -1.15, 0.42, -0.06, -1.14, 1.62, -0.9, -0.39, 0.4, 1.52, -0.43, 1.22, -0.32, -0.02, 1, -0.92, 0.11, 0.8, -0.99, -0.26, -2.85, -1.13, 0.49, -0.63, -0.54, -0.86, -0.97, -0.9, 0.23, 1.26, -1.78, -0.84, -0.48, 0.35, -1.13, -2.23, 0.1, 0.95, 1.27, 0.08, -2.21, 0.67, -0.2, 0.6, -1.14, 0.65, -0.73, -0.01, 0.9, -1.33, -1.16, 0.29, 1.16, 1.19, 0.84, 0.66, -1.55, -0.58, 1.85, -1.16, -0.95, 0.98, -0.1, -1.47, 0.78, -0.75, -1.32, 0.61, -0.5, -1, -0.42, 0.96, -1.39, 0.08, -1.82, 0.51, -0.71, -0.02, 2.32, -0.71, 0.08, -1.07 }.ToTorchTensor(new long[] { 32, 11 }).to_type(ScalarType.Float32);
             var inputs = new TorchTensor[] { input };
-            var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float32).RequiresGrad(true);
+            var scaler = new double[] { 0.2544529, 0.3184713, 0.2597403, 0.3246753, 0.3144654, 0.3322259, 0.3436426, 0.3215434, 0.308642, 0.3154574, 0.3448276 }.ToTorchTensor(new long[] { 1, 11 }).to_type(ScalarType.Float32).with_requires_grad();
             var linear = Linear(11, 1, true);
-            linear.Bias = new double[] { 373.8864 }.ToTorchTensor(new long[] { 1, 1 }).ToType(ScalarType.Float32).RequiresGrad(true);
-            linear.Weight = new double[] { 300.2818, -0.5905267, 286.2787, 0.1970505, 0.9004903, 0.1373157, 55.85495, 11.43741, 1.525748, 0.4299785, 239.9356 }.ToTorchTensor(new long[] { 1, 11 }).ToType(ScalarType.Float32).RequiresGrad(true);
+            linear.Bias = new double[] { 373.8864 }.ToTorchTensor(new long[] { 1, 1 }).to_type(ScalarType.Float32).with_requires_grad();
+            linear.Weight = new double[] { 300.2818, -0.5905267, 286.2787, 0.1970505, 0.9004903, 0.1373157, 55.85495, 11.43741, 1.525748, 0.4299785, 239.9356 }.ToTorchTensor(new long[] { 1, 11 }).to_type(ScalarType.Float32).with_requires_grad();
 
-            var afterCat = inputs.Cat(1);
+            var afterCat = inputs.cat(1);
             var afterScaler = afterCat * scaler;
-            var prediction = linear.Forward(afterScaler);
+            var prediction = linear.forward(afterScaler);
 
             var loss = MSE();
             var output = loss(prediction, y);
 
             linear.ZeroGrad();
 
-            output.Backward();
+            output.backward();
 
-            var scalerGrad = scaler.Grad();
-            var weightGrad = linear.Weight.Grad();
-            var biasGrad = linear.Bias.Grad();
-            Assert.True(scalerGrad.Shape.Length == 2);
-            Assert.True(weightGrad.Shape.Length == 2);
-            Assert.True(biasGrad.Shape.Length == 2);
+            var scalerGrad = scaler.grad();
+            var weightGrad = linear.Weight.grad();
+            var biasGrad = linear.Bias.grad();
+            Assert.True(scalerGrad.shape.Length == 2);
+            Assert.True(weightGrad.shape.Length == 2);
+            Assert.True(biasGrad.shape.Length == 2);
         }
 
         [Fact]
         public void TestSetGrad()
         {
             var x = Float32Tensor.Random(new long[] { 10, 10 });
-            Assert.False(x.IsGradRequired);
+            Assert.False(x.requires_grad);
 
-            x.RequiresGrad(true);
-            Assert.True(x.IsGradRequired);
-            x.RequiresGrad(false);
-            Assert.False(x.IsGradRequired);
+            x.requires_grad = true;
+            Assert.True(x.requires_grad);
+            x.requires_grad = false;
+            Assert.False(x.requires_grad);
         }
 
         private class CondModel : CustomModule
@@ -415,16 +415,16 @@ namespace TorchSharp
                 RegisterModule ("fbF2", fbF2);
             }
 
-            public override TorchTensor Forward(TorchTensor input)
+            public override TorchTensor forward(TorchTensor input)
             {
-                using (var x = fb.Forward(input))
+                using (var x = fb.forward(input))
                     if (_isTrue)
                     {
-                        return fbT1.Forward(x);
+                        return fbT1.forward(x);
                     }
                     else
                     {
-                        return fbF2.Forward(fbF1.Forward(x));
+                        return fbF2.forward(fbF1.forward(x));
                     }
             }
         }
@@ -446,18 +446,18 @@ namespace TorchSharp
 
             modT.Train();
 
-            var eval = modT.Forward(x);
+            var eval = modT.forward(x);
             var loss = MSE(NN.Reduction.Sum);
             var output = loss(eval, y);
 
             modT.ZeroGrad();
 
-            output.Backward();
+            output.backward();
             var gradCounts = 0;
 
             foreach (var parm in modT.GetParameters())
             {
-                var grad = parm.Grad();
+                var grad = parm.grad();
                 gradCounts += grad.Handle == IntPtr.Zero ? 0 : 1;
             }
 
@@ -466,17 +466,17 @@ namespace TorchSharp
             //{ "grad can be implicitly created only for scalar outputs (_make_grads at ..\\..\\torch\\csrc\\autograd\\autograd.cpp:47)\n(no backtrace available)"}
             modF.Train();
 
-            eval = modF.Forward(x);
+            eval = modF.forward(x);
             output = loss(eval, y);
 
             modF.ZeroGrad();
 
-            output.Backward();
+            output.backward();
             gradCounts = 0;
 
             foreach (var parm in modF.GetParameters())
             {
-                var grad = parm.Grad();
+                var grad = parm.grad();
                 gradCounts += grad.Handle == IntPtr.Zero ? 0 : 1;
             }
 
@@ -490,17 +490,17 @@ namespace TorchSharp
             using (var mode = new AutoGradMode(false))
             {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
-                var sum = x.Sum();
-                Assert.Throws<ExternalException>(() => sum.Backward());
+                var sum = x.sum();
+                Assert.Throws<ExternalException>(() => sum.backward());
                 //var grad = x.Grad();
                 //Assert.True(grad.Handle == IntPtr.Zero);
             }
             using (var mode = new AutoGradMode(true))
             {
                 Assert.True(AutoGradMode.IsAutogradEnabled());
-                var sum = x.Sum();
-                sum.Backward();
-                var grad = x.Grad();
+                var sum = x.sum();
+                sum.backward();
+                var grad = x.grad();
                 Assert.False(grad.Handle == IntPtr.Zero);
                 var data = grad.Data<float>();
                 for (int i = 0; i < 2 * 3; i++)
@@ -565,17 +565,17 @@ namespace TorchSharp
             var param = Float32Tensor.RandomN(new long[] { 1000, 100 });
             var module = new TestModule("test", param, true);
 
-            Assert.Equal(1000, module.GetParameter("test").Shape[0]);
-            Assert.Equal(100, module.GetParameter("test").Shape[1]);
+            Assert.Equal(1000, module.GetParameter("test").shape[0]);
+            Assert.Equal(100, module.GetParameter("test").shape[1]);
 
             using (var grad = new AutoGradMode(false))
             {
-                param.TransposeInPlace(0, 1);
+                param.transpose_(0, 1);
             }
-            Assert.Equal(100, module.GetParameter("test").Shape[0]);
-            Assert.Equal(1000, module.GetParameter("test").Shape[1]);
-            Assert.Equal(100, param.Shape[0]);
-            Assert.Equal(1000, param.Shape[1]);
+            Assert.Equal(100, module.GetParameter("test").shape[0]);
+            Assert.Equal(1000, module.GetParameter("test").shape[1]);
+            Assert.Equal(100, param.shape[0]);
+            Assert.Equal(1000, param.shape[1]);
         }
 
         private class TestModule : CustomModule
@@ -585,7 +585,7 @@ namespace TorchSharp
             {
             }
 
-            public override TorchTensor Forward(TorchTensor input)
+            public override TorchTensor forward(TorchTensor input)
             {
                 throw new NotImplementedException();
             }
@@ -612,7 +612,7 @@ namespace TorchSharp
 
             for (int i = 0; i < 10; i++)
             {
-                var eval = seq.Forward(x);
+                var eval = seq.forward(x);
                 var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
@@ -621,15 +621,15 @@ namespace TorchSharp
 
                 seq.ZeroGrad();
 
-                output.Backward();
+                output.backward();
 
                 using (var noGrad = new AutoGradMode(false))
                 {
                     foreach (var param in seq.GetParameters())
                     {
-                        var grad = param.Grad();
-                        var update = grad.Mul(learning_rate.ToScalar());
-                        param.SubInPlace(update);
+                        var grad = param.grad();
+                        var update = grad.mul(learning_rate.ToScalar());
+                        param.sub_(update);
                     }
                 }
             }
@@ -670,7 +670,7 @@ namespace TorchSharp
 
             for (int i = 0; i < 10; i++)
             {
-                var eval = seq.Forward(x);
+                var eval = seq.forward(x);
                 var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
@@ -679,7 +679,7 @@ namespace TorchSharp
 
                 optimizer.ZeroGrad();
 
-                output.Backward();
+                output.backward();
 
                 optimizer.Step();
             }
@@ -699,8 +699,8 @@ namespace TorchSharp
                 {
                     i++;
 
-                    Assert.Equal(data.Shape, new long[] { 32, 1, 28, 28 });
-                    Assert.Equal(target.Shape, new long[] { 32 });
+                    Assert.Equal(data.shape, new long[] { 32, 1, 28, 28 });
+                    Assert.Equal(target.shape, new long[] { 32 });
 
                     data.Dispose();
                     target.Dispose();
@@ -724,8 +724,8 @@ namespace TorchSharp
                 {
                     i++;
 
-                    Assert.Equal(data.Shape, new long[] { 16, 3, 32, 32 });
-                    Assert.Equal(target.Shape, new long[] { 16 });
+                    Assert.Equal(data.shape, new long[] { 16, 3, 32, 32 });
+                    Assert.Equal(target.shape, new long[] { 16 });
                     Assert.True(target.Data<int>().ToArray().Where(x => x >= 0 && x < 10).Count() == 16);
 
                     data.Dispose();
@@ -752,8 +752,8 @@ namespace TorchSharp
                     {
                         i++;
 
-                        Assert.Equal(data.Shape, new long[] { 32, 1, 28, 28 });
-                        Assert.Equal(target.Shape, new long[] { 32 });
+                        Assert.Equal(data.shape, new long[] { 32, 1, 28, 28 });
+                        Assert.Equal(target.shape, new long[] { 32 });
 
                         data.Dispose();
                         target.Dispose();
@@ -776,7 +776,7 @@ namespace TorchSharp
         public void AvgPool2DTensor()
         {
             TorchTensor ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2 });
-            var obj = ones.AvgPool2D(new long[] { 2, 2 });
+            var obj = ones.avg_pool2d(new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
             Assert.Equal(Float32Tensor.Ones(new long[] { 4, 2, 1, 1 }), obj);
         }
@@ -788,7 +788,7 @@ namespace TorchSharp
             var ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2 });
             var kernelSize = new long[] { 2, 2 };
             var avg = Float32Tensor.Ones(new long[] { 4, 2, 1, 1 });
-            var res = avg.AvgPool2DBackward(ones, kernelSize) * 4.0;
+            var res = avg.avg_pool2d_backward(ones, kernelSize) * 4.0;
 
             var ones0000 = ones[0, 0, 0, 0].ToSingle();
             var res0000 = res[0, 0, 0, 0].ToSingle();
@@ -804,13 +804,13 @@ namespace TorchSharp
             var ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2, 2 });
             var kernelSize = new long[] { 2, 2, 2 };
             var avg = Float32Tensor.Ones(new long[] { 4, 2, 1, 1, 1 });
-            var res = avg.AvgPool3DBackward(ones, kernelSize) * 8.0;
+            var res = avg.avg_pool3d_backward(ones, kernelSize) * 8.0;
 
             var ones0000 = ones[0, 0, 0, 0, 0].ToSingle();
             var res0000 = res[0, 0, 0, 0, 0].ToSingle();
             Assert.True(Math.Abs(ones0000 - res0000) < 0.00001);
             // This gets back to the original uniform input
-            Assert.True(res.AllClose(ones));
+            Assert.True(res.allclose(ones));
         }
 
         [Fact]
@@ -819,13 +819,13 @@ namespace TorchSharp
             var ones = Float32Tensor.Ones(new long[] { 4, 2, 2, 2, 2 });
             var kernelSize = new long[] { 2, 2, 2 };
             var avg = Float32Tensor.Ones(new long[] { 4, 2, 1, 1, 1 });
-            var res = avg.AvgPool3DBackward(ones, kernelSize, divisorOverride: 6) * 6.0;
+            var res = avg.avg_pool3d_backward(ones, kernelSize, divisorOverride: 6) * 6.0;
 
             var ones0000 = ones[0, 0, 0, 0, 0].ToSingle();
             var res0000 = res[0, 0, 0, 0, 0].ToSingle();
             Assert.True(Math.Abs(ones0000 - res0000) < 0.00001);
             // This gets back to the original uniform input
-            Assert.True(res.AllClose(ones));
+            Assert.True(res.allclose(ones));
         }
 
         [Fact]

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -27,7 +27,7 @@ namespace TorchSharp
                 Assert.False(isCudnnAvailable);
             }
 
-            //TorchTensor t = Float32Tensor.Ones(shape);
+            //TorchTensor t = Float32Tensor.ones(shape);
             //Assert.Equal(shape, t.Shape);
             //Assert.Equal(1.0f, t[0, 0].ToSingle());
             //Assert.Equal(1.0f, t[1, 1].ToSingle());
@@ -42,7 +42,7 @@ namespace TorchSharp
             for (int i = 0; i < n; i++) {
                 Console.WriteLine("ExplicitDisposal: Loop iteration {0}", i);
 
-                using (var x = Float32Tensor.Empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU)) { }
+                using (var x = Float32Tensor.empty(new long[] { 64000, 1000 }, deviceType: DeviceType.CPU)) { }
             }
             Console.WriteLine("Hello World!");
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -17,7 +17,7 @@ namespace TorchSharp
         public void CreateFloat32TensorOnes()
         {
             var shape = new long[] { 2, 2 };
-            TorchTensor t = Float32Tensor.Ones(shape);
+            TorchTensor t = Float32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 1].ToSingle());
@@ -27,7 +27,7 @@ namespace TorchSharp
         public void CreateByteTensorOnes()
         {
             var shape = new long[] { 2, 2 };
-            TorchTensor t = ByteTensor.Ones(shape);
+            TorchTensor t = ByteTensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal((byte)1, t[0,0].ToByte());
             Assert.Equal((byte)1, t[1,1].ToByte());
@@ -37,7 +37,7 @@ namespace TorchSharp
         public void CreateInt32TensorOnes()
         {
             var shape = new long[] { 2, 2 };
-            TorchTensor t = Int32Tensor.Ones(shape);
+            TorchTensor t = Int32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1, t[0,0].ToInt32());
             Assert.Equal(1, t[1,1].ToInt32());
@@ -48,7 +48,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 2 };
 
-            TorchTensor t = Int64Tensor.Ones(shape);
+            TorchTensor t = Int64Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1L, t[0,0].ToInt64());
             Assert.Equal(1L, t[1,1].ToInt64());
@@ -59,7 +59,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 2 };
 
-            TorchTensor t = BoolTensor.Ones(shape);
+            TorchTensor t = BoolTensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal((object)true, t[0,0].ToBoolean());
             Assert.Equal((object)true, t[1,1].ToBoolean());
@@ -72,7 +72,7 @@ namespace TorchSharp
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
                     var shape = new long[] { 2, 2 };
 
-                    TorchTensor t = Float16Tensor.Ones(shape, deviceType: deviceType);
+                    TorchTensor t = Float16Tensor.ones(shape, deviceType: deviceType);
                     Assert.Equal(shape, t.shape);
                     Assert.Equal(1.0f, t[0, 0].ToSingle());
                     Assert.Equal(1.0f, t[1, 1].ToSingle());
@@ -87,7 +87,7 @@ namespace TorchSharp
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
                     var shape = new long[] { 2, 2 };
 
-                    TorchTensor t = BFloat16Tensor.Ones(shape, deviceType: deviceType);
+                    TorchTensor t = BFloat16Tensor.ones(shape, deviceType: deviceType);
                     Assert.Equal(shape, t.shape);
                     Assert.Equal(1.0f, t[0, 0].ToSingle());
                     Assert.Equal(1.0f, t[1, 1].ToSingle());
@@ -100,7 +100,7 @@ namespace TorchSharp
         //{
         //    var shape = new long[] { 2, 2 };
 
-        //    TorchTensor t = ComplexFloat32Tensor.Zeros(shape);
+        //    TorchTensor t = ComplexFloat32Tensor.zeros(shape);
         //    Assert.Equal(shape, t.Shape);
         //    t.ReadComplexFloat(0, out var r3, out var i3);
         //    Assert.Equal(0.0f, r3);
@@ -116,7 +116,7 @@ namespace TorchSharp
         //{
         //    var shape = new long[] { 2, 2 };
 
-        //    TorchTensor t = ComplexFloat32Tensor.Ones(shape);
+        //    TorchTensor t = ComplexFloat32Tensor.ones(shape);
         //    Assert.Equal(shape, t.Shape);
         //    t.ReadComplexFloat(0, out var r3, out var i3);
         //    Assert.Equal(1.0f, r3);
@@ -132,7 +132,7 @@ namespace TorchSharp
         //{
         //    var shape = new long[] { 2, 2 };
 
-        //    TorchTensor t = ComplexFloat64Tensor.Zeros(shape);
+        //    TorchTensor t = ComplexFloat64Tensor.zeros(shape);
         //    Assert.Equal(shape, t.Shape);
         //    var v3 = t.ReadComplexFloat64(0);
         //    Assert.Equal(0.0, v3.Real);
@@ -147,7 +147,7 @@ namespace TorchSharp
         //public void CreateComplexFloat64TensorOnes()
         //{
         //    var shape = new long[] { 2, 2 };
-        //    TorchTensor t = ComplexFloat64Tensor.Ones(shape);
+        //    TorchTensor t = ComplexFloat64Tensor.ones(shape);
         //    Assert.Equal(shape, t.Shape);
         //    var v5 = t.ReadComplexFloat64(0);
         //    Assert.Equal(new Complex(1.0, 0.0), v5);
@@ -162,7 +162,7 @@ namespace TorchSharp
 
             for (int i = 0; i < 10; i++)
             {
-                using (var tmp = Float32Tensor.Ones(new long[] { 100, 100, 100 }))
+                using (var tmp = Float32Tensor.ones(new long[] { 100, 100, 100 }))
                 {
                     ones = tmp;
                     Assert.NotNull(ones);
@@ -173,7 +173,7 @@ namespace TorchSharp
         [Fact]
         public void CreateFloat32TensorOnesCheckData()
         {
-            var ones = Float32Tensor.Ones(new long[] { 2, 2 });
+            var ones = Float32Tensor.ones(new long[] { 2, 2 });
             var data = ones.Data<float>();
 
             for (int i = 0; i < 4; i++)
@@ -185,7 +185,7 @@ namespace TorchSharp
         [Fact]
         public void CreateFloat32TensorZerosCheckData()
         {
-            var zeros = Float32Tensor.Zeros(new long[] { 2, 2 });
+            var zeros = Float32Tensor.zeros(new long[] { 2, 2 });
             var data = zeros.Data<float>();
 
             for (int i = 0; i < 4; i++)
@@ -197,7 +197,7 @@ namespace TorchSharp
         [Fact]
         public void CreateInt32TensorOnesCheckData()
         {
-            var ones = Int32Tensor.Ones(new long[] { 2, 2 });
+            var ones = Int32Tensor.ones(new long[] { 2, 2 });
             var data = ones.Data<int>();
 
             for (int i = 0; i < 4; i++)
@@ -209,7 +209,7 @@ namespace TorchSharp
         [Fact]
         public void CreateFloat32TensorCheckDevice()
         {
-            var ones = Float32Tensor.Ones(new long[] { 2, 2 });
+            var ones = Float32Tensor.ones(new long[] { 2, 2 });
             var device = ones.device;
 
             Assert.Equal("cpu", ones.device);
@@ -221,7 +221,7 @@ namespace TorchSharp
             var data = new float[1000];
             data[100] = 1;
 
-            using (var tensor = Float32Tensor.From(data, new long[] { 100, 10 }))
+            using (var tensor = Float32Tensor.from(data, new long[] { 100, 10 }))
             {
                 Assert.Equal(1, tensor.Data<float>()[100]);
             }
@@ -233,7 +233,7 @@ namespace TorchSharp
             var data = new float[1000];
             data[100] = 1;
 
-            using (var tensor = Float32Tensor.From(data, new long[] { 100, 10 }))
+            using (var tensor = Float32Tensor.from(data, new long[] { 100, 10 }))
             {
                 Assert.Equal(1, tensor.Data<float>()[100]);
             }
@@ -282,7 +282,7 @@ namespace TorchSharp
         public void CreateFloat16TensorFromDataCheckStrides()
         {
             var data = new float[] { 0.2663158f, 0.1144736f, 0.1147367f, 0.1249998f, 0.1957895f, 0.1231576f, 0.1944732f, 0.111842f, 0.1065789f, 0.667881f, 0.5682123f, 0.5824502f, 0.4824504f, 0.4844371f, 0.6463582f, 0.5334439f, 0.5079474f, 0.2281452f };
-            var dataTensor = Float16Tensor.From(data, new long[] { 2, 9 });
+            var dataTensor = Float16Tensor.from(data, new long[] { 2, 9 });
 
             for (int r = 0; r < 2; r++) {
                 for (int i = 0; i < 9; i++) {
@@ -305,7 +305,7 @@ namespace TorchSharp
         public void CreateBFloat16TensorFromDataCheckStrides()
         {
             var data = new float[] { 0.2663158f, 0.1144736f, 0.1147367f, 0.1249998f, 0.1957895f, 0.1231576f, 0.1944732f, 0.111842f, 0.1065789f, 0.667881f, 0.5682123f, 0.5824502f, 0.4824504f, 0.4844371f, 0.6463582f, 0.5334439f, 0.5079474f, 0.2281452f };
-            var dataTensor = BFloat16Tensor.From(data, new long[] { 2, 9 });
+            var dataTensor = BFloat16Tensor.from(data, new long[] { 2, 9 });
 
             for (int r = 0; r < 2; r++) {
                 for (int i = 0; i < 9; i++) {
@@ -330,7 +330,7 @@ namespace TorchSharp
         {
             float scalar = 333.0f;
 
-            using (var tensor = Float32Tensor.From(scalar))
+            using (var tensor = Float32Tensor.from(scalar))
             {
                 Assert.Equal(333.0f, tensor.ToSingle());
             }
@@ -341,7 +341,7 @@ namespace TorchSharp
         {
             float scalar = 333.0f;
 
-            using (var tensor = Float16Tensor.From(scalar)) {
+            using (var tensor = Float16Tensor.from(scalar)) {
                 Assert.Equal(333.0f, tensor.ToSingle());
             }
         }
@@ -351,7 +351,7 @@ namespace TorchSharp
         {
             float scalar = 333.0f;
 
-            using (var tensor = BFloat16Tensor.From(scalar)) {
+            using (var tensor = BFloat16Tensor.from(scalar)) {
                 Assert.Equal(332.0f, tensor.ToSingle()); // NOTE: bfloat16 loses precision, this really is 332.0f
             }
         }
@@ -371,11 +371,11 @@ namespace TorchSharp
         public void GetSetItem2()
         {
             var shape = new long[] { 2, 3 };
-            TorchTensor t = Float32Tensor.Ones(shape);
+            TorchTensor t = Float32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2].ToSingle());
-            t[1, 2] = Float32Tensor.From(2.0f);
+            t[1, 2] = Float32Tensor.from(2.0f);
             Assert.Equal(2.0f, t[1, 2].ToSingle());
         }
 
@@ -383,11 +383,11 @@ namespace TorchSharp
         public void GetSetItem3()
         {
             var shape = new long[] { 2, 3, 4 };
-            TorchTensor t = Float32Tensor.Ones(shape);
+            TorchTensor t = Float32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3].ToSingle());
-            t[1, 2, 3] = Float32Tensor.From(2.0f);
+            t[1, 2, 3] = Float32Tensor.from(2.0f);
             Assert.Equal(2.0f, t[1, 2, 3].ToSingle());
         }
 
@@ -395,11 +395,11 @@ namespace TorchSharp
         public void GetSetItem4()
         {
             var shape = new long[] { 2, 3, 4, 5 };
-            TorchTensor t = Float32Tensor.Ones(shape);
+            TorchTensor t = Float32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3, 4].ToSingle());
-            t[1, 2, 3, 4] = Float32Tensor.From(2.0f);
+            t[1, 2, 3, 4] = Float32Tensor.from(2.0f);
             Assert.Equal(2.0f, t[1, 2, 3, 4].ToSingle());
         }
 
@@ -407,11 +407,11 @@ namespace TorchSharp
         public void GetSetItem5()
         {
             var shape = new long[] { 2, 3, 4, 5, 6 };
-            TorchTensor t = Float32Tensor.Ones(shape);
+            TorchTensor t = Float32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3, 4, 5].ToSingle());
-            t[1, 2, 3, 4, 5] = Float32Tensor.From(2.0f);
+            t[1, 2, 3, 4, 5] = Float32Tensor.from(2.0f);
             Assert.Equal(2.0f, t[1, 2, 3, 4, 5].ToSingle());
         }
 
@@ -420,11 +420,11 @@ namespace TorchSharp
         public void GetSetItem6()
         {
             var shape = new long[] { 2, 3, 4, 5, 6, 7 };
-            TorchTensor t = Float32Tensor.Ones(shape);
+            TorchTensor t = Float32Tensor.ones(shape);
             Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0, 0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3, 4, 5, 6].ToSingle());
-            t[1, 2, 3, 4, 5, 6] = Float32Tensor.From(2.0f);
+            t[1, 2, 3, 4, 5, 6] = Float32Tensor.from(2.0f);
             Assert.Equal(2.0f, t[1, 2, 3, 4, 5, 6].ToSingle());
         }
 
@@ -510,7 +510,7 @@ namespace TorchSharp
         [Fact]
         public void InitUniform()
         {
-            using (TorchTensor tensor = Float32Tensor.Zeros(new long[] { 2, 2 }))
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 }))
             {
                 NN.Init.Uniform(tensor);
             }
@@ -519,10 +519,10 @@ namespace TorchSharp
         [Fact]
         public void TestSparse()
         {
-            using (var i = Int64Tensor.From(new long[] { 0, 1, 1, 2, 0, 2 }, new long[] { 2, 3 }))
-            using (var v = Float32Tensor.From(new float[] { 3, 4, 5 }, new long[] { 3 }))
+            using (var i = Int64Tensor.from(new long[] { 0, 1, 1, 2, 0, 2 }, new long[] { 2, 3 }))
+            using (var v = Float32Tensor.from(new float[] { 3, 4, 5 }, new long[] { 3 }))
             {
-                var sparse = Float32Tensor.Sparse(i, v, new long[] { 2, 3 });
+                var sparse = Float32Tensor.sparse(i, v, new long[] { 2, 3 });
 
                 Assert.True(sparse.IsSparse);
                 Assert.False(i.IsSparse);
@@ -535,7 +535,7 @@ namespace TorchSharp
         [Fact]
         public void TestIndexSingle()
         {
-            using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
+            using (var i = Int64Tensor.from(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
                 Assert.Equal(0, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(0) }).ToInt32());
                 Assert.Equal(1, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(1) }).ToInt32());
                 Assert.Equal(2, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(2) }).ToInt32());
@@ -548,7 +548,7 @@ namespace TorchSharp
         [Fact]
         public void TestIndexEllipsis()
         {
-            using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
+            using (var i = Int64Tensor.from(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
                 var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Ellipsis, TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0].ToInt32());
                 Assert.Equal(6, t1[1].ToInt32());
@@ -558,7 +558,7 @@ namespace TorchSharp
         [Fact]
         public void TestIndexNull()
         {
-            using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
+            using (var i = Int64Tensor.from(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
                 var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.None, TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0, 0].ToInt32());
                 Assert.Equal(1, t1[0, 1].ToInt32());
@@ -569,7 +569,7 @@ namespace TorchSharp
         [Fact]
         public void TestIndexNone()
         {
-            using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
+            using (var i = Int64Tensor.from(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
                 var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.None, TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0, 0].ToInt32());
                 Assert.Equal(1, t1[0, 1].ToInt32());
@@ -580,7 +580,7 @@ namespace TorchSharp
         [Fact]
         public void TestIndexSlice()
         {
-            using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
+            using (var i = Int64Tensor.from(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
                 var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(0, 2), TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0].ToInt32());
                 Assert.Equal(6, t1[1].ToInt32());
@@ -620,7 +620,7 @@ namespace TorchSharp
         [Fact]
         public void CopyCpuToCuda()
         {
-            TorchTensor cpu = Float32Tensor.Ones(new long[] { 2, 2 });
+            TorchTensor cpu = Float32Tensor.ones(new long[] { 2, 2 });
             Assert.Equal("cpu", cpu.device);
 
             if (Torch.IsCudaAvailable())
@@ -649,7 +649,7 @@ namespace TorchSharp
         {
             if (Torch.IsCudaAvailable())
             {
-                var cuda = Float32Tensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA);
+                var cuda = Float32Tensor.ones(new long[] { 2, 2 }, DeviceType.CUDA);
                 Assert.Equal("cuda:0", cuda.device);
 
                 var cpu = cuda.cpu();
@@ -663,7 +663,7 @@ namespace TorchSharp
             }
             else
             {
-                Assert.Throws<InvalidOperationException>(() => { Float32Tensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA); });
+                Assert.Throws<InvalidOperationException>(() => { Float32Tensor.ones(new long[] { 2, 2 }, DeviceType.CUDA); });
             }
         }
 
@@ -671,8 +671,8 @@ namespace TorchSharp
         public void TestSquareEuclideanDistance()
         {
             var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).to_type(ScalarType.Float32);
-            var zeros = Float32Tensor.Zeros(new long[] { 1, 9 });
-            var ones = Float32Tensor.Ones(new long[] { 1, 9 });
+            var zeros = Float32Tensor.zeros(new long[] { 1, 9 });
+            var ones = Float32Tensor.ones(new long[] { 1, 9 });
             var centroids = new TorchTensor[] { zeros, ones }.cat(0);
 
             var distanceFromZero = input.reshape(new long[] { -1, 1, 9 }).sub(zeros).pow(2.ToScalar()).sum(new long[] { 2 });
@@ -685,8 +685,8 @@ namespace TorchSharp
         [Fact]
         public void TestCat()
         {
-            var zeros = Float32Tensor.Zeros(new long[] { 1, 9 });
-            var ones = Float32Tensor.Ones(new long[] { 1, 9 });
+            var zeros = Float32Tensor.zeros(new long[] { 1, 9 });
+            var ones = Float32Tensor.ones(new long[] { 1, 9 });
             var centroids = new TorchTensor[] { zeros, ones }.cat(0);
 
             var shape = centroids.shape;
@@ -697,8 +697,8 @@ namespace TorchSharp
         public void TestCatCuda()
         {
             if (Torch.IsCudaAvailable()) {
-                var zeros = Float32Tensor.Zeros(new long[] { 1, 9 }).cuda();
-                var ones = Float32Tensor.Ones(new long[] { 1, 9 }).cuda();
+                var zeros = Float32Tensor.zeros(new long[] { 1, 9 }).cuda();
+                var ones = Float32Tensor.ones(new long[] { 1, 9 }).cuda();
                 var centroids = new TorchTensor[] { zeros, ones }.cat(0);
                 var shape = centroids.shape;
                 Assert.Equal(new long[] { 2, 9 }, shape);
@@ -709,9 +709,9 @@ namespace TorchSharp
         void TestStackGen(DeviceType device)
         {
             {
-                var t1 = Float32Tensor.Zeros( new long[] { }, device );
-                var t2 = Float32Tensor.Ones(new long[] { }, device);
-                var t3 = Float32Tensor.Ones(new long[] { }, device);
+                var t1 = Float32Tensor.zeros( new long[] { }, device );
+                var t2 = Float32Tensor.ones(new long[] { }, device);
+                var t3 = Float32Tensor.ones(new long[] { }, device);
                 var res = new TorchTensor[] { t1, t2, t3 }.stack(0);
 
                 var shape = res.shape;
@@ -719,8 +719,8 @@ namespace TorchSharp
                 Assert.Equal(device, res.device_type);
             }
             {
-                var t1 = Float32Tensor.Zeros(new long[] { 2, 9 }, device);
-                var t2 = Float32Tensor.Ones(new long[] { 2, 9 }, device);
+                var t1 = Float32Tensor.zeros(new long[] { 2, 9 }, device);
+                var t2 = Float32Tensor.ones(new long[] { 2, 9 }, device);
                 var res = new TorchTensor[] { t1, t2 }.stack(0);
 
                 var shape = res.shape;
@@ -746,7 +746,7 @@ namespace TorchSharp
         [Fact]
         public void TestSetGrad()
         {
-            var x = Float32Tensor.Random(new long[] { 10, 10 });
+            var x = Float32Tensor.rand(new long[] { 10, 10 });
             Assert.False(x.requires_grad);
 
             x.requires_grad = true;
@@ -758,7 +758,7 @@ namespace TorchSharp
         [Fact(Skip = "Not working on MacOS (note: may now be working, we need to recheck)")]
         public void TestAutoGradMode()
         {
-            var x = Float32Tensor.RandomN(new long[] { 2, 3 }, requiresGrad: true);
+            var x = Float32Tensor.randn(new long[] { 2, 3 }, requiresGrad: true);
             using (var mode = new AutoGradMode(false))
             {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
@@ -785,8 +785,8 @@ namespace TorchSharp
         [Fact]
         public void TestSubInPlace()
         {
-            var x = Int32Tensor.Ones(new long[] { 100, 100 });
-            var y = Int32Tensor.Ones(new long[] { 100, 100 });
+            var x = Int32Tensor.ones(new long[] { 100, 100 });
+            var y = Int32Tensor.ones(new long[] { 100, 100 });
 
             x.sub_(y);
 
@@ -805,7 +805,7 @@ namespace TorchSharp
         public void TestMemoryDisposalZeros()
         {
             for (int i = 0; i < 1024; i++) {
-                var x = Float64Tensor.Zeros(new long[] { 1024, 1024 });
+                var x = Float64Tensor.zeros(new long[] { 1024, 1024 });
                 x.Dispose();
                 //System.GC.Collect();
             }
@@ -815,7 +815,7 @@ namespace TorchSharp
         public void TestMemoryDisposalOnes()
         {
             for (int i = 0; i < 1024; i++) {
-                var x = Float64Tensor.Ones(new long[] { 1024, 1024 });
+                var x = Float64Tensor.ones(new long[] { 1024, 1024 });
                 x.Dispose();
             }
         }
@@ -825,7 +825,7 @@ namespace TorchSharp
         {
             for (int i = 0; i < 5; i++) {
                 for (int j = 0; j < 1000 * 100; j++) {
-                    var x = Float64Tensor.From(i * j * 3.1415);
+                    var x = Float64Tensor.from(i * j * 3.1415);
                     x.Dispose();
                 }
                 //System.GC.Collect();
@@ -850,7 +850,7 @@ namespace TorchSharp
         {
             var file = ".saveload.double.ts";
             if (File.Exists(file)) File.Delete(file);
-            var tensor = Float64Tensor.Ones(new long[] { 5, 6 });
+            var tensor = Float64Tensor.ones(new long[] { 5, 6 });
             tensor.save(file);
             var tensorLoaded = TorchTensor.load(file);
             File.Delete(file);
@@ -864,7 +864,7 @@ namespace TorchSharp
         {
             var file = ".saveload.float.ts";
             if (File.Exists(file)) File.Delete(file);
-            var tensor = Float32Tensor.Ones(new long[] { 5, 6 });
+            var tensor = Float32Tensor.ones(new long[] { 5, 6 });
             tensor.save(file);
             var tensorLoaded = TorchTensor.load(file);
             File.Delete(file);
@@ -881,9 +881,9 @@ namespace TorchSharp
             // Float16 arange_cpu not available on cuda in LibTorch 1.8.0
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
-                    var c2 = Float16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
-                    var c3 = Float16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c1 = Float16Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c2 = Float16Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c3 = Float16Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
                     // scalar-tensor operators
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a + 0.5f, a => a + 0.5f);
@@ -929,9 +929,9 @@ namespace TorchSharp
             // BFloat16 arange_cpu not available on cuda in LibTorch 1.8.0
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = BFloat16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
-                    var c2 = BFloat16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
-                    var c3 = BFloat16Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c1 = BFloat16Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c2 = BFloat16Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c3 = BFloat16Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
                     // scalar-tensor operators
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a + 0.5f, a => a + 0.5f);
@@ -975,9 +975,9 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
-                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
-                    var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c1 = Float32Tensor.arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c2 = Float32Tensor.arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c3 = Float32Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
                     // scalar-tensor operators
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a + 0.5f, a => a + 0.5f);
@@ -1021,9 +1021,9 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float64Tensor.Arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
-                    var c2 = Float64Tensor.Arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
-                    var c3 = Float64Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c1 = Float64Tensor.arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c2 = Float64Tensor.arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c3 = Float64Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, double> getFunc = (tt, i, j) => tt[i, j].ToDouble(); 
                     // scalar-tensor operators
                     TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a + 0.5, a => a + 0.5);
@@ -1067,9 +1067,9 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 =Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
-                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
-                    var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
+                    var c1 =Float32Tensor.arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c2 = Float32Tensor.arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c3 = Float32Tensor.ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i, j].ToSingle(); 
                     Func<TorchTensor, long, long, bool> getFuncBool = (tt, i, j) => tt[i, j].ToBoolean(); 
                     // scalar-tensor operators
@@ -1229,7 +1229,7 @@ namespace TorchSharp
         [Fact]
         public void TestMul()
         {
-            var x = Float32Tensor.Ones(new long[] { 100, 100 });
+            var x = Float32Tensor.ones(new long[] { 100, 100 });
 
             var y = x.mul(0.5f.ToScalar());
 
@@ -1248,8 +1248,8 @@ namespace TorchSharp
         void TestMmGen(DeviceType device)
         {
             {
-                var x1 = Float32Tensor.Ones(new long[] { 1, 2 }, deviceType: device);
-                var x2 = Float32Tensor.Ones(new long[] { 2, 1 }, deviceType: device);
+                var x1 = Float32Tensor.ones(new long[] { 1, 2 }, deviceType: device);
+                var x2 = Float32Tensor.ones(new long[] { 2, 1 }, deviceType: device);
 
                 var y = x1.mm(x2).to_device(DeviceType.CPU);
 
@@ -1259,8 +1259,8 @@ namespace TorchSharp
             }
             //System.Runtime.InteropServices.ExternalException : addmm for CUDA tensors only supports floating - point types.Try converting the tensors with.float() at C:\w\b\windows\pytorch\aten\src\THC / generic / THCTensorMathBlas.cu:453
             if (device == DeviceType.CPU) {
-                var x1 = Int64Tensor.Ones(new long[] { 1, 2 }, deviceType: device);
-                var x2 = Int64Tensor.Ones(new long[] { 2, 1 }, deviceType: device);
+                var x1 = Int64Tensor.ones(new long[] { 1, 2 }, deviceType: device);
+                var x2 = Int64Tensor.ones(new long[] { 2, 1 }, deviceType: device);
 
                 var y = x1.mm(x2).to_device(DeviceType.CPU);
 
@@ -1289,8 +1289,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Sin).ToArray();
-            var res = Float32Tensor.From(data).sin();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).sin();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1298,8 +1298,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cos).ToArray();
-            var res = Float32Tensor.From(data).cos();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).cos();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1307,8 +1307,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Tan).ToArray();
-            var res = Float32Tensor.From(data).tan();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).tan();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1316,8 +1316,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Sinh).ToArray();
-            var res = Float32Tensor.From(data).Sinh();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).Sinh();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1325,8 +1325,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cosh).ToArray();
-            var res = Float32Tensor.From(data).cosh();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).cosh();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1334,8 +1334,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Tanh).ToArray();
-            var res = Float32Tensor.From(data).tanh();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).tanh();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1343,8 +1343,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Asin).ToArray();
-            var res = Float32Tensor.From(data).asin();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).asin();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1352,8 +1352,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Acos).ToArray();
-            var res = Float32Tensor.From(data).acos();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).acos();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1361,8 +1361,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Atan).ToArray();
-            var res = Float32Tensor.From(data).atan();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).atan();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1370,8 +1370,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(x => MathF.Log(x)).ToArray();
-            var res = Float32Tensor.From(data).log();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).log();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1379,8 +1379,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Log10).ToArray();
-            var res = Float32Tensor.From(data).log10();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).log10();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1388,8 +1388,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(MathF.Floor).ToArray();
-            var res = Float32Tensor.From(data).floor();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).floor();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1397,8 +1397,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(MathF.Ceiling).ToArray();
-            var res = Float32Tensor.From(data).ceil();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).ceil();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
@@ -1406,14 +1406,14 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(x => MathF.Round(x)).ToArray();
-            var res = Float32Tensor.From(data).round();
-            Assert.True(res.allclose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.from(data).round();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
         }
 
         [Fact]
         public void ExpandTest()
         {
-            TorchTensor ones = Float32Tensor.Ones(new long[] { 2 });
+            TorchTensor ones = Float32Tensor.ones(new long[] { 2 });
             TorchTensor onesExpanded = ones.expand(new long[] { 3, 2 });
 
             Assert.Equal(onesExpanded.shape, new long[] { 3, 2 });
@@ -1431,13 +1431,13 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res1 = Float32Tensor.From(data).topk(1);
+            var res1 = Float32Tensor.from(data).topk(1);
             var res1_0 = res1.values[0].ToSingle();
             var index1_0 = res1.indexes[0].ToInt64();
             Assert.Equal(3.1f, res1_0);
             Assert.Equal(2L, index1_0);
 
-            var res2 = Float32Tensor.From(data).topk(2, sorted: true);
+            var res2 = Float32Tensor.from(data).topk(2, sorted: true);
             var res2_0 = res2.values[0].ToSingle();
             var index2_0 = res2.indexes[0].ToInt64();
             var res2_1 = res2.values[1].ToSingle();
@@ -1453,23 +1453,23 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
 
-            var res1 = Float32Tensor.From(data).sum();
+            var res1 = Float32Tensor.from(data).sum();
             var res1_0 = res1.ToSingle();
             Assert.Equal(6.0f, res1_0);
 
-            var res2 = Float32Tensor.From(data).sum(type: ScalarType.Float64);
+            var res2 = Float32Tensor.from(data).sum(type: ScalarType.Float64);
             var res2_0 = res2.ToDouble();
             Assert.Equal(6.0, res2_0);
 
             // summing integers gives long unless type is explicitly specified
             var dataInt32 = new int[] { 1, 2, 3 };
-            var res3 = Int32Tensor.From(dataInt32).sum();
+            var res3 = Int32Tensor.from(dataInt32).sum();
             Assert.Equal(ScalarType.Int64, res3.Type);
             var res3_0 = res3.ToInt64();
             Assert.Equal(6L, res3_0);
 
             // summing integers gives long unless type is explicitly specified
-            var res4 = Int32Tensor.From(dataInt32).sum(type: ScalarType.Int32);
+            var res4 = Int32Tensor.from(dataInt32).sum(type: ScalarType.Int32);
             Assert.Equal(ScalarType.Int32, res4.Type);
             var res4_0 = res4.ToInt32();
             Assert.Equal(6L, res4_0);
@@ -1481,7 +1481,7 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).unbind();
+            var res = Float32Tensor.from(data).unbind();
             Assert.Equal(3, res.Length);
             Assert.Equal(new long[] { }, res[0].shape);
             Assert.Equal(new long[] { }, res[1].shape);
@@ -1496,7 +1496,7 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).split_with_sizes(new long[] { 2, 1 });
+            var res = Float32Tensor.from(data).split_with_sizes(new long[] { 2, 1 });
             Assert.Equal(2, res.Length);
             Assert.Equal(new long[] { 2 }, res[0].shape);
             Assert.Equal(new long[] { 1 }, res[1].shape);
@@ -1508,37 +1508,37 @@ namespace TorchSharp
         [Fact]
         public void RandomTest()
         {
-            var res = Float32Tensor.Random(new long[] { 2 });
+            var res = Float32Tensor.rand(new long[] { 2 });
             Assert.Equal(new long[] { 2 }, res.shape);
 
-            var res1 = Int16Tensor.RandomIntegers(10, new long[] { 200 });
+            var res1 = Int16Tensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res1.shape);
 
-            var res2 = Int32Tensor.RandomIntegers(10, new long[] { 200 });
+            var res2 = Int32Tensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res2.shape);
 
-            var res3 = Int64Tensor.RandomIntegers(10, new long[] { 200 });
+            var res3 = Int64Tensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res3.shape);
 
-            var res4 = ByteTensor.RandomIntegers(10, new long[] { 200 });
+            var res4 = ByteTensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res4.shape);
 
-            var res5 = Int8Tensor.RandomIntegers(10, new long[] { 200 });
+            var res5 = Int8Tensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res5.shape);
 
-            var res6 = Float16Tensor.RandomIntegers(10, new long[] { 200 });
+            var res6 = Float16Tensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res6.shape);
 
-            var res7 = BFloat16Tensor.RandomIntegers(10, new long[] { 200 });
+            var res7 = BFloat16Tensor.randint(10, new long[] { 200 });
             Assert.Equal(new long[] { 200 }, res7.shape);
 
-            //var res7 = ComplexFloat16Tensor.RandomIntegers(10, new long[] { 200 });
+            //var res7 = ComplexFloat16Tensor.randint(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res7.Shape);
 
-            //var res8 = ComplexFloat32Tensor.RandomIntegers(10, new long[] { 200 });
+            //var res8 = ComplexFloat32Tensor.randint(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res8.Shape);
 
-            //var res9 = ComplexFloat64Tensor.RandomIntegers(10, new long[] { 200 });
+            //var res9 = ComplexFloat64Tensor.randint(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res9.Shape);
         }
 
@@ -1547,7 +1547,7 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).expand(new long[] { 1, 1, 3 }).squeeze(0).squeeze(0);
+            var res = Float32Tensor.from(data).expand(new long[] { 1, 1, 3 }).squeeze(0).squeeze(0);
             Assert.Equal(new long[] { 3 }, res.shape);
             Assert.Equal(1.1f, res[0].ToSingle());
             Assert.Equal(2.0f, res[1].ToSingle());
@@ -1559,7 +1559,7 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).narrow(0, 1, 2);
+            var res = Float32Tensor.from(data).narrow(0, 1, 2);
             Assert.Equal(new long[] { 2 }, res.shape);
             Assert.Equal(2.0f, res[0].ToSingle());
             Assert.Equal(3.1f, res[1].ToSingle());
@@ -1570,14 +1570,14 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f, 4.0f };
 
-            var res = Float32Tensor.From(data).slice(0, 1, 1, 1);
+            var res = Float32Tensor.from(data).slice(0, 1, 1, 1);
             Assert.Equal(new long[] { 0 }, res.shape);
 
-            var res2 = Float32Tensor.From(data).slice(0, 1, 2, 1);
+            var res2 = Float32Tensor.from(data).slice(0, 1, 2, 1);
             Assert.Equal(new long[] { 1 }, res2.shape);
             Assert.Equal(2.0f, res2[0].ToSingle());
 
-            var res3 = Float32Tensor.From(data).slice(0, 1, 4, 2);
+            var res3 = Float32Tensor.from(data).slice(0, 1, 4, 2);
             Assert.Equal(new long[] { 2 }, res3.shape);
             Assert.Equal(2.0f, res3[0].ToSingle());
             Assert.Equal(4.0f, res3[1].ToSingle());
@@ -1617,8 +1617,8 @@ namespace TorchSharp
             var t2raw = new float[2 * 4 * 3];
             { for (int i = 0; i < 3; i++) for (int j = 0; j < 4; j++) for (int k = 0; k < 5; k++) { t1raw[i * 4 * 5 + j * 5 + k] = t1[i, j, k]; } }
             { for (int i = 0; i < 2; i++) for (int j = 0; j < 4; j++) for (int k = 0; k < 3; k++) { t2raw[i * 4 * 3 + j * 3 + k] = t2[i, j, k]; } }
-            var t1t = Float32Tensor.From(t1raw, new long[] { 3, 4, 5 });
-            var t2t = Float32Tensor.From(t2raw, new long[] { 2, 4, 3 });
+            var t1t = Float32Tensor.from(t1raw, new long[] { 3, 4, 5 });
+            var t2t = Float32Tensor.from(t2raw, new long[] { 2, 4, 3 });
             var t3t = t1t.conv1d(t2t);
 
             // Check the answer

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -18,7 +18,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 2 };
             TorchTensor t = Float32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 1].ToSingle());
         }
@@ -28,7 +28,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 2 };
             TorchTensor t = ByteTensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal((byte)1, t[0,0].ToByte());
             Assert.Equal((byte)1, t[1,1].ToByte());
         }
@@ -38,7 +38,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 2 };
             TorchTensor t = Int32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1, t[0,0].ToInt32());
             Assert.Equal(1, t[1,1].ToInt32());
         }
@@ -49,7 +49,7 @@ namespace TorchSharp
             var shape = new long[] { 2, 2 };
 
             TorchTensor t = Int64Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1L, t[0,0].ToInt64());
             Assert.Equal(1L, t[1,1].ToInt64());
         }
@@ -60,7 +60,7 @@ namespace TorchSharp
             var shape = new long[] { 2, 2 };
 
             TorchTensor t = BoolTensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal((object)true, t[0,0].ToBoolean());
             Assert.Equal((object)true, t[1,1].ToBoolean());
         }
@@ -73,7 +73,7 @@ namespace TorchSharp
                     var shape = new long[] { 2, 2 };
 
                     TorchTensor t = Float16Tensor.Ones(shape, deviceType: deviceType);
-                    Assert.Equal(shape, t.Shape);
+                    Assert.Equal(shape, t.shape);
                     Assert.Equal(1.0f, t[0, 0].ToSingle());
                     Assert.Equal(1.0f, t[1, 1].ToSingle());
                 }
@@ -88,7 +88,7 @@ namespace TorchSharp
                     var shape = new long[] { 2, 2 };
 
                     TorchTensor t = BFloat16Tensor.Ones(shape, deviceType: deviceType);
-                    Assert.Equal(shape, t.Shape);
+                    Assert.Equal(shape, t.shape);
                     Assert.Equal(1.0f, t[0, 0].ToSingle());
                     Assert.Equal(1.0f, t[1, 1].ToSingle());
                 }
@@ -210,9 +210,9 @@ namespace TorchSharp
         public void CreateFloat32TensorCheckDevice()
         {
             var ones = Float32Tensor.Ones(new long[] { 2, 2 });
-            var device = ones.DeviceString;
+            var device = ones.device;
 
-            Assert.Equal("cpu", ones.DeviceString);
+            Assert.Equal("cpu", ones.device);
         }
 
         [Fact]
@@ -372,7 +372,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 3 };
             TorchTensor t = Float32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2].ToSingle());
             t[1, 2] = Float32Tensor.From(2.0f);
@@ -384,7 +384,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 3, 4 };
             TorchTensor t = Float32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3].ToSingle());
             t[1, 2, 3] = Float32Tensor.From(2.0f);
@@ -396,7 +396,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 3, 4, 5 };
             TorchTensor t = Float32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3, 4].ToSingle());
             t[1, 2, 3, 4] = Float32Tensor.From(2.0f);
@@ -408,7 +408,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 3, 4, 5, 6 };
             TorchTensor t = Float32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3, 4, 5].ToSingle());
             t[1, 2, 3, 4, 5] = Float32Tensor.From(2.0f);
@@ -421,7 +421,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 2, 3, 4, 5, 6, 7 };
             TorchTensor t = Float32Tensor.Ones(shape);
-            Assert.Equal(shape, t.Shape);
+            Assert.Equal(shape, t.shape);
             Assert.Equal(1.0f, t[0, 0, 0, 0, 0, 0].ToSingle());
             Assert.Equal(1.0f, t[1, 2, 3, 4, 5, 6].ToSingle());
             t[1, 2, 3, 4, 5, 6] = Float32Tensor.From(2.0f);
@@ -536,12 +536,12 @@ namespace TorchSharp
         public void TestIndexSingle()
         {
             using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
-                Assert.Equal(0, i.Index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(0) }).ToInt32());
-                Assert.Equal(1, i.Index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(1) }).ToInt32());
-                Assert.Equal(2, i.Index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(2) }).ToInt32());
-                Assert.Equal(6, i.Index(new TorchTensorIndex[] { TorchTensorIndex.Single(1), TorchTensorIndex.Single(0) }).ToInt32());
-                Assert.Equal(5, i.Index(new TorchTensorIndex[] { TorchTensorIndex.Single(1), TorchTensorIndex.Single(1) }).ToInt32());
-                Assert.Equal(4, i.Index(new TorchTensorIndex[] { TorchTensorIndex.Single(1), TorchTensorIndex.Single(2) }).ToInt32());
+                Assert.Equal(0, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(0) }).ToInt32());
+                Assert.Equal(1, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(1) }).ToInt32());
+                Assert.Equal(2, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(0), TorchTensorIndex.Single(2) }).ToInt32());
+                Assert.Equal(6, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(1), TorchTensorIndex.Single(0) }).ToInt32());
+                Assert.Equal(5, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(1), TorchTensorIndex.Single(1) }).ToInt32());
+                Assert.Equal(4, i.index(new TorchTensorIndex[] { TorchTensorIndex.Single(1), TorchTensorIndex.Single(2) }).ToInt32());
             }
         }
 
@@ -549,7 +549,7 @@ namespace TorchSharp
         public void TestIndexEllipsis()
         {
             using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
-                var t1 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Ellipsis, TorchTensorIndex.Single(0) });
+                var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Ellipsis, TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0].ToInt32());
                 Assert.Equal(6, t1[1].ToInt32());
             }
@@ -559,7 +559,7 @@ namespace TorchSharp
         public void TestIndexNull()
         {
             using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
-                var t1 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.None, TorchTensorIndex.Single(0) });
+                var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.None, TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0, 0].ToInt32());
                 Assert.Equal(1, t1[0, 1].ToInt32());
                 Assert.Equal(2, t1[0, 2].ToInt32());
@@ -570,7 +570,7 @@ namespace TorchSharp
         public void TestIndexNone()
         {
             using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
-                var t1 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.None, TorchTensorIndex.Single(0) });
+                var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.None, TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0, 0].ToInt32());
                 Assert.Equal(1, t1[0, 1].ToInt32());
                 Assert.Equal(2, t1[0, 2].ToInt32());
@@ -581,36 +581,36 @@ namespace TorchSharp
         public void TestIndexSlice()
         {
             using (var i = Int64Tensor.From(new long[] { 0, 1, 2, 6, 5, 4 }, new long[] { 2, 3 })) {
-                var t1 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(0, 2), TorchTensorIndex.Single(0) });
+                var t1 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(0, 2), TorchTensorIndex.Single(0) });
                 Assert.Equal(0, t1[0].ToInt32());
                 Assert.Equal(6, t1[1].ToInt32());
 
                 // one slice
-                var t2 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(1, 2), TorchTensorIndex.Single(0) });
+                var t2 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(1, 2), TorchTensorIndex.Single(0) });
                 Assert.Equal(6, t2[0].ToInt32());
 
                 // two slice
-                var t3 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(1, 2), TorchTensorIndex.Slice(1, 3) });
+                var t3 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(1, 2), TorchTensorIndex.Slice(1, 3) });
                 Assert.Equal(5, t3[0, 0].ToInt32());
                 Assert.Equal(4, t3[0, 1].ToInt32());
 
                 // slice with step
-                var t4 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(1, 2), TorchTensorIndex.Slice(0, 3, step: 2) });
+                var t4 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(1, 2), TorchTensorIndex.Slice(0, 3, step: 2) });
                 Assert.Equal(6, t4[0, 0].ToInt32());
                 Assert.Equal(4, t4[0, 1].ToInt32());
 
                 // end absent
-                var t5 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(start: 1), TorchTensorIndex.Slice(start: 1) });
+                var t5 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(start: 1), TorchTensorIndex.Slice(start: 1) });
                 Assert.Equal(5, t5[0, 0].ToInt32());
                 Assert.Equal(4, t5[0, 1].ToInt32());
 
                 // start absent
-                var t6 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(start: 1), TorchTensorIndex.Slice(stop: 2) });
+                var t6 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(start: 1), TorchTensorIndex.Slice(stop: 2) });
                 Assert.Equal(6, t6[0, 0].ToInt32());
                 Assert.Equal(5, t6[0, 1].ToInt32());
 
                 // start and end absent
-                var t7 = i.Index(new TorchTensorIndex[] { TorchTensorIndex.Slice(start: 1), TorchTensorIndex.Slice(step: 2) });
+                var t7 = i.index(new TorchTensorIndex[] { TorchTensorIndex.Slice(start: 1), TorchTensorIndex.Slice(step: 2) });
                 Assert.Equal(6, t7[0, 0].ToInt32());
                 Assert.Equal(4, t7[0, 1].ToInt32());
             }
@@ -621,16 +621,16 @@ namespace TorchSharp
         public void CopyCpuToCuda()
         {
             TorchTensor cpu = Float32Tensor.Ones(new long[] { 2, 2 });
-            Assert.Equal("cpu", cpu.DeviceString);
+            Assert.Equal("cpu", cpu.device);
 
             if (Torch.IsCudaAvailable())
             {
-                var cuda = cpu.Cuda();
-                Assert.Equal("cuda:0", cuda.DeviceString);
+                var cuda = cpu.cuda();
+                Assert.Equal("cuda:0", cuda.device);
 
                 // Copy back to CPU to inspect the elements
-                var cpu2 = cuda.Cpu();
-                Assert.Equal("cpu", cpu2.DeviceString);
+                var cpu2 = cuda.cpu();
+                Assert.Equal("cpu", cpu2.device);
                 var data = cpu.Data<float>();
                 for (int i = 0; i < 4; i++)
                 {
@@ -639,7 +639,7 @@ namespace TorchSharp
             }
             else
             {
-                Assert.Throws<InvalidOperationException>(() => cpu.Cuda());
+                Assert.Throws<InvalidOperationException>(() => cpu.cuda());
             }
 
         }
@@ -650,10 +650,10 @@ namespace TorchSharp
             if (Torch.IsCudaAvailable())
             {
                 var cuda = Float32Tensor.Ones(new long[] { 2, 2 }, DeviceType.CUDA);
-                Assert.Equal("cuda:0", cuda.DeviceString);
+                Assert.Equal("cuda:0", cuda.device);
 
-                var cpu = cuda.Cpu();
-                Assert.Equal("cpu", cpu.DeviceString);
+                var cpu = cuda.cpu();
+                Assert.Equal("cpu", cpu.device);
 
                 var data = cpu.Data<float>();
                 for (int i = 0; i < 4; i++)
@@ -670,14 +670,14 @@ namespace TorchSharp
         [Fact]
         public void TestSquareEuclideanDistance()
         {
-            var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).ToType(ScalarType.Float32);
+            var input = new double[] { 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1 }.ToTorchTensor(new long[] { 9 }).to_type(ScalarType.Float32);
             var zeros = Float32Tensor.Zeros(new long[] { 1, 9 });
             var ones = Float32Tensor.Ones(new long[] { 1, 9 });
-            var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
+            var centroids = new TorchTensor[] { zeros, ones }.cat(0);
 
-            var distanceFromZero = input.Reshape(new long[] { -1, 1, 9 }).Sub(zeros).Pow(2.ToScalar()).Sum(new long[] { 2 });
-            var distanceFromOne = input.Reshape(new long[] { -1, 1, 9 }).Sub(ones).Pow(2.ToScalar()).Sum(new long[] { 2 });
-            var distanceFromCentroids = input.Reshape(new long[] { -1, 1, 9 }).Sub(centroids).Pow(2.ToScalar()).Sum(new long[] { 2 });
+            var distanceFromZero = input.reshape(new long[] { -1, 1, 9 }).sub(zeros).pow(2.ToScalar()).sum(new long[] { 2 });
+            var distanceFromOne = input.reshape(new long[] { -1, 1, 9 }).sub(ones).pow(2.ToScalar()).sum(new long[] { 2 });
+            var distanceFromCentroids = input.reshape(new long[] { -1, 1, 9 }).sub(centroids).pow(2.ToScalar()).sum(new long[] { 2 });
 
             Assert.True(true);
         }
@@ -687,9 +687,9 @@ namespace TorchSharp
         {
             var zeros = Float32Tensor.Zeros(new long[] { 1, 9 });
             var ones = Float32Tensor.Ones(new long[] { 1, 9 });
-            var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
+            var centroids = new TorchTensor[] { zeros, ones }.cat(0);
 
-            var shape = centroids.Shape;
+            var shape = centroids.shape;
             Assert.Equal(new long[] { 2, 9 }, shape);
         }
 
@@ -697,12 +697,12 @@ namespace TorchSharp
         public void TestCatCuda()
         {
             if (Torch.IsCudaAvailable()) {
-                var zeros = Float32Tensor.Zeros(new long[] { 1, 9 }).Cuda();
-                var ones = Float32Tensor.Ones(new long[] { 1, 9 }).Cuda();
-                var centroids = new TorchTensor[] { zeros, ones }.Cat(0);
-                var shape = centroids.Shape;
+                var zeros = Float32Tensor.Zeros(new long[] { 1, 9 }).cuda();
+                var ones = Float32Tensor.Ones(new long[] { 1, 9 }).cuda();
+                var centroids = new TorchTensor[] { zeros, ones }.cat(0);
+                var shape = centroids.shape;
                 Assert.Equal(new long[] { 2, 9 }, shape);
-                Assert.Equal(DeviceType.CUDA, centroids.DeviceType);
+                Assert.Equal(DeviceType.CUDA, centroids.device_type);
             }
         }
 
@@ -712,20 +712,20 @@ namespace TorchSharp
                 var t1 = Float32Tensor.Zeros( new long[] { }, device );
                 var t2 = Float32Tensor.Ones(new long[] { }, device);
                 var t3 = Float32Tensor.Ones(new long[] { }, device);
-                var res = new TorchTensor[] { t1, t2, t3 }.Stack(0);
+                var res = new TorchTensor[] { t1, t2, t3 }.stack(0);
 
-                var shape = res.Shape;
+                var shape = res.shape;
                 Assert.Equal(new long[] { 3 }, shape);
-                Assert.Equal(device, res.DeviceType);
+                Assert.Equal(device, res.device_type);
             }
             {
                 var t1 = Float32Tensor.Zeros(new long[] { 2, 9 }, device);
                 var t2 = Float32Tensor.Ones(new long[] { 2, 9 }, device);
-                var res = new TorchTensor[] { t1, t2 }.Stack(0);
+                var res = new TorchTensor[] { t1, t2 }.stack(0);
 
-                var shape = res.Shape;
+                var shape = res.shape;
                 Assert.Equal(new long[] { 2, 2, 9 }, shape);
-                Assert.Equal(device, res.DeviceType);
+                Assert.Equal(device, res.device_type);
             }
         }
 
@@ -747,12 +747,12 @@ namespace TorchSharp
         public void TestSetGrad()
         {
             var x = Float32Tensor.Random(new long[] { 10, 10 });
-            Assert.False(x.IsGradRequired);
+            Assert.False(x.requires_grad);
 
-            x.RequiresGrad(true);
-            Assert.True(x.IsGradRequired);
-            x.RequiresGrad(false);
-            Assert.False(x.IsGradRequired);
+            x.requires_grad = true;
+            Assert.True(x.requires_grad);
+            x.requires_grad = false;
+            Assert.False(x.requires_grad);
         }
 
         [Fact(Skip = "Not working on MacOS (note: may now be working, we need to recheck)")]
@@ -762,17 +762,17 @@ namespace TorchSharp
             using (var mode = new AutoGradMode(false))
             {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
-                var sum = x.Sum();
-                Assert.Throws<ExternalException>(() => sum.Backward());
+                var sum = x.sum();
+                Assert.Throws<ExternalException>(() => sum.backward());
                 //var grad = x.Grad();
                 //Assert.True(grad.Handle == IntPtr.Zero);
             }
             using (var mode = new AutoGradMode(true))
             {
                 Assert.True(AutoGradMode.IsAutogradEnabled());
-                var sum = x.Sum();
-                sum.Backward();
-                var grad = x.Grad();
+                var sum = x.sum();
+                sum.backward();
+                var grad = x.grad();
                 Assert.False(grad.Handle == IntPtr.Zero);
                 var data = grad.Data<float>();
                 for (int i = 0; i < 2 * 3; i++)
@@ -788,7 +788,7 @@ namespace TorchSharp
             var x = Int32Tensor.Ones(new long[] { 100, 100 });
             var y = Int32Tensor.Ones(new long[] { 100, 100 });
 
-            x.SubInPlace(y);
+            x.sub_(y);
 
             var xdata = x.Data<int>();
 
@@ -851,8 +851,8 @@ namespace TorchSharp
             var file = ".saveload.double.ts";
             if (File.Exists(file)) File.Delete(file);
             var tensor = Float64Tensor.Ones(new long[] { 5, 6 });
-            tensor.Save(file);
-            var tensorLoaded = TorchTensor.Load(file);
+            tensor.save(file);
+            var tensorLoaded = TorchTensor.load(file);
             File.Delete(file);
             Assert.NotNull(tensorLoaded);
             Assert.Equal(tensorLoaded.Type, tensor.Type);
@@ -865,8 +865,8 @@ namespace TorchSharp
             var file = ".saveload.float.ts";
             if (File.Exists(file)) File.Delete(file);
             var tensor = Float32Tensor.Ones(new long[] { 5, 6 });
-            tensor.Save(file);
-            var tensorLoaded = TorchTensor.Load(file);
+            tensor.save(file);
+            var tensorLoaded = TorchTensor.load(file);
             File.Delete(file);
             Assert.NotNull(tensorLoaded);
             Assert.Equal(tensorLoaded.Type, tensor.Type);
@@ -893,15 +893,15 @@ namespace TorchSharp
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f * a, a => 0.5f * a);
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a / 0.5f, a => a / 0.5f);
 
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Add(0.5f), a => a + 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Sub(0.5f), a => a - 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Mul(0.5f), a => a * 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Div(0.5f), a => a / 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.add(0.5f), a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.sub(0.5f), a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.mul(0.5f), a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.div(0.5f), a => a / 0.5f);
 
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.AddInPlace(0.5f), a => a + 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.SubInPlace(0.5f), a => a - 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.MulInPlace(0.5f), a => a * 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.DivInPlace(0.5f), a => a / 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.add_(0.5f), a => a + 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.sub_(0.5f), a => a - 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.mul_(0.5f), a => a * 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.div_(0.5f), a => a / 0.5f);
 
                     // tensor-tensor operators
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
@@ -909,15 +909,15 @@ namespace TorchSharp
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
 
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.add(b), (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.sub(b), (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.mul(b), (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.div(b), (a, b) => a / b);
 
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.add_(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.sub_(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.mul_(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.div_(b), (a, b) => a / b);
                 }
             }
         }
@@ -941,15 +941,15 @@ namespace TorchSharp
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f * a, a => 0.5f * a);
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a / 0.5f, a => a / 0.5f);
 
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Add(0.5f), a => a + 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Sub(0.5f), a => a - 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Mul(0.5f), a => a * 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Div(0.5f), a => a / 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.add(0.5f), a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.sub(0.5f), a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.mul(0.5f), a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.div(0.5f), a => a / 0.5f);
 
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.AddInPlace(0.5f), a => a + 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.SubInPlace(0.5f), a => a - 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.MulInPlace(0.5f), a => a * 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.DivInPlace(0.5f), a => a / 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.add_(0.5f), a => a + 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.sub_(0.5f), a => a - 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.mul_(0.5f), a => a * 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.div_(0.5f), a => a / 0.5f);
 
                     // tensor-tensor operators
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
@@ -957,15 +957,15 @@ namespace TorchSharp
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
 
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.add(b), (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.sub(b), (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.mul(b), (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.div(b), (a, b) => a / b);
 
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.add_(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.sub_(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.mul_(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.div_(b), (a, b) => a / b);
                 }
             }
         }
@@ -975,8 +975,8 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).Expand(new long[] { 10, 10 });
-                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).Expand(new long[] { 10, 10 });
+                    var c1 = Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
                     var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i,j].ToSingle();
                     // scalar-tensor operators
@@ -987,15 +987,15 @@ namespace TorchSharp
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => 0.5f * a, a => 0.5f * a);
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a / 0.5f, a => a / 0.5f);
 
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Add(0.5f), a => a + 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Sub(0.5f), a => a - 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Mul(0.5f), a => a * 0.5f);
-                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.Div(0.5f), a => a / 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.add(0.5f), a => a + 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.sub(0.5f), a => a - 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.mul(0.5f), a => a * 0.5f);
+                    TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a.div(0.5f), a => a / 0.5f);
 
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.AddInPlace(0.5f), a => a + 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.SubInPlace(0.5f), a => a - 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.MulInPlace(0.5f), a => a * 0.5f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.DivInPlace(0.5f), a => a / 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.add_(0.5f), a => a + 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.sub_(0.5f), a => a - 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.mul_(0.5f), a => a * 0.5f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.div_(0.5f), a => a / 0.5f);
 
                     // tensor-tensor operators
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
@@ -1003,15 +1003,15 @@ namespace TorchSharp
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
 
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
-                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.add(b), (a, b) => a + b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.sub(b), (a, b) => a - b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.mul(b), (a, b) => a * b);
+                    TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a.div(b), (a, b) => a / b);
 
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.add_(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.sub_(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.mul_(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.div_(b), (a, b) => a / b);
                 }
             }
         }
@@ -1021,8 +1021,8 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 = Float64Tensor.Arange(0, 10, 1, deviceType: deviceType).Expand(new long[] { 10, 10 });
-                    var c2 = Float64Tensor.Arange(10, 0, -1, deviceType: deviceType).Expand(new long[] { 10, 10 });
+                    var c1 = Float64Tensor.Arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c2 = Float64Tensor.Arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
                     var c3 = Float64Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, double> getFunc = (tt, i, j) => tt[i, j].ToDouble(); 
                     // scalar-tensor operators
@@ -1033,15 +1033,15 @@ namespace TorchSharp
                     TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => 0.5 * a, a => 0.5 * a);
                     TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a / 0.5, a => a / 0.5);
 
-                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Add(0.5), a => a + 0.5);
-                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Sub(0.5), a => a - 0.5);
-                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Mul(0.5), a => a * 0.5);
-                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.Div(0.5), a => a / 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.add(0.5), a => a + 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.sub(0.5), a => a - 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.mul(0.5), a => a * 0.5);
+                    TestOneTensor<double, double>(c1, c2, getFunc, getFunc, a => a.div(0.5), a => a / 0.5);
 
-                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.AddInPlace(0.5), a => a + 0.5);
-                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.SubInPlace(0.5), a => a - 0.5);
-                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.MulInPlace(0.5), a => a * 0.5);
-                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.DivInPlace(0.5), a => a / 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.add_(0.5), a => a + 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.sub_(0.5), a => a - 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.mul_(0.5), a => a * 0.5);
+                    TestOneTensorInPlace<double>(c1, c2, getFunc, a => a.div_(0.5), a => a / 0.5);
 
                     // tensor-tensor operators
                     TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a + b, (a, b) => a + b);
@@ -1049,15 +1049,15 @@ namespace TorchSharp
                     TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a * b, (a, b) => a * b);
                     TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a / b, (a, b) => a / b);
 
-                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Add(b), (a, b) => a + b);
-                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Sub(b), (a, b) => a - b);
-                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Mul(b), (a, b) => a * b);
-                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.Div(b), (a, b) => a / b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.add(b), (a, b) => a + b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.sub(b), (a, b) => a - b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.mul(b), (a, b) => a * b);
+                    TestTwoTensor<double, double>(c1, c2, c3, getFunc, getFunc, (a, b) => a.div(b), (a, b) => a / b);
 
-                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.AddInPlace(b), (a, b) => a + b);
-                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.SubInPlace(b), (a, b) => a - b);
-                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.MulInPlace(b), (a, b) => a * b);
-                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.DivInPlace(b), (a, b) => a / b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.add_(b), (a, b) => a + b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.sub_(b), (a, b) => a - b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.mul_(b), (a, b) => a * b);
+                    TestTwoTensorInPlace<double>(c1, c2, c3, getFunc, (a, b) => a.div_(b), (a, b) => a / b);
                 }
             }
         }
@@ -1067,16 +1067,16 @@ namespace TorchSharp
         {
             foreach (var deviceType in new DeviceType[] { DeviceType.CPU, DeviceType.CUDA }) {
                 if (deviceType != DeviceType.CUDA || Torch.IsCudaAvailable()) {
-                    var c1 =Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).Expand(new long[] { 10, 10 });
-                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).Expand(new long[] { 10, 10 });
+                    var c1 =Float32Tensor.Arange(0, 10, 1, deviceType: deviceType).expand(new long[] { 10, 10 });
+                    var c2 = Float32Tensor.Arange(10, 0, -1, deviceType: deviceType).expand(new long[] { 10, 10 });
                     var c3 = Float32Tensor.Ones(new long[] { 10, 10 }, deviceType: deviceType);
                     Func<TorchTensor, long, long, float> getFunc = (tt, i, j) => tt[i, j].ToSingle(); 
                     Func<TorchTensor, long, long, bool> getFuncBool = (tt, i, j) => tt[i, j].ToBoolean(); 
                     // scalar-tensor operators
                     TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a == 5.0f, a => a == 5.0f);
                     TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a != 5.0f, a => a != 5.0f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.EqInPlace(5.0f), a => a == 5.0f ? 1.0f : 0.0f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.NeInPlace(5.0f), a => a != 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.eq_(5.0f), a => a == 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.ne_(5.0f), a => a != 5.0f ? 1.0f : 0.0f);
 
                     TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a < 5.0f, a => a < 5.0f);
                     TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => 5.0f < a, a => 5.0f < a);
@@ -1087,32 +1087,32 @@ namespace TorchSharp
                     TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => a >= 5.0f, a => a >= 5.0f);
                     TestOneTensor<float, bool>(c1, c2, getFunc, getFuncBool, a => 5.0f >= a, a => 5.0f >= a);
 
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.LtInPlace(5.0f), a => a < 5.0f ? 1.0f : 0.0f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.LeInPlace(5.0f), a => a <= 5.0f ? 1.0f : 0.0f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.GtInPlace(5.0f), a => a > 5.0f ? 1.0f : 0.0f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.GeInPlace(5.0f), a => a >= 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.lt_(5.0f), a => a < 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.le_(5.0f), a => a <= 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.gt_(5.0f), a => a > 5.0f ? 1.0f : 0.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.ge_(5.0f), a => a >= 5.0f ? 1.0f : 0.0f);
 
                     TestOneTensor<float, float>(c1, c2, getFunc, getFunc, a => a % 5.0f, a => a % 5.0f);
-                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.RemainderInPlace(5.0f), a => a % 5.0f);
+                    TestOneTensorInPlace<float>(c1, c2, getFunc, a => a.remainder_(5.0f), a => a % 5.0f);
 
                     // tensor-tensor operators
                     TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a == b, (a, b) => a == b);
                     TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a != b, (a, b) => a != b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.EqInPlace(b), (a, b) => a == b ? 1.0f : 0.0f);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.NeInPlace(b), (a, b) => a != b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.eq_(b), (a, b) => a == b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.ne_(b), (a, b) => a != b ? 1.0f : 0.0f);
 
                     TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a < b, (a, b) => a < b);
                     TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a <= b, (a, b) => a <= b);
                     TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a > b, (a, b) => a > b);
                     TestTwoTensor<float, bool>(c1, c2, c3, getFunc, getFuncBool, (a, b) => a >= b, (a, b) => a >= b);
 
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.LtInPlace(b), (a, b) => a < b ? 1.0f : 0.0f);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.LeInPlace(b), (a, b) => a <= b ? 1.0f : 0.0f);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.GtInPlace(b), (a, b) => a > b ? 1.0f : 0.0f);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.GeInPlace(b), (a, b) => a >= b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.lt_(b), (a, b) => a < b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.le_(b), (a, b) => a <= b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.gt_(b), (a, b) => a > b ? 1.0f : 0.0f);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.ge_(b), (a, b) => a >= b ? 1.0f : 0.0f);
 
                     TestTwoTensor<float, float>(c1, c2, c3, getFunc, getFunc, (a, b) => a % b, (a, b) => a % b);
-                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.RemainderInPlace(b), (a, b) => a % b);
+                    TestTwoTensorInPlace<float>(c1, c2, c3, getFunc, (a, b) => a.remainder_(b), (a, b) => a % b);
                 }
             }
         }
@@ -1148,7 +1148,7 @@ namespace TorchSharp
         {
 
             var x = c1 * c2;
-            var xClone = x.Clone();
+            var xClone = x.clone();
             var y = tensorFunc(x);
 
             for (int i = 0; i < 10; i++)
@@ -1201,7 +1201,7 @@ namespace TorchSharp
         {
 
             var x = c1 * c3;
-            var xClone = x.Clone();
+            var xClone = x.clone();
             var y = c2 * c3;
 
             var z = tensorFunc(x, y);
@@ -1231,7 +1231,7 @@ namespace TorchSharp
         {
             var x = Float32Tensor.Ones(new long[] { 100, 100 });
 
-            var y = x.Mul(0.5f.ToScalar());
+            var y = x.mul(0.5f.ToScalar());
 
             var ydata = y.Data<float>();
             var xdata = x.Data<float>();
@@ -1251,7 +1251,7 @@ namespace TorchSharp
                 var x1 = Float32Tensor.Ones(new long[] { 1, 2 }, deviceType: device);
                 var x2 = Float32Tensor.Ones(new long[] { 2, 1 }, deviceType: device);
 
-                var y = x1.Mm(x2).ToDevice(DeviceType.CPU);
+                var y = x1.mm(x2).to_device(DeviceType.CPU);
 
                 var ydata = y.Data<float>();
 
@@ -1262,7 +1262,7 @@ namespace TorchSharp
                 var x1 = Int64Tensor.Ones(new long[] { 1, 2 }, deviceType: device);
                 var x2 = Int64Tensor.Ones(new long[] { 2, 1 }, deviceType: device);
 
-                var y = x1.Mm(x2).ToDevice(DeviceType.CPU);
+                var y = x1.mm(x2).to_device(DeviceType.CPU);
 
                 var ydata = y.Data<long>();
 
@@ -1289,8 +1289,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Sin).ToArray();
-            var res = Float32Tensor.From(data).Sin();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).sin();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1298,8 +1298,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cos).ToArray();
-            var res = Float32Tensor.From(data).Cos();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).cos();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1307,8 +1307,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Tan).ToArray();
-            var res = Float32Tensor.From(data).Tan();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).tan();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1317,7 +1317,7 @@ namespace TorchSharp
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Sinh).ToArray();
             var res = Float32Tensor.From(data).Sinh();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1325,8 +1325,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cosh).ToArray();
-            var res = Float32Tensor.From(data).Cosh();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).cosh();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1334,8 +1334,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Tanh).ToArray();
-            var res = Float32Tensor.From(data).Tanh();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).tanh();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1343,8 +1343,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Asin).ToArray();
-            var res = Float32Tensor.From(data).Asin();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).asin();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1352,8 +1352,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Acos).ToArray();
-            var res = Float32Tensor.From(data).Acos();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).acos();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1361,8 +1361,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 0.2f, -0.1f };
             var expected = data.Select(MathF.Atan).ToArray();
-            var res = Float32Tensor.From(data).Atan();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).atan();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1370,8 +1370,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(x => MathF.Log(x)).ToArray();
-            var res = Float32Tensor.From(data).Log();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).log();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1379,8 +1379,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Log10).ToArray();
-            var res = Float32Tensor.From(data).Log10();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).log10();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1388,8 +1388,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(MathF.Floor).ToArray();
-            var res = Float32Tensor.From(data).Floor();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).floor();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1397,8 +1397,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(MathF.Ceiling).ToArray();
-            var res = Float32Tensor.From(data).Ceil();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).ceil();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
@@ -1406,17 +1406,17 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
             var expected = data.Select(x => MathF.Round(x)).ToArray();
-            var res = Float32Tensor.From(data).Round();
-            Assert.True(res.AllClose(Float32Tensor.From(expected)));
+            var res = Float32Tensor.From(data).round();
+            Assert.True(res.allclose(Float32Tensor.From(expected)));
         }
 
         [Fact]
         public void ExpandTest()
         {
             TorchTensor ones = Float32Tensor.Ones(new long[] { 2 });
-            TorchTensor onesExpanded = ones.Expand(new long[] { 3, 2 });
+            TorchTensor onesExpanded = ones.expand(new long[] { 3, 2 });
 
-            Assert.Equal(onesExpanded.Shape, new long[] { 3, 2 });
+            Assert.Equal(onesExpanded.shape, new long[] { 3, 2 });
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 2; j++)
@@ -1431,13 +1431,13 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res1 = Float32Tensor.From(data).TopK(1);
+            var res1 = Float32Tensor.From(data).topk(1);
             var res1_0 = res1.values[0].ToSingle();
             var index1_0 = res1.indexes[0].ToInt64();
             Assert.Equal(3.1f, res1_0);
             Assert.Equal(2L, index1_0);
 
-            var res2 = Float32Tensor.From(data).TopK(2, sorted: true);
+            var res2 = Float32Tensor.From(data).topk(2, sorted: true);
             var res2_0 = res2.values[0].ToSingle();
             var index2_0 = res2.indexes[0].ToInt64();
             var res2_1 = res2.values[1].ToSingle();
@@ -1453,23 +1453,23 @@ namespace TorchSharp
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };
 
-            var res1 = Float32Tensor.From(data).Sum();
+            var res1 = Float32Tensor.From(data).sum();
             var res1_0 = res1.ToSingle();
             Assert.Equal(6.0f, res1_0);
 
-            var res2 = Float32Tensor.From(data).Sum(type: ScalarType.Float64);
+            var res2 = Float32Tensor.From(data).sum(type: ScalarType.Float64);
             var res2_0 = res2.ToDouble();
             Assert.Equal(6.0, res2_0);
 
             // summing integers gives long unless type is explicitly specified
             var dataInt32 = new int[] { 1, 2, 3 };
-            var res3 = Int32Tensor.From(dataInt32).Sum();
+            var res3 = Int32Tensor.From(dataInt32).sum();
             Assert.Equal(ScalarType.Int64, res3.Type);
             var res3_0 = res3.ToInt64();
             Assert.Equal(6L, res3_0);
 
             // summing integers gives long unless type is explicitly specified
-            var res4 = Int32Tensor.From(dataInt32).Sum(type: ScalarType.Int32);
+            var res4 = Int32Tensor.From(dataInt32).sum(type: ScalarType.Int32);
             Assert.Equal(ScalarType.Int32, res4.Type);
             var res4_0 = res4.ToInt32();
             Assert.Equal(6L, res4_0);
@@ -1481,11 +1481,11 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).Unbind();
+            var res = Float32Tensor.From(data).unbind();
             Assert.Equal(3, res.Length);
-            Assert.Equal(new long[] { }, res[0].Shape);
-            Assert.Equal(new long[] { }, res[1].Shape);
-            Assert.Equal(new long[] { }, res[2].Shape);
+            Assert.Equal(new long[] { }, res[0].shape);
+            Assert.Equal(new long[] { }, res[1].shape);
+            Assert.Equal(new long[] { }, res[2].shape);
             Assert.Equal(1.1f, res[0].ToSingle());
             Assert.Equal(2.0f, res[1].ToSingle());
             Assert.Equal(3.1f, res[2].ToSingle());
@@ -1496,10 +1496,10 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).SplitWithSizes(new long[] { 2, 1 });
+            var res = Float32Tensor.From(data).split_with_sizes(new long[] { 2, 1 });
             Assert.Equal(2, res.Length);
-            Assert.Equal(new long[] { 2 }, res[0].Shape);
-            Assert.Equal(new long[] { 1 }, res[1].Shape);
+            Assert.Equal(new long[] { 2 }, res[0].shape);
+            Assert.Equal(new long[] { 1 }, res[1].shape);
             Assert.Equal(1.1f, res[0][0].ToSingle());
             Assert.Equal(2.0f, res[0][1].ToSingle());
             Assert.Equal(3.1f, res[1][0].ToSingle());
@@ -1509,28 +1509,28 @@ namespace TorchSharp
         public void RandomTest()
         {
             var res = Float32Tensor.Random(new long[] { 2 });
-            Assert.Equal(new long[] { 2 }, res.Shape);
+            Assert.Equal(new long[] { 2 }, res.shape);
 
             var res1 = Int16Tensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res1.Shape);
+            Assert.Equal(new long[] { 200 }, res1.shape);
 
             var res2 = Int32Tensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res2.Shape);
+            Assert.Equal(new long[] { 200 }, res2.shape);
 
             var res3 = Int64Tensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res3.Shape);
+            Assert.Equal(new long[] { 200 }, res3.shape);
 
             var res4 = ByteTensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res4.Shape);
+            Assert.Equal(new long[] { 200 }, res4.shape);
 
             var res5 = Int8Tensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res5.Shape);
+            Assert.Equal(new long[] { 200 }, res5.shape);
 
             var res6 = Float16Tensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res6.Shape);
+            Assert.Equal(new long[] { 200 }, res6.shape);
 
             var res7 = BFloat16Tensor.RandomIntegers(10, new long[] { 200 });
-            Assert.Equal(new long[] { 200 }, res7.Shape);
+            Assert.Equal(new long[] { 200 }, res7.shape);
 
             //var res7 = ComplexFloat16Tensor.RandomIntegers(10, new long[] { 200 });
             //Assert.Equal(new long[] { 200 }, res7.Shape);
@@ -1547,8 +1547,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).Expand(new long[] { 1, 1, 3 }).Squeeze(0).Squeeze(0);
-            Assert.Equal(new long[] { 3 }, res.Shape);
+            var res = Float32Tensor.From(data).expand(new long[] { 1, 1, 3 }).squeeze(0).squeeze(0);
+            Assert.Equal(new long[] { 3 }, res.shape);
             Assert.Equal(1.1f, res[0].ToSingle());
             Assert.Equal(2.0f, res[1].ToSingle());
             Assert.Equal(3.1f, res[2].ToSingle());
@@ -1559,8 +1559,8 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };
 
-            var res = Float32Tensor.From(data).Narrow(0, 1, 2);
-            Assert.Equal(new long[] { 2 }, res.Shape);
+            var res = Float32Tensor.From(data).narrow(0, 1, 2);
+            Assert.Equal(new long[] { 2 }, res.shape);
             Assert.Equal(2.0f, res[0].ToSingle());
             Assert.Equal(3.1f, res[1].ToSingle());
         }
@@ -1570,15 +1570,15 @@ namespace TorchSharp
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f, 4.0f };
 
-            var res = Float32Tensor.From(data).Slice(0, 1, 1, 1);
-            Assert.Equal(new long[] { 0 }, res.Shape);
+            var res = Float32Tensor.From(data).slice(0, 1, 1, 1);
+            Assert.Equal(new long[] { 0 }, res.shape);
 
-            var res2 = Float32Tensor.From(data).Slice(0, 1, 2, 1);
-            Assert.Equal(new long[] { 1 }, res2.Shape);
+            var res2 = Float32Tensor.From(data).slice(0, 1, 2, 1);
+            Assert.Equal(new long[] { 1 }, res2.shape);
             Assert.Equal(2.0f, res2[0].ToSingle());
 
-            var res3 = Float32Tensor.From(data).Slice(0, 1, 4, 2);
-            Assert.Equal(new long[] { 2 }, res3.Shape);
+            var res3 = Float32Tensor.From(data).slice(0, 1, 4, 2);
+            Assert.Equal(new long[] { 2 }, res3.shape);
             Assert.Equal(2.0f, res3[0].ToSingle());
             Assert.Equal(4.0f, res3[1].ToSingle());
         }
@@ -1619,7 +1619,7 @@ namespace TorchSharp
             { for (int i = 0; i < 2; i++) for (int j = 0; j < 4; j++) for (int k = 0; k < 3; k++) { t2raw[i * 4 * 3 + j * 3 + k] = t2[i, j, k]; } }
             var t1t = Float32Tensor.From(t1raw, new long[] { 3, 4, 5 });
             var t2t = Float32Tensor.From(t2raw, new long[] { 2, 4, 3 });
-            var t3t = t1t.Conv1D(t2t);
+            var t3t = t1t.conv1d(t2t);
 
             // Check the answer
             var t3Correct =
@@ -1644,7 +1644,7 @@ namespace TorchSharp
                         }
             }
             
-            var t3p2d3 = t1t.Conv1D(t2t, padding: 2, dilation: 3);
+            var t3p2d3 = t1t.conv1d(t2t, padding: 2, dilation: 3);
 
             // Check the answer
             var t3p2d3Correct =


### PR DESCRIPTION

Implements the renaming discused in https://github.com/xamarin/TorchSharp/issues/95 to match SciSharp conventions.

This aligns TorchSharp with the conentions and methodology of TensorFlow.NET which is used in ML.NET.

There are pros and cons to this, but as TorchSharp is adding no specific semantics over PyTorch, it simplifies a lot of things along education paths to adopt PyTorch namings.

