### PR TITLE
Random

### DIFF
--- a/src/Native/LibTorchSharp/THSTorch.cpp
+++ b/src/Native/LibTorchSharp/THSTorch.cpp
@@ -44,13 +44,13 @@ void  THSGenerator_set_rng_state(const Generator gen, const Tensor tensor)
 
 Generator THSGenerator_new(uint64_t seed, int64_t device, int64_t index)
 {
+    // TODO: Support creation of GPU RNGs. 'device' and 'index' are in the
+    //       function signature in preparation thereof.
     return new at::Generator(at::detail::createCPUGenerator(seed));
 }
 
 void THSGenerator_dispose(const Generator generator)
 {
-    auto defi = at::globalContext().defaultGenerator(at::DeviceType::CPU).getIntrusivePtr();
-    auto geni = generator->getIntrusivePtr();
     delete generator;
 }
 

--- a/src/Native/LibTorchSharp/THSTorch.cpp
+++ b/src/Native/LibTorchSharp/THSTorch.cpp
@@ -9,6 +9,35 @@ void THSTorch_manual_seed(const int64_t seed)
     torch::manual_seed(seed);
 }
 
+Generator THSGenerator_manual_seed(const int64_t seed)
+{
+    torch::manual_seed(seed);
+    return THSGenerator_default_generator();
+}
+
+Generator THSGenerator_default_generator()
+{
+    auto gen = at::globalContext().defaultGenerator(at::DeviceType::CPU);
+    return new at::Generator(gen.getIntrusivePtr());
+}
+
+int64_t THSGenerator_initial_seed(const Generator gen)
+{
+    return gen->current_seed();
+}
+
+Generator THSGenerator_new(int64_t device, int64_t index)
+{
+    return new torch::Generator(c10::make_intrusive<torch::CPUGeneratorImpl>());
+}
+
+void THSGenerator_dispose(const Generator generator)
+{
+    auto defi = at::globalContext().defaultGenerator(at::DeviceType::CPU).getIntrusivePtr();
+    auto geni = generator->getIntrusivePtr();
+    delete generator;
+}
+
 int THSTorchCuda_is_available()
 {
     return torch::cuda::is_available();

--- a/src/Native/LibTorchSharp/THSTorch.cpp
+++ b/src/Native/LibTorchSharp/THSTorch.cpp
@@ -15,6 +15,11 @@ Generator THSGenerator_manual_seed(const int64_t seed)
     return THSGenerator_default_generator();
 }
 
+void THSGenerator_gen_manual_seed(const Generator generator, const int64_t seed)
+{
+    generator->set_current_seed(seed);
+}
+
 Generator THSGenerator_default_generator()
 {
     auto gen = at::globalContext().defaultGenerator(at::DeviceType::CPU);
@@ -26,9 +31,20 @@ int64_t THSGenerator_initial_seed(const Generator gen)
     return gen->current_seed();
 }
 
-Generator THSGenerator_new(int64_t device, int64_t index)
+Tensor THSGenerator_get_rng_state(const Generator gen)
 {
-    return new torch::Generator(c10::make_intrusive<torch::CPUGeneratorImpl>());
+    CATCH_TENSOR(gen->get_state());
+}
+
+void  THSGenerator_set_rng_state(const Generator gen, const Tensor tensor)
+{
+    gen->set_state(*tensor);
+}
+
+
+Generator THSGenerator_new(uint64_t seed, int64_t device, int64_t index)
+{
+    return new at::Generator(at::detail::createCPUGenerator(seed));
 }
 
 void THSGenerator_dispose(const Generator generator)

--- a/src/Native/LibTorchSharp/THSTorch.h
+++ b/src/Native/LibTorchSharp/THSTorch.h
@@ -9,6 +9,11 @@
 
 // Sets manually the seed.
 EXPORT_API(void) THSTorch_manual_seed(const int64_t seed);
+EXPORT_API(Generator) THSGenerator_manual_seed(const int64_t seed);
+EXPORT_API(Generator) THSGenerator_default_generator();
+EXPORT_API(Generator) THSGenerator_new(int64_t device, int64_t index);
+EXPORT_API(int64_t) THSGenerator_initial_seed(const Generator gen);
+EXPORT_API(void) THSGenerator_dispose(const Generator generator);
 
 EXPORT_API(int) THSTorchCuda_is_available();
 EXPORT_API(int) THSTorchCuda_cudnn_is_available();

--- a/src/Native/LibTorchSharp/THSTorch.h
+++ b/src/Native/LibTorchSharp/THSTorch.h
@@ -8,12 +8,18 @@
 // API.
 
 // Sets manually the seed.
-EXPORT_API(void) THSTorch_manual_seed(const int64_t seed);
+EXPORT_API(void)      THSTorch_manual_seed(const int64_t seed);
+
 EXPORT_API(Generator) THSGenerator_manual_seed(const int64_t seed);
+EXPORT_API(void) THSGenerator_gen_manual_seed(const Generator gen, const int64_t seed);
+
+EXPORT_API(Tensor) THSGenerator_get_rng_state(const Generator gen);
+EXPORT_API(void)  THSGenerator_set_rng_state(const Generator gen, const Tensor tensor);
+
 EXPORT_API(Generator) THSGenerator_default_generator();
-EXPORT_API(Generator) THSGenerator_new(int64_t device, int64_t index);
-EXPORT_API(int64_t) THSGenerator_initial_seed(const Generator gen);
-EXPORT_API(void) THSGenerator_dispose(const Generator generator);
+EXPORT_API(Generator) THSGenerator_new(uint64_t seed, int64_t device, int64_t index);
+EXPORT_API(int64_t)   THSGenerator_initial_seed(const Generator gen);
+EXPORT_API(void)      THSGenerator_dispose(const Generator generator);
 
 EXPORT_API(int) THSTorchCuda_is_available();
 EXPORT_API(int) THSTorchCuda_cudnn_is_available();

--- a/src/Native/LibTorchSharp/Utils.h
+++ b/src/Native/LibTorchSharp/Utils.h
@@ -10,6 +10,8 @@ extern thread_local char *torch_last_err;
 
 typedef torch::Tensor *Tensor;
 typedef torch::Scalar *Scalar;
+typedef torch::Generator* Generator;
+
 typedef std::shared_ptr<torch::nn::Module>* NNModule;
 typedef std::shared_ptr<torch::nn::AnyModule> * NNAnyModule;
 typedef std::shared_ptr<torch::optim::Optimizer> * Optimizer;

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -20,9 +20,17 @@ namespace TorchSharp
         [DllImport("LibTorchSharp")]
         private static extern void THSTorch_manual_seed(long seed);
 
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSGenerator_manual_seed(long seed);
+
         public static void SetSeed(long seed)
         {
             THSTorch_manual_seed(seed);
+        }
+
+        public static TorchGenerator ManualSeed(long seed)
+        {
+            return new TorchGenerator(THSGenerator_manual_seed(seed));
         }
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/TorchSharp/TorchGenerator.cs
+++ b/src/TorchSharp/TorchGenerator.cs
@@ -92,8 +92,9 @@ namespace TorchSharp
         protected virtual void Dispose(bool disposing)
         {
             if (Handle != IntPtr.Zero) {
-                THSGenerator_dispose(Handle);
+                var h = Handle;
                 Handle = IntPtr.Zero;
+                THSGenerator_dispose(h);
             }
         }
 

--- a/src/TorchSharp/TorchGenerator.cs
+++ b/src/TorchSharp/TorchGenerator.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#nullable enable
+
+namespace TorchSharp
+{
+    public class TorchGenerator : IDisposable
+    {
+        public IntPtr Handle { get; private set; }
+
+        internal TorchGenerator(IntPtr nativeHandle)
+        {
+            Handle = nativeHandle;
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSGenerator_default_generator();
+
+        public static TorchGenerator Default {
+            get {
+                return new TorchGenerator(THSGenerator_default_generator());
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static long THSGenerator_initial_seed(IntPtr handle);
+
+        public long InitialSeed {
+            get {
+                return THSGenerator_initial_seed(Handle);
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static void THSGenerator_dispose(IntPtr handle);
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (Handle != IntPtr.Zero) {
+                THSGenerator_dispose(Handle);
+                Handle = IntPtr.Zero;
+            }
+        }
+
+        ~TorchGenerator()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -47,5 +47,25 @@ namespace TorchSharp
             Console.WriteLine("Hello World!");
         }
 
+        [Fact]
+        public void TestDefaultGenerators()
+        {
+            // This tests that the default generator can be disposed, but will keep on going,
+            long a, b, c;
+            using(var gen = Torch.ManualSeed(4711)) {
+                a = gen.InitialSeed;
+            }
+            using (var gen = TorchGenerator.Default) {
+                b = gen.InitialSeed;
+            }
+            Assert.Equal(a, b);
+            using (var gen = Torch.ManualSeed(17)) {
+                c = gen.InitialSeed;
+            }
+            Assert.NotEqual(a, c);
+
+            var x = Float32Tensor.rand(new long[] { 10, 10, 10 });
+            Assert.Equal(new long[] { 10, 10, 10 }, x.shape);
+        }
     }
 }

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -67,5 +67,53 @@ namespace TorchSharp
             var x = Float32Tensor.rand(new long[] { 10, 10, 10 });
             Assert.Equal(new long[] { 10, 10, 10 }, x.shape);
         }
+
+        [Fact]
+        public void TestExplicitGenerators()
+        {
+            // This tests that the default generator can be disposed, but will keep on going,
+            long a, b, c;
+            using (var gen = Torch.ManualSeed(4711)) {
+                a = gen.InitialSeed;
+            }
+            using (TorchGenerator gen = TorchGenerator.Default, genA = new TorchGenerator(4355)) {
+                b = gen.InitialSeed;
+                c = genA.InitialSeed;
+            }
+            Assert.Equal(a, b);
+            Assert.NotEqual(a, c);
+            Assert.Equal(4355, c);
+        }
+
+        [Fact]
+        public void TestGeneratorState()
+        {
+            // After restoring a saved RNG state, the next number should be the
+            // same as right after the snapshot.
+
+            using (var gen = Torch.ManualSeed(4711)) {
+
+                // Take a snapshot
+                var state = gen.State;
+                Assert.NotNull(state);
+
+                // Generate a number
+                var val1 = Float32Tensor.randn(new long[] { 1 });
+                var value1 = val1[0].ToSingle();
+
+                // Genereate a different number
+                var val2 = Float32Tensor.randn(new long[] { 1 });
+                var value2 = val2[0].ToSingle();
+                Assert.NotEqual(value1, value2);
+
+                // Restore the state
+                gen.State = state;
+
+                // Generate the first number again.
+                var val3 = Float32Tensor.randn(new long[] { 1 });
+                var value3 = val3[0].ToSingle();
+                Assert.Equal(value1, value3);
+            }
+        }
     }
 }


### PR DESCRIPTION
Several APIs take a random number Generator object as input. In order to be able to provide them, the Generator class itself has to be implemented. This PR adds it, as 'TorchGenerator,' and allows the seed to be set, state to be snapshot and restored, etc. Currently, only CPU-based RNGs are supported.