### PR TITLE
Loss functions

### DIFF
--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -6,7 +6,6 @@ using TorchSharp.Tensor;
 using TorchSharp.NN;
 using static TorchSharp.NN.Modules;
 using static TorchSharp.NN.Functions;
-using static TorchSharp.NN.Losses;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -30,13 +30,11 @@ namespace TorchSharp.Examples
             using (var train = Data.Loader.CIFAR10(_dataLocation, _trainBatchSize))
             using (var test = Data.Loader.CIFAR10(_dataLocation, _testBatchSize, false))
             using (var model = new Model("model", _numClasses))
-            using (var optimizer = NN.Optimizer.Adam(model.parameters(), 0.001))
-            {
+            using (var optimizer = NN.Optimizer.Adam(model.parameters(), 0.001)) {
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
-                for (var epoch = 1; epoch <= _epochs; epoch++)
-                {
+                for (var epoch = 1; epoch <= _epochs; epoch++) {
                     Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size());
                     Test(model, nll_loss(), test, test.Size());
                 }
@@ -82,9 +80,9 @@ namespace TorchSharp.Examples
                     ("l3", Linear(4096, numClasses))
                 );
 
-                RegisterModule ("features", features);
-                RegisterModule ("avg", avgPool);
-                RegisterModule ("classify", classifier);
+                RegisterModule("features", features);
+                RegisterModule("avg", avgPool);
+                RegisterModule("classify", classifier);
             }
 
             public override TorchTensor forward(TorchTensor input)
@@ -112,13 +110,11 @@ namespace TorchSharp.Examples
             long total = 0;
             long correct = 0;
 
-            foreach (var (data, target) in dataLoader)
-            {
+            foreach (var (data, target) in dataLoader) {
                 optimizer.zero_grad();
 
                 using (var prediction = model.forward(data))
-                using (var output = loss(LogSoftMax(prediction, 1), target))
-                {
+                using (var output = loss(LogSoftMax(prediction, 1), target)) {
                     output.backward();
 
                     optimizer.step();
@@ -127,8 +123,7 @@ namespace TorchSharp.Examples
                     total += target.shape[0];
                     correct += predicted.eq(target).sum().ToInt64();
 
-                    if (batchId % _logInterval == 0)
-                    {
+                    if (batchId % _logInterval == 0) {
                         Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.ToSingle()} Acc: { (float)correct / total }");
                     }
 
@@ -151,11 +146,9 @@ namespace TorchSharp.Examples
             double testLoss = 0;
             long correct = 0;
 
-            foreach (var (data, target) in dataLoader)
-            {
+            foreach (var (data, target) in dataLoader) {
                 using (var prediction = model.forward(data))
-                using (var output = loss(LogSoftMax(prediction, 1), target))
-                {
+                using (var output = loss(LogSoftMax(prediction, 1), target)) {
                     testLoss += output.ToSingle();
 
                     var pred = prediction.argmax(1);

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -6,7 +6,6 @@ using TorchSharp.Tensor;
 using TorchSharp.NN;
 using static TorchSharp.NN.Modules;
 using static TorchSharp.NN.Functions;
-using static TorchSharp.NN.Losses;
 
 namespace TorchSharp.Examples
 {

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -846,27 +846,48 @@ NNModule THSNN_BatchNorm3d_ctor(const int64_t features, const double eps, const 
 {
     CATCH_RETURN_NNModule(
         auto opts = torch::nn::BatchNorm3dOptions(features)
-        .eps(eps)
-        .momentum(momentum)
-        .affine(affine)
-        .track_running_stats(track_running_stats);
+            .eps(eps)
+            .momentum(momentum)
+            .affine(affine)
+            .track_running_stats(track_running_stats);
 
-    auto mod = std::make_shared<torch::nn::BatchNorm3dImpl>(opts);
+        auto mod = std::make_shared<torch::nn::BatchNorm3dImpl>(opts);
 
-    // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
-    // a Module can only be boxed to AnyModule at the point its static type is known).
-    if (outAsAnyModule != NULL)
-    {
-        auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<torch::nn::BatchNorm3dImpl>(*mod));
-        *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);
-    }
-    res = new std::shared_ptr<torch::nn::Module>(mod);
+        // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
+        // a Module can only be boxed to AnyModule at the point its static type is known).
+        if (outAsAnyModule != NULL)
+        {
+            auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<torch::nn::BatchNorm3dImpl>(*mod));
+            *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);
+        }
+        res = new std::shared_ptr<torch::nn::Module>(mod);
     )
 }
 
 Tensor THSNN_BatchNorm3d_forward(const NNModule module, const Tensor tensor)
 {
     CATCH_TENSOR((*module)->as<torch::nn::BatchNorm3d>()->forward(*tensor));
+}
+
+NNModule THSNN_Identity_ctor(NNAnyModule* outAsAnyModule)
+{
+    CATCH_RETURN_NNModule(
+        auto mod = std::make_shared<torch::nn::IdentityImpl>();
+
+        // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
+        // a Module can only be boxed to AnyModule at the point its static type is known).
+        if (outAsAnyModule != NULL)
+        {
+            auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<torch::nn::IdentityImpl>(*mod));
+            *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);
+        }
+        res = new std::shared_ptr<torch::nn::Module>(mod);
+    );
+}
+
+Tensor THSNN_Identity_forward(const NNModule module, const Tensor tensor)
+{
+    CATCH_TENSOR((*module)->as<torch::nn::Identity>()->forward(*tensor));
 }
 
 NNModule THSNN_Linear_ctor(const int64_t input_size, const int64_t output_size, const bool bias,

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -1064,10 +1064,23 @@ void THSNN_Embedding_set_weight(const NNModule module, const Tensor weights)
     )
 }
 
+template<typename T>
+void ApplyPaddingMode(T& opts, const int64_t padding)
+{
+    if (padding == 0)
+        opts = opts.padding_mode(torch::kZeros);
+    if (padding == 1)
+        opts = opts.padding_mode(torch::kReflect);
+    if (padding == 2)
+        opts = opts.padding_mode(torch::kReplicate);
+    if (padding == 3)
+        opts = opts.padding_mode(torch::kCircular);
+}
+
 
 NNModule THSNN_Conv1d_ctor(const int64_t inputChannel, const int64_t outputChannel,
     const int64_t kernelSize, const int64_t stride, const int64_t padding,
-    const int64_t dilation, const int64_t groups, const int64_t bias,
+    const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias,
     NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(
@@ -1079,6 +1092,7 @@ NNModule THSNN_Conv1d_ctor(const int64_t inputChannel, const int64_t outputChann
         .bias(bias);
 
         auto mod = std::make_shared<torch::nn::Conv1dImpl>(opts);
+        ApplyPaddingMode(opts, paddingMode);
 
         // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
         // a Module can only be boxed to AnyModule at the point its static type is known).
@@ -1098,7 +1112,7 @@ Tensor THSNN_Conv1d_forward(const NNModule module, const Tensor tensor)
 
 NNModule THSNN_Conv2d_ctor(const int64_t inputChannel, const int64_t outputChannel,
     const int64_t kernelSize, const int64_t stride, const int64_t padding,
-    const int64_t dilation, const int64_t groups, const int64_t bias,
+    const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias,
     NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(
@@ -1110,6 +1124,7 @@ NNModule THSNN_Conv2d_ctor(const int64_t inputChannel, const int64_t outputChann
             .bias(bias);
 
         auto mod = std::make_shared<torch::nn::Conv2dImpl>(opts);
+        ApplyPaddingMode(opts, paddingMode);
 
         // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
         // a Module can only be boxed to AnyModule at the point its static type is known).
@@ -1129,13 +1144,14 @@ Tensor THSNN_Conv2d_forward(const NNModule module, const Tensor tensor)
 
 NNModule THSNN_Conv3d_ctor(const int64_t inputChannel, const int64_t outputChannel,
     const int64_t kernelSize, const int64_t stride, const int64_t padding,
-    const int64_t dilation, const int64_t groups, const int64_t bias,
+    const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias,
     NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(
         auto opts = torch::nn::Conv3dOptions(inputChannel, outputChannel, kernelSize).stride(stride).padding(padding);
 
     auto mod = std::make_shared<torch::nn::Conv3dImpl>(opts);
+    ApplyPaddingMode(opts, paddingMode);
 
     // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
     // a Module can only be boxed to AnyModule at the point its static type is known).

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -1438,3 +1438,9 @@ void THSNN_AnyModule_dispose(const NNAnyModule module)
     delete module; // NOTE: this only deletes the shared_ptr
 }
 
+Tensor THSNN_one_hot(const Tensor self, const int64_t num_classes)
+{
+    CATCH_RETURN_Tensor(
+        res = ResultTensor(torch::nn::functional::one_hot(*self, num_classes));
+    )
+}

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -128,6 +128,13 @@ EXPORT_API(Tensor)   THSNN_Softmin_forward(const NNModule module, const Tensor t
 EXPORT_API(NNModule) THSNN_Tanh_ctor(NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Tanh_forward(const NNModule module, const Tensor tensor);
 
+// Sparse
+
+EXPORT_API(NNModule) THSNN_Embedding_ctor(const int64_t num_embeddings, const int64_t embedding_dims, const int64_t padding_idx, bool has_pi, const double max_norm, const bool has_mn, const double norm_type, const bool scale_grad_by_freq, const bool sparse, NNAnyModule* outAsAnyModule);
+EXPORT_API(NNModule) THSNN_Embedding_from_pretrained(const Tensor embeddings, const bool freeze, const int64_t padding_idx, bool has_pi, const double max_norm, const bool has_mn, const double norm_type, const bool scale_grad_by_freq, const bool sparse, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_Embedding_forward(const NNModule module, const Tensor weights);
+EXPORT_API(Tensor)   THSNN_Embedding_weight(const NNModule module);
+EXPORT_API(void)     THSNN_Embedding_set_weight(const NNModule module, const Tensor weights);
 
 // Containers
 

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -144,7 +144,10 @@ EXPORT_API(Tensor)   THSNN_Sequential_forward(const NNModule module, const Tenso
 
 // Loss functions
 
+EXPORT_API(Tensor) THSNN_cross_entropy(const Tensor inputwrapper, const Tensor targetwrapper, const Tensor weightwrapper, const int64_t ignore_index, const bool has_ii, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_binary_cross_entropy(const Tensor inputwrapper, const Tensor targetwrapper, const Tensor weightwrapper, const int64_t reduction);
+EXPORT_API(Tensor) THSNN_binary_cross_entropy_with_logits(const Tensor inputwrapper, const Tensor targetwrapper, const Tensor weightwrapper, const int64_t reduction, const Tensor pos_weights_wrapper);
+EXPORT_API(Tensor) THSNN_l1_loss(const Tensor inputwrapper, const Tensor targetwrapper, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_mse_loss(const Tensor inputwrapper, const Tensor targetwrapper, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_nll_loss(const Tensor inputwrapper, const Tensor targetwrapper, const Tensor weightwrapper, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_poisson_loss(const Tensor input, const Tensor target, const bool logInput, const bool full, const double eps, const int64_t reduction);

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -62,11 +62,11 @@ EXPORT_API(Tensor)   THSNN_AvgPool3d_forward(const NNModule module, const Tensor
 
 // Convolution
 
-EXPORT_API(NNModule) THSNN_Conv1d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(NNModule) THSNN_Conv1d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Conv1d_forward(const NNModule module, const Tensor tensor);
-EXPORT_API(NNModule) THSNN_Conv2d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(NNModule) THSNN_Conv2d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Conv2d_forward(const NNModule module, const Tensor tensor);
-EXPORT_API(NNModule) THSNN_Conv3d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(NNModule) THSNN_Conv3d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Conv3d_forward(const NNModule module, const Tensor tensor);
 
 // Batch Normalization

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -164,6 +164,10 @@ EXPORT_API(void) THSNN_Optimizer_getParameters(const Optimizer optimizer, Tensor
 EXPORT_API(void) THSNN_Optimizer_step(const Optimizer optimizer);
 EXPORT_API(void) THSNN_Optimizer_dispose(const Optimizer optimizer);
 
+// Misc.
+
+EXPORT_API(Tensor) THSNN_one_hot(const Tensor self, const int64_t num_classes);
+
 // Initializers
 
 EXPORT_API(void) THSNN_initUniform(Tensor twrapper, double low, double high);

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -62,12 +62,43 @@ EXPORT_API(Tensor)   THSNN_AvgPool3d_forward(const NNModule module, const Tensor
 
 // Convolution
 
-EXPORT_API(NNModule) THSNN_Conv1d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(NNModule) THSNN_Conv1d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const bool bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Conv1d_forward(const NNModule module, const Tensor tensor);
-EXPORT_API(NNModule) THSNN_Conv2d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_Conv1d_bias(const NNModule module);
+EXPORT_API(void)     THSNN_Conv1d_set_bias(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor)   THSNN_Conv1d_weight(const NNModule module);
+EXPORT_API(void)     THSNN_Conv1d_set_weight(const NNModule module, const Tensor weight);
+EXPORT_API(NNModule) THSNN_Conv2d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const bool bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Conv2d_forward(const NNModule module, const Tensor tensor);
-EXPORT_API(NNModule) THSNN_Conv3d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const int64_t bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_Conv2d_weight(const NNModule module);
+EXPORT_API(void)     THSNN_Conv2d_set_weight(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor)   THSNN_Conv2d_bias(const NNModule module);
+EXPORT_API(void)     THSNN_Conv2d_set_bias(const NNModule module, const Tensor bias);
+EXPORT_API(NNModule) THSNN_Conv3d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const bool bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Conv3d_forward(const NNModule module, const Tensor tensor);
+EXPORT_API(Tensor)   THSNN_Conv3d_weight(const NNModule module);
+EXPORT_API(void)     THSNN_Conv3d_set_weight(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor)   THSNN_Conv3d_bias(const NNModule module);
+EXPORT_API(void)     THSNN_Conv3d_set_bias(const NNModule module, const Tensor bias);
+
+EXPORT_API(NNModule) THSNN_ConvTranspose1d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t output_padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const bool bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_ConvTranspose1d_forward(const NNModule module, const Tensor tensor);
+EXPORT_API(Tensor)   THSNN_ConvTranspose1d_bias(const NNModule module);
+EXPORT_API(void)     THSNN_ConvTranspose1d_set_bias(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor)   THSNN_ConvTranspose1d_weight(const NNModule module);
+EXPORT_API(void)     THSNN_ConvTranspose1d_set_weight(const NNModule module, const Tensor weight);
+EXPORT_API(NNModule) THSNN_ConvTranspose2d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t output_padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const bool bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_ConvTranspose2d_forward(const NNModule module, const Tensor tensor);
+EXPORT_API(Tensor)   THSNN_ConvTranspose2d_weight(const NNModule module);
+EXPORT_API(void)     THSNN_ConvTranspose2d_set_weight(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor)   THSNN_ConvTranspose2d_bias(const NNModule module);
+EXPORT_API(void)     THSNN_ConvTranspose2d_set_bias(const NNModule module, const Tensor bias);
+EXPORT_API(NNModule) THSNN_ConvTranspose3d_ctor(const int64_t inputChannel, const int64_t outputChannel, const int64_t kernelSize, const int64_t stride, const int64_t padding, const int64_t output_padding, const int64_t dilation, const int64_t paddingMode, const int64_t groups, const bool bias, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_ConvTranspose3d_forward(const NNModule module, const Tensor tensor);
+EXPORT_API(Tensor)   THSNN_ConvTranspose3d_weight(const NNModule module);
+EXPORT_API(void)     THSNN_ConvTranspose3d_set_weight(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor)   THSNN_ConvTranspose3d_bias(const NNModule module);
+EXPORT_API(void)     THSNN_ConvTranspose3d_set_bias(const NNModule module, const Tensor bias);
 
 // Batch Normalization
 

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -86,6 +86,8 @@ EXPORT_API(Tensor)   THSNN_FeatureAlphaDropout_forward(const NNModule module, co
 
 // Linear
 
+EXPORT_API(NNModule) THSNN_Identity_ctor(NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_Identity_forward(const NNModule module, const Tensor tensor);
 EXPORT_API(NNModule) THSNN_Linear_ctor(const int64_t input_size, const int64_t output_size, const bool with_bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_Linear_forward(const NNModule module, const Tensor tensor);
 EXPORT_API(Tensor)   THSNN_Linear_bias(const NNModule module);

--- a/src/TorchSharp/NN/Conv1D.cs
+++ b/src/TorchSharp/NN/Conv1D.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
-        /// <param name="paddingMode"></param>
+        /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
@@ -64,7 +64,7 @@ namespace TorchSharp.NN
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
-        /// <param name="paddingMode"></param>
+        /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>

--- a/src/TorchSharp/NN/Conv1D.cs
+++ b/src/TorchSharp/NN/Conv1D.cs
@@ -7,10 +7,10 @@ namespace TorchSharp.NN
 {
     public enum PaddingModes
     {
-        Zeros,
-        Reflect,
-        Replicate,
-        Circular
+        Zeros = 0,
+        Reflect = 1,
+        Replicate = 2,
+        Circular = 3
     }
 
     public class Conv1D : Module
@@ -30,7 +30,7 @@ namespace TorchSharp.NN
     public static partial class Modules
     {
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv1d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long groups, bool bias, out IntPtr pBoxedModule);
+        private static extern IntPtr THSNN_Conv1d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
 
         /// <summary>
         /// Applies a 1D convolution over an input signal composed of several input planes.
@@ -47,8 +47,7 @@ namespace TorchSharp.NN
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
         static public Conv1D Conv1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            if (paddingMode != PaddingModes.Zeros) throw new NotImplementedException("Convolution padding mode other than 'zeros'");
-            var res = THSNN_Conv1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, groups, bias, out var boxedHandle);
+            var res = THSNN_Conv1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Conv1D (res, boxedHandle);
         }

--- a/src/TorchSharp/NN/Conv1D.cs
+++ b/src/TorchSharp/NN/Conv1D.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.InteropServices;
 using TorchSharp.Tensor;
 
+#nullable enable
 namespace TorchSharp.NN
 {
     public enum PaddingModes
@@ -26,7 +27,41 @@ namespace TorchSharp.NN
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (res);
         }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSNN_Conv1d_bias(Module.HType module);
+        [DllImport("LibTorchSharp")]
+        extern static void THSNN_Conv1d_set_bias(Module.HType module, IntPtr tensor);
+
+        public TorchTensor? Bias {
+            get {
+                var res = THSNN_Conv1d_bias(handle);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return ((res == IntPtr.Zero) ? null : new TorchTensor(res));
+            }
+            set {
+                THSNN_Conv1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                Torch.CheckForErrors();
+            }
+        }
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSNN_Conv1d_weight(Module.HType module);
+        [DllImport("LibTorchSharp")]
+        extern static void THSNN_Conv1d_set_weight(Module.HType module, IntPtr tensor);
+
+        public TorchTensor Weight {
+            get {
+                var res = THSNN_Conv1d_weight(handle);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            }
+            set {
+                THSNN_Conv1d_set_weight(handle, value.Handle);
+                Torch.CheckForErrors();
+            }
+        }
     }
+
     public static partial class Modules
     {
         [DllImport ("LibTorchSharp")]

--- a/src/TorchSharp/NN/Conv2D.cs
+++ b/src/TorchSharp/NN/Conv2D.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.InteropServices;
 using TorchSharp.Tensor;
 
+#nullable enable
 namespace TorchSharp.NN
 {
     public class Conv2D : Module
@@ -17,6 +18,39 @@ namespace TorchSharp.NN
             var res = THSNN_Conv2d_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSNN_Conv2d_bias(Module.HType module);
+        [DllImport("LibTorchSharp")]
+        extern static void THSNN_Conv2d_set_bias(Module.HType module, IntPtr tensor);
+
+        public TorchTensor? Bias {
+            get {
+                var res = THSNN_Conv2d_bias(handle);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return ((res == IntPtr.Zero) ? null : new TorchTensor(res));
+            }
+            set {
+                THSNN_Conv2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                Torch.CheckForErrors();
+            }
+        }
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSNN_Conv2d_weight(Module.HType module);
+        [DllImport("LibTorchSharp")]
+        extern static void THSNN_Conv2d_set_weight(Module.HType module, IntPtr tensor);
+
+        public TorchTensor Weight {
+            get {
+                var res = THSNN_Conv2d_weight(handle);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            }
+            set {
+                THSNN_Conv2d_set_weight(handle, value.Handle);
+                Torch.CheckForErrors();
+            }
         }
     }
     public static partial class Modules

--- a/src/TorchSharp/NN/Conv2D.cs
+++ b/src/TorchSharp/NN/Conv2D.cs
@@ -33,7 +33,7 @@ namespace TorchSharp.NN
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
-        /// <param name="paddingMode"></param>
+        /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
@@ -56,7 +56,7 @@ namespace TorchSharp.NN
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
-        /// <param name="paddingMode"></param>
+        /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>

--- a/src/TorchSharp/NN/Conv2D.cs
+++ b/src/TorchSharp/NN/Conv2D.cs
@@ -22,7 +22,7 @@ namespace TorchSharp.NN
     public static partial class Modules
     {
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv2d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long groups, bool bias, out IntPtr pBoxedModule);
+        private static extern IntPtr THSNN_Conv2d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
 
         /// <summary>
         /// Applies a 2D convolution over an input signal composed of several input planes
@@ -39,8 +39,7 @@ namespace TorchSharp.NN
         /// <returns></returns>
         static public Conv2D Conv2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            if (paddingMode != PaddingModes.Zeros) throw new NotImplementedException("Convolution padding mode other than 'zeros'");
-            var res = THSNN_Conv2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, groups, bias, out var boxedHandle);
+            var res = THSNN_Conv2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Conv2D (res, boxedHandle);
         }

--- a/src/TorchSharp/NN/Conv3D.cs
+++ b/src/TorchSharp/NN/Conv3D.cs
@@ -33,7 +33,7 @@ namespace TorchSharp.NN
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
-        /// <param name="paddingMode"></param>
+        /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
@@ -56,7 +56,7 @@ namespace TorchSharp.NN
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
-        /// <param name="paddingMode"></param>
+        /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>

--- a/src/TorchSharp/NN/Conv3D.cs
+++ b/src/TorchSharp/NN/Conv3D.cs
@@ -22,7 +22,7 @@ namespace TorchSharp.NN
     public static partial class Modules
     {
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long groups, bool bias, out IntPtr pBoxedModule);
+        private static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
 
         /// <summary>
         /// Applies a 2D convolution over an input signal composed of several input planes
@@ -39,8 +39,7 @@ namespace TorchSharp.NN
         /// <returns></returns>
         static public Conv3D Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            if (paddingMode != PaddingModes.Zeros) throw new NotImplementedException("Convolution padding mode other than 'zeros'");
-            var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, groups, bias, out var boxedHandle);
+            var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new Conv3D(res, boxedHandle);
         }

--- a/src/TorchSharp/NN/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/ConvTranspose1D.cs
@@ -6,98 +6,101 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class Conv3D : Module
+    public class ConvTranspose1D : Module
     {
-        internal Conv3D(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+        internal ConvTranspose1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_forward(Module.HType module, IntPtr tensor);
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_ConvTranspose1d_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor forward(TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
-            var res = THSNN_Conv3d_forward(handle, tensor.Handle);
+            var res = THSNN_ConvTranspose1d_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
+            return new TorchTensor (res);
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Conv3d_bias(Module.HType module);
+        extern static IntPtr THSNN_ConvTranspose1d_bias(Module.HType module);
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Conv3d_set_bias(Module.HType module, IntPtr tensor);
+        extern static void THSNN_ConvTranspose1d_set_bias(Module.HType module, IntPtr tensor);
 
         public TorchTensor? Bias {
             get {
-                var res = THSNN_Conv3d_bias(handle);
+                var res = THSNN_ConvTranspose1d_bias(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return ((res == IntPtr.Zero) ? null : new TorchTensor(res));
             }
             set {
-                THSNN_Conv3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                THSNN_ConvTranspose1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                 Torch.CheckForErrors();
             }
         }
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Conv3d_weight(Module.HType module);
+        extern static IntPtr THSNN_ConvTranspose1d_weight(Module.HType module);
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Conv3d_set_weight(Module.HType module, IntPtr tensor);
+        extern static void THSNN_ConvTranspose1d_set_weight(Module.HType module, IntPtr tensor);
 
         public TorchTensor Weight {
             get {
-                var res = THSNN_Conv3d_weight(handle);
+                var res = THSNN_ConvTranspose1d_weight(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(res);
             }
             set {
-                THSNN_Conv3d_set_weight(handle, value.Handle);
+                THSNN_ConvTranspose1d_set_weight(handle, value.Handle);
                 Torch.CheckForErrors();
             }
         }
     }
+
     public static partial class Modules
     {
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_ConvTranspose1d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
 
         /// <summary>
-        /// Applies a 2D convolution over an input signal composed of several input planes
+        /// Applies a 1D convolution over an input signal composed of several input planes.
         /// </summary>
         /// <param name="inputChannel">Number of channels in the input image</param>
         /// <param name="outputChannel">Number of channels produced by the convolution</param>
         /// <param name="kernelSize">Size of the convolving kernel</param>
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
+        /// <param name="outputPadding">Additional size added to one side of the output shape. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
         /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
-        /// <returns></returns>
-        static public Conv3D Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        /// <returns>Tensor of shape (N,C_out,L_out)</returns>
+        static public ConvTranspose1D ConvTranspose1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
+            var res = THSNN_ConvTranspose1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Conv3D(res, boxedHandle);
+            return new ConvTranspose1D (res, boxedHandle);
         }
     }
     public static partial class Functions
     {
         /// <summary>
-        /// Applies a 2D convolution over an input signal composed of several input planes
+        /// Applies a 1D convolution over an input signal composed of several input planes.
         /// </summary>
-        /// <param name="x">Tensor representing an image, (N,C,H,W).</param>
+        /// <param name="x">Tensor of shape (N,C_in,L_in)</param>
         /// <param name="inputChannel">Number of channels in the input image</param>
         /// <param name="outputChannel">Number of channels produced by the convolution</param>
         /// <param name="kernelSize">Size of the convolving kernel</param>
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
+        /// <param name="outputPadding">Additional size added to one side of the output shape. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
         /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
-        /// <returns></returns>
-        static public TorchTensor Conv3D(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        /// <returns>Tensor of shape (N,C_out,L_out)</returns>
+        static public TorchTensor ConvTranspose1D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.Conv3D(inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
-                return d.forward(x);
+            using (var d = Modules.ConvTranspose1D (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/ConvTranspose2D.cs
@@ -6,98 +6,101 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class Conv3D : Module
+    public class ConvTranspose2D : Module
     {
-        internal Conv3D(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+        internal ConvTranspose2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_forward(Module.HType module, IntPtr tensor);
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_ConvTranspose2d_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor forward(TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
-            var res = THSNN_Conv3d_forward(handle, tensor.Handle);
+            var res = THSNN_ConvTranspose2d_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
+            return new TorchTensor (res);
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Conv3d_bias(Module.HType module);
+        extern static IntPtr THSNN_ConvTranspose2d_bias(Module.HType module);
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Conv3d_set_bias(Module.HType module, IntPtr tensor);
+        extern static void THSNN_ConvTranspose2d_set_bias(Module.HType module, IntPtr tensor);
 
         public TorchTensor? Bias {
             get {
-                var res = THSNN_Conv3d_bias(handle);
+                var res = THSNN_ConvTranspose2d_bias(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return ((res == IntPtr.Zero) ? null : new TorchTensor(res));
             }
             set {
-                THSNN_Conv3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                THSNN_ConvTranspose2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                 Torch.CheckForErrors();
             }
         }
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Conv3d_weight(Module.HType module);
+        extern static IntPtr THSNN_ConvTranspose2d_weight(Module.HType module);
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Conv3d_set_weight(Module.HType module, IntPtr tensor);
+        extern static void THSNN_ConvTranspose2d_set_weight(Module.HType module, IntPtr tensor);
 
         public TorchTensor Weight {
             get {
-                var res = THSNN_Conv3d_weight(handle);
+                var res = THSNN_ConvTranspose2d_weight(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(res);
             }
             set {
-                THSNN_Conv3d_set_weight(handle, value.Handle);
+                THSNN_ConvTranspose2d_set_weight(handle, value.Handle);
                 Torch.CheckForErrors();
             }
         }
     }
+
     public static partial class Modules
     {
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_ConvTranspose2d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
 
         /// <summary>
-        /// Applies a 2D convolution over an input signal composed of several input planes
+        /// Applies a 1D convolution over an input signal composed of several input planes.
         /// </summary>
         /// <param name="inputChannel">Number of channels in the input image</param>
         /// <param name="outputChannel">Number of channels produced by the convolution</param>
         /// <param name="kernelSize">Size of the convolving kernel</param>
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
+        /// <param name="outputPadding">Additional size added to one side of the output shape. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
         /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
-        /// <returns></returns>
-        static public Conv3D Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        /// <returns>Tensor of shape (N,C_out,L_out)</returns>
+        static public ConvTranspose2D ConvTranspose2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
+            var res = THSNN_ConvTranspose2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Conv3D(res, boxedHandle);
+            return new ConvTranspose2D (res, boxedHandle);
         }
     }
     public static partial class Functions
     {
         /// <summary>
-        /// Applies a 2D convolution over an input signal composed of several input planes
+        /// Applies a 1D convolution over an input signal composed of several input planes.
         /// </summary>
-        /// <param name="x">Tensor representing an image, (N,C,H,W).</param>
+        /// <param name="x">Tensor of shape (N,C_in,L_in)</param>
         /// <param name="inputChannel">Number of channels in the input image</param>
         /// <param name="outputChannel">Number of channels produced by the convolution</param>
         /// <param name="kernelSize">Size of the convolving kernel</param>
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
+        /// <param name="outputPadding">Additional size added to one side of the output shape. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
         /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
-        /// <returns></returns>
-        static public TorchTensor Conv3D(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        /// <returns>Tensor of shape (N,C_out,L_out)</returns>
+        static public TorchTensor ConvTranspose2D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.Conv3D(inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
-                return d.forward(x);
+            using (var d = Modules.ConvTranspose2D (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/ConvTranspose3D.cs
@@ -6,98 +6,101 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class Conv3D : Module
+    public class ConvTranspose3D : Module
     {
-        internal Conv3D(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+        internal ConvTranspose3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_forward(Module.HType module, IntPtr tensor);
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_ConvTranspose3d_forward (Module.HType module, IntPtr tensor);
 
-        public TorchTensor forward(TorchTensor tensor)
+        public TorchTensor forward (TorchTensor tensor)
         {
-            var res = THSNN_Conv3d_forward(handle, tensor.Handle);
+            var res = THSNN_ConvTranspose3d_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
+            return new TorchTensor (res);
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Conv3d_bias(Module.HType module);
+        extern static IntPtr THSNN_ConvTranspose3d_bias(Module.HType module);
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Conv3d_set_bias(Module.HType module, IntPtr tensor);
+        extern static void THSNN_ConvTranspose3d_set_bias(Module.HType module, IntPtr tensor);
 
         public TorchTensor? Bias {
             get {
-                var res = THSNN_Conv3d_bias(handle);
+                var res = THSNN_ConvTranspose3d_bias(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return ((res == IntPtr.Zero) ? null : new TorchTensor(res));
             }
             set {
-                THSNN_Conv3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                THSNN_ConvTranspose3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                 Torch.CheckForErrors();
             }
         }
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Conv3d_weight(Module.HType module);
+        extern static IntPtr THSNN_ConvTranspose3d_weight(Module.HType module);
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Conv3d_set_weight(Module.HType module, IntPtr tensor);
+        extern static void THSNN_ConvTranspose3d_set_weight(Module.HType module, IntPtr tensor);
 
         public TorchTensor Weight {
             get {
-                var res = THSNN_Conv3d_weight(handle);
+                var res = THSNN_ConvTranspose3d_weight(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(res);
             }
             set {
-                THSNN_Conv3d_set_weight(handle, value.Handle);
+                THSNN_ConvTranspose3d_set_weight(handle, value.Handle);
                 Torch.CheckForErrors();
             }
         }
     }
+
     public static partial class Modules
     {
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_ConvTranspose3d_ctor (long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
 
         /// <summary>
-        /// Applies a 2D convolution over an input signal composed of several input planes
+        /// Applies a 1D convolution over an input signal composed of several input planes.
         /// </summary>
         /// <param name="inputChannel">Number of channels in the input image</param>
         /// <param name="outputChannel">Number of channels produced by the convolution</param>
         /// <param name="kernelSize">Size of the convolving kernel</param>
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
+        /// <param name="outputPadding">Additional size added to one side of the output shape. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
         /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
-        /// <returns></returns>
-        static public Conv3D Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        /// <returns>Tensor of shape (N,C_out,L_out)</returns>
+        static public ConvTranspose3D ConvTranspose3D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
+            var res = THSNN_ConvTranspose3d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Conv3D(res, boxedHandle);
+            return new ConvTranspose3D (res, boxedHandle);
         }
     }
     public static partial class Functions
     {
         /// <summary>
-        /// Applies a 2D convolution over an input signal composed of several input planes
+        /// Applies a 1D convolution over an input signal composed of several input planes.
         /// </summary>
-        /// <param name="x">Tensor representing an image, (N,C,H,W).</param>
+        /// <param name="x">Tensor of shape (N,C_in,L_in)</param>
         /// <param name="inputChannel">Number of channels in the input image</param>
         /// <param name="outputChannel">Number of channels produced by the convolution</param>
         /// <param name="kernelSize">Size of the convolving kernel</param>
         /// <param name="stride">Stride of the convolution. Default: 1</param>
         /// <param name="padding">Zero-padding added to both sides of the input. Default: 0</param>
+        /// <param name="outputPadding">Additional size added to one side of the output shape. Default: 0</param>
         /// <param name="dilation">Spacing between kernel elements. Default: 1</param>
         /// <param name="paddingMode">'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'</param>
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
-        /// <returns></returns>
-        static public TorchTensor Conv3D(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        /// <returns>Tensor of shape (N,C_out,L_out)</returns>
+        static public TorchTensor ConvTranspose3D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.Conv3D(inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
-                return d.forward(x);
+            using (var d = Modules.ConvTranspose3D (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
+                return d.forward (x);
             }
         }
     }

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+using System;
+using System.Runtime.InteropServices;
+using TorchSharp.Tensor;
+
+namespace TorchSharp.NN
+{
+    public class Embedding : Module
+    {
+        internal Embedding (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_Embedding_forward (Module.HType module, IntPtr tensor);
+
+        public TorchTensor forward (TorchTensor tensor)
+        {
+            if (!tensor.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
+            var res = THSNN_Embedding_forward (handle, tensor.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSNN_Embedding_weight(Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        extern static void THSNN_Embedding_set_weight(Module.HType module, IntPtr tensor);
+
+        public TorchTensor Weight {
+            get {
+                var res = THSNN_Embedding_weight(handle);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            }
+            set {
+                THSNN_Embedding_set_weight(handle, value.Handle);
+                Torch.CheckForErrors();
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_Embedding_from_pretrained(IntPtr embeddings, bool freeze, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
+
+        /// <summary>
+        /// A simple lookup table that stores embeddings of a fixed dictionary and size.
+        /// This module is often used to store word embeddings and retrieve them using indices. The input to the module is a list of indices, and the output is the corresponding word embeddings.
+        /// </summary>
+        /// <param name="embeddings">FloatTensor containing weights for the Embedding in two dimensions. First dimension is being passed to Embedding as num_embeddings, second as embedding_dim.</param>
+        /// <param name="freeze">If true (the default), the tensor does not get updated in the learning</param>
+        /// <param name="padding_idx">If given, pads the output with the embedding vector at padding_idx (initialized to zeros) whenever it encounters the index.</param>
+        /// <param name="max_norm">If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm.</param>
+        /// <param name="norm_type">The p of the p-norm to compute for the max_norm option. Default 2.</param>
+        /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
+        /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
+        /// <returns></returns>
+        public static Embedding from_pretrained(TorchTensor embeddings, bool freeze = true, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
+        {
+            var res = THSNN_Embedding_from_pretrained(embeddings.Handle, freeze,
+                padding_idx.HasValue ? padding_idx.Value : -1, padding_idx.HasValue,
+                max_norm.HasValue ? max_norm.Value : 0.0, max_norm.HasValue,
+                norm_type, scale_grad_by_freq, sparse, out var boxedHandle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new Embedding(res, boxedHandle);
+
+        }
+
+    }
+    public static partial class Modules
+    {
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_Embedding_ctor (long num_embeddings, long embedding_dims, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
+
+        /// <summary>
+        /// A simple lookup table that stores embeddings of a fixed dictionary and size.
+        /// This module is often used to store word embeddings and retrieve them using indices. The input to the module is a list of indices, and the output is the corresponding word embeddings.
+        /// </summary>
+        /// <param name="num_embeddings">Size of the dictionary of embeddings, the vocabulary size.</param>
+        /// <param name="embedding_dims">The size of each embedding vector</param>
+        /// <param name="padding_idx">If given, pads the output with the embedding vector at padding_idx (initialized to zeros) whenever it encounters the index.</param>
+        /// <param name="max_norm">If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm.</param>
+        /// <param name="norm_type">The p of the p-norm to compute for the max_norm option. Default 2.</param>
+        /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
+        /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
+        /// <returns></returns>
+        static public Embedding Embedding (long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
+        {
+            var res = THSNN_Embedding_ctor (num_embeddings, embedding_dims,
+                padding_idx.HasValue ? padding_idx.Value : -1, padding_idx.HasValue,
+                max_norm.HasValue ? max_norm.Value : 0.0, max_norm.HasValue,
+                norm_type, scale_grad_by_freq, sparse, out var boxedHandle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new Embedding (res, boxedHandle);
+        }
+    }
+    public static partial class Functions
+    {
+        /// <summary>
+        /// A simple lookup table that stores embeddings of a fixed dictionary and size.
+        /// This module is often used to store word embeddings and retrieve them using indices. The input to the module is a list of indices, and the output is the corresponding word embeddings.
+        /// </summary>
+        /// <param name="x">An input tensor of arbitrary shape.</param>
+        /// <param name="num_embeddings">Size of the dictionary of embeddings, the vocabulary size.</param>
+        /// <param name="embedding_dims">The size of each embedding vector</param>
+        /// <param name="padding_idx">If given, pads the output with the embedding vector at padding_idx (initialized to zeros) whenever it encounters the index.</param>
+        /// <param name="max_norm">If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm.</param>
+        /// <param name="norm_type">The p of the p-norm to compute for the max_norm option. Default 2.</param>
+        /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
+        /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
+        /// <returns></returns>
+        static public TorchTensor Embedding (TorchTensor x, long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
+        {
+            using (var d = Modules.Embedding(num_embeddings, embedding_dims, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse)) {
+                return d.forward (x);
+            }
+        }
+    }
+
+}

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -53,6 +53,7 @@ namespace TorchSharp.NN
         /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
         /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
         /// <returns></returns>
+        /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
         public static Embedding from_pretrained(TorchTensor embeddings, bool freeze = true, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
         {
             var res = THSNN_Embedding_from_pretrained(embeddings.Handle, freeze,
@@ -82,6 +83,7 @@ namespace TorchSharp.NN
         /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
         /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
         /// <returns></returns>
+        /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
         static public Embedding Embedding (long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
         {
             var res = THSNN_Embedding_ctor (num_embeddings, embedding_dims,
@@ -107,6 +109,7 @@ namespace TorchSharp.NN
         /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
         /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
         /// <returns></returns>
+        /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
         static public TorchTensor Embedding (TorchTensor x, long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
         {
             using (var d = Modules.Embedding(num_embeddings, embedding_dims, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse)) {

--- a/src/TorchSharp/NN/Identity.cs
+++ b/src/TorchSharp/NN/Identity.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using TorchSharp.Tensor;
+
+#nullable enable
+namespace TorchSharp.NN
+{
+    public class Identity : Module
+    {
+        internal Identity (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+
+        [DllImport ("LibTorchSharp")]
+        extern static IntPtr THSNN_Identity_forward (Module.HType module, IntPtr tensor);
+
+        public TorchTensor forward (TorchTensor tensor)
+        {
+            var res = THSNN_Identity_forward (handle, tensor.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (res);
+        }
+    }
+    public static partial class Modules
+    {
+        [DllImport ("LibTorchSharp")]
+        private static extern IntPtr THSNN_Identity_ctor (out IntPtr pBoxedModule);
+
+        /// <summary>
+        /// A placeholder identity operator.
+        /// </summary>
+        /// <returns>The same tensor as is input.</returns>
+        static public Identity Identity ()
+        {
+            var res = THSNN_Identity_ctor (out var boxedHandle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new Identity (res, boxedHandle);
+        }
+    }
+    public static partial class Functions
+    {
+        /// <summary>
+        /// A placeholder identity operator.
+        /// </summary>
+        /// <param name="x">The input tensor.</param>
+        /// <returns>The same tensor as is input.</returns>
+        static public TorchTensor Identity (TorchTensor x)
+        {
+            using (var d = Modules.Identity()) {
+                return d.forward (x);
+            }
+        }
+    }
+
+}

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -16,14 +16,39 @@ namespace TorchSharp.NN
     {
 
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_binary_cross_entropy (IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
+        private static extern IntPtr THSNN_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long ignore_index, bool hasII, long reduction);
 
-        public static Loss binary_cross_entropy (TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        public static Loss cross_entropy_loss(TorchTensor? weigths = null, long? ignore_index = null, Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => {
-                var res = THSNN_binary_cross_entropy (src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction);
+                var ii = ignore_index.HasValue ? ignore_index.Value : -100;
+                var res = THSNN_cross_entropy (src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, ii, ignore_index.HasValue, (long)reduction);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor (res);
+            };
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_binary_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
+
+        public static Loss binary_cross_entropy_loss(TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => {
+                var res = THSNN_binary_cross_entropy(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            };
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_binary_cross_entropy_with_logits(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction, IntPtr posWeights);
+
+        public static Loss binary_cross_entropy_with_logits_loss(TorchTensor? weigths = null, Reduction reduction = Reduction.Mean, TorchTensor? posWeights = null)
+        {
+            return (TorchTensor src, TorchTensor target) => {
+                var res = THSNN_binary_cross_entropy_with_logits(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction, posWeights?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
             };
         }
 
@@ -37,6 +62,18 @@ namespace TorchSharp.NN
                     if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor (res);
                 };
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_l1_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+        public static Loss l1_loss(Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => {
+                var res = THSNN_l1_loss(src.Handle, target.Handle, (long)reduction);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            };
         }
 
         [DllImport ("LibTorchSharp")]

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -12,7 +12,7 @@ namespace TorchSharp.NN
     /// <summary>
     /// Class maintaing the supported loss functions.
     /// </summary>
-    public class Losses
+    public static partial class Functions
     {
 
         [DllImport ("LibTorchSharp")]

--- a/src/TorchSharp/NN/OneHot.cs
+++ b/src/TorchSharp/NN/OneHot.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+using System;
+using System.Runtime.InteropServices;
+using TorchSharp.Tensor;
+
+namespace TorchSharp.NN
+{
+    public static partial class Functions
+    {
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_one_hot(IntPtr self, long num_classes);
+
+        static public TorchTensor OneHot (TorchTensor x, long num_classes = -1)
+        {
+            if (x.Type != ScalarType.Int64) throw new ArgumentException("OneHot input tensor must have elements of type Int64");
+            var res = THSNN_one_hot(x.Handle, num_classes);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+    }
+
+}

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -5055,6 +5055,21 @@ namespace TorchSharp.Tensor
 
     public static class TensorExtensionMethods
     {
+        internal static bool IsIntegral(this TorchTensor tensor)
+        {
+            switch(tensor.Type) {
+            case ScalarType.Byte:
+            case ScalarType.Int8:
+            case ScalarType.Int16:
+            case ScalarType.Int32:
+            case ScalarType.Int64:
+            case ScalarType.Bool:
+                return true;
+            default:
+                return false;
+            }
+        }
+
         public static TorchTensor ToTorchTensor<T>(this T[] rawArray, long[] dimensions, bool doCopy = false, bool requiresGrad = false)
         {
             var array = doCopy ? (T[])rawArray.Clone() : rawArray;

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1690,5 +1690,25 @@ namespace TorchSharp
                 Assert.Equal(emb.Weight.shape[1], weights.shape[1]);
             }
         }
+
+        [Fact]
+        public void TestOneHotEncoding1()
+        {
+            var ones = Int64Tensor.from(new long[] { 1, 2, 0, 0, 3, 4, 2, 2 });
+            var env = OneHot(ones,5);
+            var values = env.Data<long>().ToArray();
+            Assert.Equal(ones.shape[0], env.shape[0]);
+            Assert.Equal(5, env.shape[1]);
+        }
+
+        [Fact]
+        public void TestOneHotEncoding2()
+        {
+            var ones = Int64Tensor.from(new long[] { 1, 2, 0, 5, 3, 4, 2, 2 });
+            var env = OneHot(ones);
+            var values = env.Data<long>().ToArray();
+            Assert.Equal(ones.shape[0], env.shape[0]);
+            Assert.Equal(6, env.shape[1]);
+        }
     }
 }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -733,6 +733,37 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestConv1DGetWeight()
+        {
+            var conv = Conv1D(3, 64, 3);
+            var weight = conv.Weight;
+            var bias = conv.Bias;
+            Assert.NotNull(weight);
+            Assert.NotNull(bias);
+            Assert.Equal(new long[] { 64, 3, 3 }, weight.shape);
+        }
+
+        [Fact]
+        public void TestConv1DEditWeightAndBias()
+        {
+            var conv = Conv1D(3, 64, 3);
+
+            conv.Bias = Float32Tensor.randn(new long[] { 64 });
+            var weights = Float32Tensor.randn(new long[] { 64, 3, 3 });
+
+            var weight = conv.Weight;
+            var bias = conv.Bias;
+
+            Assert.NotNull(weight);
+            Assert.NotNull(bias);
+            Assert.Equal(new long[] { 64, 3, 3 }, weight.shape);
+
+            for (int i = 0; i < 64; i++) {
+                Assert.Equal(conv.Bias.Data<float>()[i], bias.Data<float>()[i]);
+            }
+        }
+
+        [Fact]
         public void TestConv1DStride()
         {
             var shape = new long[] { 16, 3, 28 };
@@ -775,6 +806,37 @@ namespace TorchSharp
             Assert.Equal(64, output.shape[1]);
             Assert.Equal(26, output.shape[2]);
             Assert.Equal(26, output.shape[3]);
+        }
+
+        [Fact]
+        public void TestConv2DGetWeight()
+        {
+            var conv = Conv2D(3, 64, 3);
+            var weight = conv.Weight;
+            var bias = conv.Bias;
+            Assert.NotNull(weight);
+            Assert.NotNull(bias);
+            Assert.Equal(new long[] { 64, 3, 3, 3 }, weight.shape);
+        }
+
+        [Fact]
+        public void TestConv2DEditWeightAndBias()
+        {
+            var conv = Conv2D(3, 64, 3);
+
+            conv.Bias = Float32Tensor.randn(new long[] { 64 });
+            var weights = Float32Tensor.randn(new long[] { 64, 3, 3, 3 });
+
+            var weight = conv.Weight;
+            var bias = conv.Bias;
+
+            Assert.NotNull(weight);
+            Assert.NotNull(bias);
+            Assert.Equal(new long[] { 64, 3, 3, 3 }, weight.shape);
+
+            for (int i = 0; i < 64; i++) {
+                Assert.Equal(conv.Bias.Data<float>()[i], bias.Data<float>()[i]);
+            }
         }
 
         [Fact]
@@ -826,6 +888,37 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestConv3DGetWeight()
+        {
+            var conv = Conv3D(3, 64, 3);
+            var weight = conv.Weight;
+            var bias = conv.Bias;
+            Assert.NotNull(weight);
+            Assert.NotNull(bias);
+            Assert.Equal(new long[] { 64, 3, 3, 3, 3 }, weight.shape);
+        }
+
+        [Fact]
+        public void TestConv3DEditWeightAndBias()
+        {
+            var conv = Conv3D(3, 64, 3);
+
+            conv.Bias = Float32Tensor.randn(new long[] { 64 });
+            var weights = Float32Tensor.randn(new long[] { 64, 3, 3, 3 });
+
+            var weight = conv.Weight;
+            var bias = conv.Bias;
+
+            Assert.NotNull(weight);
+            Assert.NotNull(bias);
+            Assert.Equal(new long[] { 64, 3, 3, 3, 3 }, weight.shape);
+
+            for (int i = 0; i < 64; i++) {
+                Assert.Equal(conv.Bias.Data<float>()[i], bias.Data<float>()[i]);
+            }
+        }
+
+        [Fact]
         public void TestConv3DStride()
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
@@ -852,7 +945,7 @@ namespace TorchSharp
                 Assert.Equal(28, output.shape[3]);
                 Assert.Equal(28, output.shape[4]);
             }
-            using (var conv = Conv3D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
+            using (var conv = Conv3D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Replicate))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
@@ -860,6 +953,45 @@ namespace TorchSharp
                 Assert.Equal(28, output.shape[3]);
                 Assert.Equal(28, output.shape[4]);
             }
+        }
+
+        [Fact]
+        public void TestConvTranspose1D()
+        {
+            var shape = new long[] { 16, 3, 28 };
+            TorchTensor t = Float32Tensor.rand(shape);
+            var conv = ConvTranspose1D(3, 64, 3);
+            var output = conv.forward(t);
+            Assert.Equal(16, output.shape[0]);
+            Assert.Equal(64, output.shape[1]);
+            Assert.Equal(30, output.shape[2]);
+        }
+
+        [Fact]
+        public void TestConvTranspose2D()
+        {
+            var shape = new long[] { 16, 3, 28, 28 };
+            TorchTensor t = Float32Tensor.rand(shape);
+            var conv = ConvTranspose2D(3, 64, 3);
+            var output = conv.forward(t);
+            Assert.Equal(16, output.shape[0]);
+            Assert.Equal(64, output.shape[1]);
+            Assert.Equal(30, output.shape[2]);
+            Assert.Equal(30, output.shape[3]);
+        }
+
+        [Fact]
+        public void TestConvTranspose3D()
+        {
+            var shape = new long[] { 16, 3, 28, 28, 28 };
+            TorchTensor t = Float32Tensor.rand(shape);
+            var conv = ConvTranspose3D(3, 64, 3);
+            var output = conv.forward(t);
+            Assert.Equal(16, output.shape[0]);
+            Assert.Equal(64, output.shape[1]);
+            Assert.Equal(30, output.shape[2]);
+            Assert.Equal(30, output.shape[3]);
+            Assert.Equal(30, output.shape[4]);
         }
 
         [Fact]

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -749,11 +749,19 @@ namespace TorchSharp
         {
             var shape = new long[] { 16, 3, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv1D(3, 64, 3, padding: 1);
-            var output = conv.forward(t);
-            Assert.Equal(16, output.shape[0]);
-            Assert.Equal(64, output.shape[1]);
-            Assert.Equal(28, output.shape[2]);
+
+            using (var conv = Conv1D(3, 64, 3, padding: 1))
+            using (var output = conv.forward(t)){
+                Assert.Equal(16, output.shape[0]);
+                Assert.Equal(64, output.shape[1]);
+                Assert.Equal(28, output.shape[2]);
+            }
+            using (var conv = Conv1D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
+            using (var output = conv.forward(t)) {
+                Assert.Equal(16, output.shape[0]);
+                Assert.Equal(64, output.shape[1]);
+                Assert.Equal(28, output.shape[2]);
+            }
         }
 
         [Fact]
@@ -787,12 +795,20 @@ namespace TorchSharp
         {
             var shape = new long[] { 16, 3, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv2D(3, 64, 3, padding: 1);
-            var output = conv.forward(t);
-            Assert.Equal(16, output.shape[0]);
-            Assert.Equal(64, output.shape[1]);
-            Assert.Equal(28, output.shape[2]);
-            Assert.Equal(28, output.shape[3]);
+            using (var conv = Conv2D(3, 64, 3, padding: 1))
+            using (var output = conv.forward(t)) {
+                Assert.Equal(16, output.shape[0]);
+                Assert.Equal(64, output.shape[1]);
+                Assert.Equal(28, output.shape[2]);
+                Assert.Equal(28, output.shape[3]);
+            }
+            using (var conv = Conv2D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
+            using (var output = conv.forward(t)) {
+                Assert.Equal(16, output.shape[0]);
+                Assert.Equal(64, output.shape[1]);
+                Assert.Equal(28, output.shape[2]);
+                Assert.Equal(28, output.shape[3]);
+            }
         }
 
         [Fact]
@@ -828,13 +844,22 @@ namespace TorchSharp
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv3D(3, 64, 3, padding: 1);
-            var output = conv.forward(t);
-            Assert.Equal(16, output.shape[0]);
-            Assert.Equal(64, output.shape[1]);
-            Assert.Equal(28, output.shape[2]);
-            Assert.Equal(28, output.shape[3]);
-            Assert.Equal(28, output.shape[4]);
+            using (var conv = Conv3D(3, 64, 3, padding: 1))
+            using (var output = conv.forward(t)) {
+                Assert.Equal(16, output.shape[0]);
+                Assert.Equal(64, output.shape[1]);
+                Assert.Equal(28, output.shape[2]);
+                Assert.Equal(28, output.shape[3]);
+                Assert.Equal(28, output.shape[4]);
+            }
+            using (var conv = Conv3D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
+            using (var output = conv.forward(t)) {
+                Assert.Equal(16, output.shape[0]);
+                Assert.Equal(64, output.shape[1]);
+                Assert.Equal(28, output.shape[2]);
+                Assert.Equal(28, output.shape[3]);
+                Assert.Equal(28, output.shape[4]);
+            }
         }
 
         [Fact]

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -46,7 +46,7 @@ namespace TorchSharp
         public void TestSetGetBiasInLinear()
         {
             var lin = Linear(1000, 100, true);
-            var bias = Float32Tensor.ones (new long[] { 1000 });
+            var bias = Float32Tensor.ones(new long[] { 1000 });
             lin.Bias = bias;
             Assert.True(!(lin.Bias is null));
 
@@ -110,8 +110,7 @@ namespace TorchSharp
             Assert.Equal(forward.shape[0], matmul.shape[0]);
             Assert.Equal(forward.shape[1], matmul.shape[1]);
 
-            for (int i = 0; i < 100; i++)
-            {
+            for (int i = 0; i < 100; i++) {
                 Assert.InRange(forward.Data<float>()[i], matmul.Data<float>()[i] - 10e5f, matmul.Data<float>()[i] + 10e5f);
             }
         }
@@ -131,8 +130,7 @@ namespace TorchSharp
             Assert.Equal(forward.shape[0], matmul.shape[0]);
             Assert.Equal(forward.shape[1], matmul.shape[1]);
 
-            for (int i = 0; i < 100; i++)
-            {
+            for (int i = 0; i < 100; i++) {
                 Assert.Equal(forward.Data<float>()[i], matmul.Data<float>()[i]);
             }
         }
@@ -157,8 +155,7 @@ namespace TorchSharp
             var bias = Float32Tensor.randn(new long[] { 100 });
             lin.Bias = bias;
 
-            for (int i = 0; i < 100; i++)
-            {
+            for (int i = 0; i < 100; i++) {
                 Assert.Equal(lin.Bias.Data<float>()[i], bias.Data<float>()[i]);
             }
         }
@@ -177,8 +174,7 @@ namespace TorchSharp
             Assert.Equal(lin.Weight.shape[0], weights.shape[0]);
             Assert.Equal(lin.Weight.shape[1], weights.shape[1]);
 
-            for (int i = 0; i < 100; i++)
-            {
+            for (int i = 0; i < 100; i++) {
                 Assert.Equal(lin.Bias.Data<float>()[i], bias.Data<float>()[i]);
             }
         }
@@ -383,11 +379,11 @@ namespace TorchSharp
                 ("relu1", ReLU()),
                 ("lin2", lin2));
             var parameters = seq.parameters();
-            var parametersCount = parameters.Count ();
-            Assert.Equal (4, parametersCount);
+            var parametersCount = parameters.Count();
+            Assert.Equal(4, parametersCount);
 
-            var namedParams = seq.parameters ();
-            var namedParamsCount = namedParams.Count ();
+            var namedParams = seq.parameters();
+            var namedParamsCount = namedParams.Count();
             Assert.Equal(4, namedParamsCount);
         }
 
@@ -415,8 +411,7 @@ namespace TorchSharp
         public void TestPoissonNLLLoss()
         {
             using (TorchTensor input = Float32Tensor.from(new float[] { 0.5f, 1.5f, 2.5f }))
-            using (TorchTensor target = Float32Tensor.from(new float[] { 1f, 2f, 3f }))
-            {
+            using (TorchTensor target = Float32Tensor.from(new float[] { 1f, 2f, 3f })) {
                 var componentWiseLoss = ((TorchTensor)input.exp()) - target * input;
                 Assert.True(componentWiseLoss.Equals(poisson_loss(reduction: NN.Reduction.None)(input, target)));
                 Assert.True(componentWiseLoss.sum().Equals(poisson_loss(reduction: NN.Reduction.Sum)(input, target)));
@@ -428,9 +423,35 @@ namespace TorchSharp
         public void TestPoissonNLLLoss2()
         {
             using (TorchTensor input = Float32Tensor.rand(new long[] { 5, 2 }))
-            using (TorchTensor target = Float32Tensor.rand(new long[] { 5, 2 }))
-            {
+            using (TorchTensor target = Float32Tensor.rand(new long[] { 5, 2 })) {
                 var outTensor = poisson_loss(true, true)(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestCrossEntropyLoss()
+        {
+            using (TorchTensor input = Float32Tensor.rand(new long[] { 5, 12 }))
+            using (TorchTensor target = Int64Tensor.randint(12, new long[] { 5 })) {
+                var outTensor = cross_entropy_loss()(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestL1Loss()
+        {
+            using (TorchTensor input = Float32Tensor.rand(new long[] { 5, 2 }))
+            using (TorchTensor target = Float32Tensor.rand(new long[] { 5, 2 })) {
+                var outTensor = l1_loss()(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
             }
         }
 
@@ -439,8 +460,7 @@ namespace TorchSharp
         public void TestErrorHandling()
         {
             using (TorchTensor input = Float32Tensor.from(new float[] { 0.5f, 1.5f }))
-            using (TorchTensor target = Float32Tensor.from(new float[] { 1f, 2f, 3f }))
-            {
+            using (TorchTensor target = Float32Tensor.from(new float[] { 1f, 2f, 3f })) {
                 Assert.Throws<ExternalException>(() => poisson_loss()(input, target));
             }
         }
@@ -489,8 +509,7 @@ namespace TorchSharp
 
             output.backward();
 
-            foreach (var parm in seq.parameters())
-            {
+            foreach (var parm in seq.parameters()) {
             }
         }
 
@@ -515,8 +534,7 @@ namespace TorchSharp
 
             output.backward();
 
-            foreach (var parm in seq.parameters())
-            {
+            foreach (var parm in seq.parameters()) {
                 var grad = parm.grad();
             }
         }
@@ -576,19 +594,16 @@ namespace TorchSharp
                 _isTrue = isTrue;
                 RegisterModule("fb", fb);
                 RegisterModule("fbT1", fbT1);
-                RegisterModule ("fbF1", fbF1);
-                RegisterModule ("fbF2", fbF2);
+                RegisterModule("fbF1", fbF1);
+                RegisterModule("fbF2", fbF2);
             }
 
             public override TorchTensor forward(TorchTensor input)
             {
                 using (var x = fb.forward(input))
-                    if (_isTrue)
-                    {
+                    if (_isTrue) {
                         return fbT1.forward(x);
-                    }
-                    else
-                    {
+                    } else {
                         return fbF2.forward(fbF1.forward(x));
                     }
             }
@@ -620,8 +635,7 @@ namespace TorchSharp
             output.backward();
             var gradCounts = 0;
 
-            foreach (var parm in modT.parameters())
-            {
+            foreach (var parm in modT.parameters()) {
                 var grad = parm.grad();
                 gradCounts += grad.Handle == IntPtr.Zero ? 0 : 1;
             }
@@ -639,8 +653,7 @@ namespace TorchSharp
             output.backward();
             gradCounts = 0;
 
-            foreach (var parm in modF.parameters())
-            {
+            foreach (var parm in modF.parameters()) {
                 var grad = parm.grad();
                 gradCounts += grad.Handle == IntPtr.Zero ? 0 : 1;
             }
@@ -652,24 +665,21 @@ namespace TorchSharp
         public void TestAutoGradMode()
         {
             var x = Float32Tensor.randn(new long[] { 2, 3 }, requiresGrad: true);
-            using (var mode = new AutoGradMode(false))
-            {
+            using (var mode = new AutoGradMode(false)) {
                 Assert.False(AutoGradMode.IsAutogradEnabled());
                 var sum = x.sum();
                 Assert.Throws<ExternalException>(() => sum.backward());
                 //var grad = x.Grad();
                 //Assert.True(grad.Handle == IntPtr.Zero);
             }
-            using (var mode = new AutoGradMode(true))
-            {
+            using (var mode = new AutoGradMode(true)) {
                 Assert.True(AutoGradMode.IsAutogradEnabled());
                 var sum = x.sum();
                 sum.backward();
                 var grad = x.grad();
                 Assert.False(grad.Handle == IntPtr.Zero);
                 var data = grad.Data<float>();
-                for (int i = 0; i < 2 * 3; i++)
-                {
+                for (int i = 0; i < 2 * 3; i++) {
                     Assert.Equal(1.0, data[i]);
                 }
             }
@@ -678,7 +688,7 @@ namespace TorchSharp
         [Fact]
         public void TestSaveLoadLinear()
         {
-            if (File.Exists (".model.ts")) File.Delete (".model.ts");
+            if (File.Exists(".model.ts")) File.Delete(".model.ts");
             var linear = Linear(100, 10, true);
             linear.Save(".model.ts");
             var loadedLinear = NN.Linear.Load(".model.ts");
@@ -703,7 +713,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 16, 3, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv1D(3, 64, 3, stride:2);
+            var conv = Conv1D(3, 64, 3, stride: 2);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -780,7 +790,7 @@ namespace TorchSharp
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv3D(3, 64, 3, stride:2);
+            var conv = Conv3D(3, 64, 3, stride: 2);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -806,7 +816,7 @@ namespace TorchSharp
         [Fact]
         public void TestSaveLoadConv2D()
         {
-            if (File.Exists (".model.ts")) File.Delete (".model.ts");
+            if (File.Exists(".model.ts")) File.Delete(".model.ts");
             var conv = Conv2D(100, 10, 5);
             conv.Save(".model.ts");
             var loaded = NN.Conv2D.Load(".model.ts");
@@ -817,7 +827,7 @@ namespace TorchSharp
         [Fact]
         public void TestSaveLoadSequence()
         {
-            if (File.Exists (".model-list.txt")) File.Delete (".model-list.txt");
+            if (File.Exists(".model-list.txt")) File.Delete(".model-list.txt");
             var lin1 = Linear(100, 10, true);
             var lin2 = Linear(10, 5, true);
             var seq = Sequential(("lin1", lin1), ("lin2", lin2));
@@ -850,8 +860,7 @@ namespace TorchSharp
             Assert.Equal(1000, module.GetParameter("test").shape[0]);
             Assert.Equal(100, module.GetParameter("test").shape[1]);
 
-            using (var grad = new AutoGradMode(false))
-            {
+            using (var grad = new AutoGradMode(false)) {
                 param.transpose_(0, 1);
             }
             Assert.Equal(100, module.GetParameter("test").shape[0]);
@@ -892,8 +901,7 @@ namespace TorchSharp
             float prevLoss = float.MaxValue;
             var loss = mse_loss(NN.Reduction.Sum);
 
-            for (int i = 0; i < 10; i++)
-            {
+            for (int i = 0; i < 10; i++) {
                 var eval = seq.forward(x);
                 var output = loss(eval, y);
                 var lossVal = output.ToSingle();
@@ -905,10 +913,8 @@ namespace TorchSharp
 
                 output.backward();
 
-                using (var noGrad = new AutoGradMode(false))
-                {
-                    foreach (var param in seq.parameters())
-                    {
+                using (var noGrad = new AutoGradMode(false)) {
+                    foreach (var param in seq.parameters()) {
                         var grad = param.grad();
                         var update = grad.mul(learning_rate.ToScalar());
                         param.sub_(update);
@@ -922,7 +928,7 @@ namespace TorchSharp
         {
             var lin1 = Linear(1000, 100);
             var lin2 = Linear(100, 10);
-                        var seq = Sequential(("lin1", lin1), ("relu1", ReLU()), ("lin2", lin2));
+            var seq = Sequential(("lin1", lin1), ("relu1", ReLU()), ("lin2", lin2));
 
             double learning_rate = 0.00001;
 
@@ -949,8 +955,7 @@ namespace TorchSharp
             var optimizer = NN.Optimizer.Adam(seq.parameters());
             var loss = mse_loss(NN.Reduction.Sum);
 
-            for (int i = 0; i < 10; i++)
-            {
+            for (int i = 0; i < 10; i++) {
                 var eval = seq.forward(x);
                 var output = loss(eval, y);
                 var lossVal = output.ToSingle();
@@ -1228,15 +1233,13 @@ namespace TorchSharp
         [Fact(Skip = "MNIST data too big to keep in repo")]
         public void TestMNISTLoader()
         {
-            using (var train = Data.Loader.MNIST("../../../../test/data/MNIST", 32))
-            {
+            using (var train = Data.Loader.MNIST("../../../../test/data/MNIST", 32)) {
                 Assert.NotNull(train);
 
                 var size = train.Size();
                 int i = 0;
 
-                foreach (var (data, target) in train)
-                {
+                foreach (var (data, target) in train) {
                     i++;
 
                     Assert.Equal(data.shape, new long[] { 32, 1, 28, 28 });
@@ -1253,15 +1256,13 @@ namespace TorchSharp
         [Fact(Skip = "CIFAR10 data too big to keep in repo")]
         public void TestCIFAR10Loader()
         {
-            using (var train = Data.Loader.CIFAR10("../../../../src/Examples/Data", 16))
-            {
+            using (var train = Data.Loader.CIFAR10("../../../../src/Examples/Data", 16)) {
                 Assert.NotNull(train);
 
                 var size = train.Size();
                 int i = 0;
 
-                foreach (var (data, target) in train)
-                {
+                foreach (var (data, target) in train) {
                     i++;
 
                     Assert.Equal(data.shape, new long[] { 16, 3, 32, 32 });
@@ -1279,17 +1280,14 @@ namespace TorchSharp
         [Fact(Skip = "MNIST data too big to keep in repo")]
         public void TestMNISTLoaderWithEpochs()
         {
-            using (var train = Data.Loader.MNIST("../../../../test/data/MNIST", 32))
-            {
+            using (var train = Data.Loader.MNIST("../../../../test/data/MNIST", 32)) {
                 var size = train.Size();
                 var epochs = 10;
 
                 int i = 0;
 
-                for (int e = 0; e < epochs; e++)
-                {
-                    foreach (var (data, target) in train)
-                    {
+                for (int e = 0; e < epochs; e++) {
+                    foreach (var (data, target) in train) {
                         i++;
 
                         Assert.Equal(data.shape, new long[] { 32, 1, 28, 28 });
@@ -1406,10 +1404,9 @@ namespace TorchSharp
         public void TestMaxPool2D_1()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4 });
-            using (var pool = MaxPool2D(new long[] { 2, 2 }))
-            {
+            using (var pool = MaxPool2D(new long[] { 2, 2 })) {
                 var pooled = pool.forward(ones);
-                Assert.Equal(new long[] {16, 2, 2 }, pooled.shape);
+                Assert.Equal(new long[] { 16, 2, 2 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0].ToSingle());
                 Assert.Equal(1, pooled[0, 0, 1].ToSingle());
                 Assert.Equal(1, pooled[0, 1, 0].ToSingle());
@@ -1625,7 +1622,7 @@ namespace TorchSharp
         public void TestEmbeddingDefaults()
         {
             var ones = Int32Tensor.ones(new long[] { 16 });
-            using (var emb = Embedding(1000,12)) {
+            using (var emb = Embedding(1000, 12)) {
                 var output = emb.forward(ones);
                 Assert.Equal(new long[] { 16, 12 }, output.shape);
             }
@@ -1646,7 +1643,7 @@ namespace TorchSharp
         {
             var ones = Int32Tensor.ones(new long[] { 16 });
             using (var emb = Embedding(1000, 12)) {
-                var weights = Float32Tensor.randn(new long[] { 1000,12 });
+                var weights = Float32Tensor.randn(new long[] { 1000, 12 });
 
                 emb.Weight = weights;
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -138,6 +138,19 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestIdentity()
+        {
+            var lin = Identity();
+
+            var input = Float32Tensor.randn(new long[] { 1, 1000 });
+            var output = lin.forward(input);
+
+            for (int i = 0; i < 1000; i++) {
+                Assert.Equal(input.Data<float>()[i], output.Data<float>()[i]);
+            }
+        }
+
+        [Fact]
         public void TestLinearEditBias()
         {
             var lin = Linear(1000, 100, true);

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1620,5 +1620,53 @@ namespace TorchSharp
                 Assert.Equal(ones.shape, pooled.shape);
             }
         }
+
+        [Fact]
+        public void TestEmbeddingDefaults()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            using (var emb = Embedding(1000,12)) {
+                var output = emb.forward(ones);
+                Assert.Equal(new long[] { 16, 12 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void TestEmbeddingWithMaxNorm()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            using (var emb = Embedding(1000, 128, max_norm: 1.5)) {
+                var output = emb.forward(ones);
+                Assert.Equal(new long[] { 16, 128 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void TestEmbeddingSetWeights()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            using (var emb = Embedding(1000, 12)) {
+                var weights = Float32Tensor.randn(new long[] { 1000,12 });
+
+                emb.Weight = weights;
+
+                Assert.Equal(emb.Weight.shape.Length, weights.shape.Length);
+                Assert.Equal(emb.Weight.shape[0], weights.shape[0]);
+                Assert.Equal(emb.Weight.shape[1], weights.shape[1]);
+            }
+        }
+
+        [Fact]
+        public void TestEmbeddingFromPretrained()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            var weights = Float32Tensor.randn(new long[] { 1000, 12 });
+
+            using (var emb = NN.Embedding.from_pretrained(weights)) {
+                Assert.Equal(emb.Weight.shape.Length, weights.shape.Length);
+                Assert.Equal(emb.Weight.shape[0], weights.shape[0]);
+                Assert.Equal(emb.Weight.shape[1], weights.shape[1]);
+            }
+        }
     }
 }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -455,6 +455,31 @@ namespace TorchSharp
             }
         }
 
+        [Fact]
+        public void TestBinaryCrossEntropyLoss()
+        {
+            var m = Sigmoid();
+            using (TorchTensor input = Float32Tensor.randn(new long[] { 3 }))
+            using (TorchTensor target = Float32Tensor.randn(new long[] { 3 })) {
+                var outTensor = binary_cross_entropy_loss()(m.forward(input), target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestBinaryCrossEntropyLossWithLogits()
+        {
+            using (TorchTensor input = Float32Tensor.randn(new long[] { 3 }))
+            using (TorchTensor target = Float32Tensor.randn(new long[] { 3 })) {
+                var outTensor = binary_cross_entropy_with_logits_loss()(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
 #if DEBUG
         [Fact(Skip = "Not working on Mac and Ubuntu (note: may now be working, we need to recheck)")]
         public void TestErrorHandling()

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using TorchSharp.NN;
 using static TorchSharp.NN.Modules;
-using static TorchSharp.NN.Losses;
 using static TorchSharp.NN.Functions;
 using TorchSharp.Tensor;
 using Xunit;


### PR DESCRIPTION
Added:
-  a number of the most common loss functions.
- one-hot encoding
- Embedding module

Moved the loss functions to the 'Functions' static class, since there's no 'nn.losses' in PyTorch.
