### PR TITLE
Allow all the optimizer parameters to be passed explicitly

### DIFF
--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -499,34 +499,52 @@ Tensor THSNN_poisson_loss(const Tensor input, const Tensor target, const bool lo
     )
 }
 
-Optimizer THSNN_Adagrad_ctor(const Tensor* parameters, const int length, const double learning_rate, const double lr_decay, const double weight_decay)
+Optimizer THSNN_Adagrad_ctor(const Tensor* parameters, const int length, const double learning_rate, const double lr_decay, const double weight_decay, const double initial_accumulator_value, const double eps)
 {
     auto params = toTensors<at::Tensor>((torch::Tensor**)parameters, length);
-    auto options = torch::optim::AdagradOptions(learning_rate).lr_decay(lr_decay).weight_decay(weight_decay);
+    auto options = torch::optim::AdagradOptions(learning_rate)
+        .lr_decay(lr_decay)
+        .weight_decay(weight_decay)
+        .initial_accumulator_value(initial_accumulator_value)
+        .eps(eps);
 
     return new std::shared_ptr<torch::optim::Optimizer>(std::make_shared<torch::optim::Adagrad>(torch::optim::Adagrad(params, options)));
 }
 
-Optimizer THSNN_Adam_ctor(const Tensor* parameters, const int length, const double learning_rate)
+Optimizer THSNN_Adam_ctor(const Tensor* parameters, const int length, const double learning_rate, const double beta1, const double beta2, const double eps, const double weight_decay, const bool amsgrad)
 {
     auto  params = toTensors<at::Tensor>((torch::Tensor**)parameters, length);
+    auto options = torch::optim::AdamOptions(learning_rate)
+        .betas(std::make_tuple(beta1, beta2))
+        .eps(eps)
+        .weight_decay(weight_decay)
+        .amsgrad(amsgrad);
 
-    return new std::shared_ptr<torch::optim::Optimizer>(std::make_shared<torch::optim::Adam>(torch::optim::Adam(params, learning_rate)));
+    return new std::shared_ptr<torch::optim::Optimizer>(std::make_shared<torch::optim::Adam>(torch::optim::Adam(params, options)));
 }
 
-Optimizer THSNN_RMSprop_ctor(const Tensor* parameters, const int length, const double learning_rate, const double alpha)
+Optimizer THSNN_RMSprop_ctor(const Tensor* parameters, const int length, const double learning_rate, const double alpha, const double eps, const double weight_decay, const double momentum, const bool centered)
 {
     auto  params = toTensors<at::Tensor>((torch::Tensor**)parameters, length);
 
-    auto options = torch::optim::RMSpropOptions(learning_rate).alpha(alpha);
+    auto options = torch::optim::RMSpropOptions(learning_rate)
+        .alpha(alpha)
+        .eps(eps)
+        .weight_decay(weight_decay)
+        .momentum(momentum)
+        .centered(centered);
 
     return new std::shared_ptr<torch::optim::Optimizer>(std::make_shared<torch::optim::RMSprop>(torch::optim::RMSprop(params, options)));
 }
 
-Optimizer THSNN_SGD_ctor(const Tensor* parameters, const int length, const double learning_rate, const double momentum)
+Optimizer THSNN_SGD_ctor(const Tensor* parameters, const int length, const double learning_rate, const double momentum, const double dampening, const double weight_decay, const bool nesterov)
 {
     auto  params = toTensors<at::Tensor>((torch::Tensor**)parameters, length);
-    auto opts = torch::optim::SGDOptions(learning_rate).momentum(momentum);
+    auto opts = torch::optim::SGDOptions(learning_rate)
+        .momentum(momentum)
+        .dampening(dampening)
+        .weight_decay(weight_decay)
+        .nesterov(nesterov);
 
     return new std::shared_ptr<torch::optim::Optimizer>(std::make_shared<torch::optim::SGD>(torch::optim::SGD(params, opts)));
 }

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -74,11 +74,11 @@ EXPORT_API(Tensor) THSNN_mse_loss(const Tensor inputwrapper, const Tensor target
 EXPORT_API(Tensor) THSNN_nll_loss(const Tensor inputwrapper, const Tensor targetwrapper, const Tensor weightwrapper, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_poisson_loss(const Tensor input, const Tensor target, const bool logInput, const bool full, const double eps, const int64_t reduction);
 
-EXPORT_API(Optimizer) THSNN_Adagrad_ctor(const Tensor* parameters, const int len, const double learning_rate, const double lr_decay, const double weight_decay);
-EXPORT_API(Optimizer) THSNN_Adam_ctor(const Tensor* parameters, const int len, const double learning_rate);
-EXPORT_API(Optimizer) THSNN_RMSprop_ctor(const Tensor* parameters, const int len, const double learning_rate, const double alpha);
+EXPORT_API(Optimizer) THSNN_Adagrad_ctor(const Tensor* parameters, const int len, const double learning_rate, const double lr_decay, const double weight_decay, const double initial_accumulator_value, const double eps);
+EXPORT_API(Optimizer) THSNN_Adam_ctor(const Tensor* parameters, const int len, const double learning_rate, const double beta1, const double beta2, const double eps, const double weight_decay, const bool amsgrad);
+EXPORT_API(Optimizer) THSNN_RMSprop_ctor(const Tensor* parameters, const int length, const double learning_rate, const double alpha, const double eps, const double weight_decay, const double momentum, const bool centered);
 
-EXPORT_API(Optimizer) THSNN_SGD_ctor(const Tensor* parameters, const int len, const double learnig_rate, const double momentum);
+EXPORT_API(Optimizer) THSNN_SGD_ctor(const Tensor* parameters, const int length, const double learning_rate, const double momentum, const double dampening, const double weight_decay, const bool nesterov);
 
 EXPORT_API(void) THSNN_initUniform(Tensor twrapper, double low, double high);
 

--- a/src/TorchSharp/NN/Optimizer.cs
+++ b/src/TorchSharp/NN/Optimizer.cs
@@ -79,7 +79,7 @@ namespace TorchSharp.NN
     public partial class Optimizer
     {
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_RMSprop_ctor(IntPtr parameters, int len, double learningRate, double alpha);
+        private static extern IntPtr THSNN_RMSprop_ctor(IntPtr parameters, int len, double learningRate, double alpha, double eps, double weight_decay, double momemtum, bool centered);
 
         /// <summary>
         /// Implements RMSprop algorithm.
@@ -89,19 +89,23 @@ namespace TorchSharp.NN
         /// <param name="parameters">Prameters to optimize</param>
         /// <param name="learningRate">Learning rate (default: 1e-2)</param>
         /// <param name="alpha">Smoothing constant (default: 0.99)</param>
+        /// <param name="eps">Term added to the denominator to improve numerical stability (default: 1e-8)</param>
+        /// <param name="weight_decay">Weight decay (L2 penalty) (default: 0)</param>
+        /// <param name="momentum">Momentum factor (default: 0)</param>
+        /// <param name="centered">If True, compute the centered RMSProp, the gradient is normalized by an estimation of its variance</param>
         /// <returns></returns>
-        public static Optimizer RMSProp(IEnumerable<TorchTensor> parameters, double learningRate = 0.01, double alpha = 0.99)
+        public static Optimizer RMSProp(IEnumerable<TorchTensor> parameters, double learningRate = 0.01, double alpha = 0.99, double eps = 1e-8, double weight_decay = 0, double momentum = 0, bool centered = false)
         {
             var parray = new PinnedArray<IntPtr>();
             IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());
 
-            var res = THSNN_RMSprop_ctor(paramsRef, parray.Array.Length, learningRate, alpha);
+            var res = THSNN_RMSprop_ctor(paramsRef, parray.Array.Length, learningRate, alpha, eps, weight_decay, momentum, centered);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Optimizer(res);
         }
 
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_Adam_ctor (IntPtr parameters, int len, double learningRate);
+        private static extern IntPtr THSNN_Adam_ctor (IntPtr parameters, int len, double learningRate, double beta1, double beta2, double eps, double weight_decay, bool amsgrad);
 
         /// <summary>
         /// Implements Adam algorithm.
@@ -110,19 +114,24 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="parameters">Prameters to optimize</param>
         /// <param name="learningRate">learning rate (default: 1e-3)</param>
+        /// <param name="beta1">Coefficient used for computing running averages of gradient and its square (default: 0.9)</param>
+        /// <param name="beta2">Coefficient used for computing running averages of gradient and its square (default: 0.999)</param>
+        /// <param name="eps">Term added to the denominator to improve numerical stability (default: 1e-8)</param>
+        /// <param name="weight_decay">Weight decay (L2 penalty) (default: 0)</param>
+        /// <param name="amsgrad">Whether to use the AMSGrad variant of this algorithm. (default: False)</param>
         /// <returns></returns>
-        public static Optimizer Adam (IEnumerable<TorchTensor> parameters, double learningRate = 1e-3)
+        public static Optimizer Adam (IEnumerable<TorchTensor> parameters, double learningRate = 1e-3, double beta1 = 0.9, double beta2 = 0.99, double eps = 1e-8, double weight_decay = 0, bool amsgrad = false)
         {
             var parray = new PinnedArray<IntPtr> ();
             IntPtr paramsRef = parray.CreateArray (parameters.Select (p => p.Handle).ToArray ());
 
-            var res = THSNN_Adam_ctor (paramsRef, parray.Array.Length, learningRate);
+            var res = THSNN_Adam_ctor (paramsRef, parray.Array.Length, learningRate, beta1, beta2, eps, weight_decay, amsgrad);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Optimizer (res);
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Adagrad_ctor(IntPtr parameters, int len, double learningRate, double lr_decay, double weight_decay);
+        private static extern IntPtr THSNN_Adagrad_ctor(IntPtr parameters, int len, double learningRate, double lr_decay, double weight_decay, double initial_accumulator_value, double eps);
 
         /// <summary>
         /// Implements Adagrad algorithm.
@@ -133,19 +142,21 @@ namespace TorchSharp.NN
         /// <param name="learningRate">learning rate (default: 1e-2)</param>
         /// <param name="lr_decay">learning rate decay (default: 0)</param>
         /// <param name="weight_decay">weight decay (L2 penalty) (default: 0)</param>
+        /// <param name="initial_accumulator_value"></param>
+        /// <param name="eps">Term added to the denominator to improve numerical stability (default: 1e-10)</param>
         /// <returns></returns>
-        public static Optimizer Adagrad(IEnumerable<TorchTensor> parameters, double learningRate = 1e-2, double lr_decay = 0, double weight_decay = 0)
+        public static Optimizer Adagrad(IEnumerable<TorchTensor> parameters, double learningRate = 1e-2, double lr_decay = 0, double weight_decay = 0, double initial_accumulator_value = 0, double eps = 1e-10)
         {
             var parray = new PinnedArray<IntPtr>();
             IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());
 
-            var res = THSNN_Adagrad_ctor(paramsRef, parray.Array.Length, learningRate, lr_decay, weight_decay);
+            var res = THSNN_Adagrad_ctor(paramsRef, parray.Array.Length, learningRate, lr_decay, weight_decay, initial_accumulator_value, eps);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Optimizer(res);
         }
 
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_SGD_ctor (IntPtr parameters, int len, double learningRate, double momentum);
+        private static extern IntPtr THSNN_SGD_ctor (IntPtr parameters, int len, double learningRate, double momentum, double dampening, double weight_decay, bool nesterov);
 
         /// <summary>
         /// Implements stochastic gradient descent (optionally with momentum).
@@ -153,13 +164,16 @@ namespace TorchSharp.NN
         /// <param name="parameters">Prameters to optimize</param>
         /// <param name="learningRate">Learning rate</param>
         /// <param name="momentum">Momentum factor (default: 0)</param>
+        /// <param name="dampening">Dampening for momentum (default: 0)</param>
+        /// <param name="weight_decay">Weight decay (L2 penalty) (default: 0)</param>
+        /// <param name="nesterov">Enables Nesterov momentum (default: False)</param>
         /// <returns></returns>
-        public static Optimizer SGD (IEnumerable<TorchTensor> parameters, double learningRate, double momentum = 0)
+        public static Optimizer SGD (IEnumerable<TorchTensor> parameters, double learningRate, double momentum = 0, double dampening = 0, double weight_decay = 0, bool nesterov = false)
         {
             var parray = new PinnedArray<IntPtr> ();
             IntPtr paramsRef = parray.CreateArray (parameters.Select (p => p.Handle).ToArray ());
 
-            var res = THSNN_SGD_ctor (paramsRef, parray.Array.Length, learningRate, momentum);
+            var res = THSNN_SGD_ctor (paramsRef, parray.Array.Length, learningRate, momentum, dampening, weight_decay, nesterov);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Optimizer (res);
         }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -654,7 +654,7 @@ namespace TorchSharp
         /// Taken from <see href="https://pytorch.org/tutorials/beginner/pytorch_with_examples.html#pytorch-optim"/>.
         /// </summary>
         [Fact]
-        public void TestTrainingAdam()
+        public void TestTrainingAdamDefaults()
         {
             var lin1 = Linear(1000, 100);
             var lin2 = Linear(100, 10);
@@ -663,13 +663,42 @@ namespace TorchSharp
             var x = Float32Tensor.randn(new long[] { 64, 1000 });
             var y = Float32Tensor.randn(new long[] { 64, 10 });
 
-            double learning_rate = 0.00004f;
             float prevLoss = float.MaxValue;
-            var optimizer = NN.Optimizer.Adam(seq.parameters(), learning_rate);
+            var optimizer = NN.Optimizer.Adam(seq.parameters());
             var loss = mse_loss(NN.Reduction.Sum);
 
             for (int i = 0; i < 10; i++)
             {
+                var eval = seq.forward(x);
+                var output = loss(eval, y);
+                var lossVal = output.ToSingle();
+
+                Assert.True(lossVal < prevLoss);
+                prevLoss = lossVal;
+
+                optimizer.zero_grad();
+
+                output.backward();
+
+                optimizer.step();
+            }
+        }
+
+        [Fact]
+        public void TestTrainingAdamAmsGrad()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
+
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
+
+            float prevLoss = float.MaxValue;
+            var optimizer = NN.Optimizer.Adam(seq.parameters(), amsgrad: true);
+            var loss = mse_loss(NN.Reduction.Sum);
+
+            for (int i = 0; i < 10; i++) {
                 var eval = seq.forward(x);
                 var output = loss(eval, y);
                 var lossVal = output.ToSingle();
@@ -725,7 +754,7 @@ namespace TorchSharp
         /// Taken from <see href="https://pytorch.org/tutorials/beginner/pytorch_with_examples.html#pytorch-optim"/>.
         /// </summary>
         [Fact]
-        public void TestTrainingRMSProp()
+        public void TestTrainingRMSLR()
         {
             var lin1 = Linear(1000, 100);
             var lin2 = Linear(100, 10);
@@ -755,12 +784,136 @@ namespace TorchSharp
             }
         }
 
+        [Fact]
+        public void TestTrainingRMSAlpha()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
+
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
+
+            double learning_rate = 0.00004f;
+            float prevLoss = float.MaxValue;
+            var optimizer = NN.Optimizer.RMSProp(seq.parameters(), learning_rate, alpha: 0.75);
+            var loss = mse_loss(NN.Reduction.Sum);
+
+            for (int i = 0; i < 10; i++) {
+                var eval = seq.forward(x);
+                var output = loss(eval, y);
+                var lossVal = output.ToSingle();
+
+                Assert.True(lossVal < prevLoss);
+                prevLoss = lossVal;
+
+                optimizer.zero_grad();
+
+                output.backward();
+
+                optimizer.step();
+            }
+        }
+
+        [Fact]
+        public void TestTrainingRMSCentered()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
+
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
+
+            double learning_rate = 0.00004f;
+            float prevLoss = float.MaxValue;
+            var optimizer = NN.Optimizer.RMSProp(seq.parameters(), learning_rate, centered: true);
+            var loss = mse_loss(NN.Reduction.Sum);
+
+            for (int i = 0; i < 10; i++) {
+                var eval = seq.forward(x);
+                var output = loss(eval, y);
+                var lossVal = output.ToSingle();
+
+                Assert.True(lossVal < prevLoss);
+                prevLoss = lossVal;
+
+                optimizer.zero_grad();
+
+                output.backward();
+
+                optimizer.step();
+            }
+        }
+
         /// <summary>
         /// Fully connected Relu net with one hidden layer trained using SGD optimizer.
         /// Taken from <see href="https://pytorch.org/tutorials/beginner/pytorch_with_examples.html#pytorch-optim"/>.
         /// </summary>
         [Fact]
-        public void TestTrainingSGD()
+        public void TestTrainingSGDMomentum()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
+
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
+
+            double learning_rate = 0.00004f;
+            float prevLoss = float.MaxValue;
+            var optimizer = NN.Optimizer.SGD(seq.parameters(), learning_rate, momentum: 0.5);
+            var loss = mse_loss(NN.Reduction.Sum);
+
+            for (int i = 0; i < 10; i++) {
+                var eval = seq.forward(x);
+                var output = loss(eval, y);
+                var lossVal = output.ToSingle();
+
+                Assert.True(lossVal < prevLoss);
+                prevLoss = lossVal;
+
+                optimizer.zero_grad();
+
+                output.backward();
+
+                optimizer.step();
+            }
+        }
+
+        [Fact(Skip = "Fails with an exception in native code.")]
+        public void TestTrainingSGDNesterov()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(("lin1", lin1), ("relu1", Relu()), ("lin2", lin2));
+
+            var x = Float32Tensor.randn(new long[] { 64, 1000 });
+            var y = Float32Tensor.randn(new long[] { 64, 10 });
+
+            double learning_rate = 0.00004f;
+            float prevLoss = float.MaxValue;
+            var optimizer = NN.Optimizer.SGD(seq.parameters(), learning_rate, nesterov: true);
+            var loss = mse_loss(NN.Reduction.Sum);
+
+            for (int i = 0; i < 10; i++) {
+                var eval = seq.forward(x);
+                var output = loss(eval, y);
+                var lossVal = output.ToSingle();
+
+                Assert.True(lossVal < prevLoss);
+                prevLoss = lossVal;
+
+                optimizer.zero_grad();
+
+                output.backward();
+
+                optimizer.step();
+            }
+        }
+
+        [Fact]
+        public void TestTrainingSGDDefaults()
         {
             var lin1 = Linear(1000, 100);
             var lin2 = Linear(100, 10);


### PR DESCRIPTION
Prior to this PR, not all optimizer hyperparameters were available to the .NET client code. This adds all parameters and implements any defaulting on the .NET side.