### PR TITLE
Renamed 1D/2D/3D -> 1d/2d/3d

### DIFF
--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -47,7 +47,7 @@ namespace TorchSharp.Examples
         private class Model : CustomModule
         {
             private readonly Sequential features;
-            private readonly AdaptiveAvgPool2D avgPool;
+            private readonly AdaptiveAvgPool2d avgPool;
             private readonly Sequential classifier;
 
             public Model(string name, int numClasses) : base(name)

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -44,8 +44,8 @@ namespace TorchSharp.Examples
 
         private class Model : CustomModule
         {
-            private Conv2D conv1 = Conv2D(1, 10, 5);
-            private Conv2D conv2 = Conv2D(10, 20, 5);
+            private Conv2d conv1 = Conv2D(1, 10, 5);
+            private Conv2d conv2 = Conv2D(10, 20, 5);
             private Linear fc1 = Linear(320, 50);
             private Linear fc2 = Linear(50, 10);
 

--- a/src/TorchSharp/NN/Convolution/Conv1D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv1D.cs
@@ -14,9 +14,9 @@ namespace TorchSharp.NN
         Circular = 3
     }
 
-    public class Conv1D : Module
+    public class Conv1d : Module
     {
-        internal Conv1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+        internal Conv1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_Conv1d_forward (Module.HType module, IntPtr tensor);
@@ -80,11 +80,11 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public Conv1D Conv1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public Conv1d Conv1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_Conv1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Conv1D (res, boxedHandle);
+            return new Conv1d (res, boxedHandle);
         }
     }
     public static partial class Functions

--- a/src/TorchSharp/NN/Convolution/Conv2D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv2D.cs
@@ -6,9 +6,9 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class Conv2D : Module
+    public class Conv2d : Module
     {
-        internal Conv2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+        internal Conv2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_Conv2d_forward (Module.HType module, IntPtr tensor);
@@ -71,11 +71,11 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
-        static public Conv2D Conv2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public Conv2d Conv2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_Conv2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Conv2D (res, boxedHandle);
+            return new Conv2d (res, boxedHandle);
         }
     }
     public static partial class Functions

--- a/src/TorchSharp/NN/Convolution/Conv3D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv3D.cs
@@ -6,9 +6,9 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class Conv3D : Module
+    public class Conv3d : Module
     {
-        internal Conv3D(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+        internal Conv3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
         [DllImport("LibTorchSharp")]
         private static extern IntPtr THSNN_Conv3d_forward(Module.HType module, IntPtr tensor);
@@ -71,11 +71,11 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
-        static public Conv3D Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public Conv3d Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Conv3D(res, boxedHandle);
+            return new Conv3d(res, boxedHandle);
         }
     }
     public static partial class Functions

--- a/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
@@ -6,9 +6,9 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class ConvTranspose1D : Module
+    public class ConvTranspose1d : Module
     {
-        internal ConvTranspose1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+        internal ConvTranspose1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_ConvTranspose1d_forward (Module.HType module, IntPtr tensor);
@@ -73,11 +73,11 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public ConvTranspose1D ConvTranspose1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public ConvTranspose1d ConvTranspose1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_ConvTranspose1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new ConvTranspose1D (res, boxedHandle);
+            return new ConvTranspose1d (res, boxedHandle);
         }
     }
     public static partial class Functions

--- a/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
@@ -6,9 +6,9 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class ConvTranspose2D : Module
+    public class ConvTranspose2d : Module
     {
-        internal ConvTranspose2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+        internal ConvTranspose2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_ConvTranspose2d_forward (Module.HType module, IntPtr tensor);
@@ -73,11 +73,11 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public ConvTranspose2D ConvTranspose2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public ConvTranspose2d ConvTranspose2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_ConvTranspose2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new ConvTranspose2D (res, boxedHandle);
+            return new ConvTranspose2d (res, boxedHandle);
         }
     }
     public static partial class Functions

--- a/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
@@ -6,9 +6,9 @@ using TorchSharp.Tensor;
 #nullable enable
 namespace TorchSharp.NN
 {
-    public class ConvTranspose3D : Module
+    public class ConvTranspose3d : Module
     {
-        internal ConvTranspose3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+        internal ConvTranspose3d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
         [DllImport ("LibTorchSharp")]
         private static extern IntPtr THSNN_ConvTranspose3d_forward (Module.HType module, IntPtr tensor);
@@ -73,11 +73,11 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public ConvTranspose3D ConvTranspose3D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public ConvTranspose3d ConvTranspose3D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_ConvTranspose3d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new ConvTranspose3D (res, boxedHandle);
+            return new ConvTranspose3d (res, boxedHandle);
         }
     }
     public static partial class Functions

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a BatchNorm1D module.
     /// </summary>
-    public class BatchNorm1D : Module
+    public class BatchNorm1d : Module
     {
-        internal BatchNorm1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal BatchNorm1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -41,12 +41,12 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public BatchNorm1D BatchNorm1D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public BatchNorm1d BatchNorm1D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_BatchNorm1d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new BatchNorm1D (handle, boxedHandle);
+                return new BatchNorm1d (handle, boxedHandle);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a BatchNorm2D module.
     /// </summary>
-    public class BatchNorm2D : Module
+    public class BatchNorm2d : Module
     {
-        internal BatchNorm2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal BatchNorm2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -41,12 +41,12 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public BatchNorm2D BatchNorm2D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public BatchNorm2d BatchNorm2D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_BatchNorm2d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new BatchNorm2D (handle, boxedHandle);
+                return new BatchNorm2d (handle, boxedHandle);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a BatchNorm3D module.
     /// </summary>
-    public class BatchNorm3D : Module
+    public class BatchNorm3d : Module
     {
-        internal BatchNorm3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal BatchNorm3d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -41,12 +41,12 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public BatchNorm3D BatchNorm3D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public BatchNorm3d BatchNorm3D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_BatchNorm3d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new BatchNorm3D (handle, boxedHandle);
+                return new BatchNorm3d (handle, boxedHandle);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a InstanceNorm1D module.
     /// </summary>
-    public class InstanceNorm1D : Module
+    public class InstanceNorm1d : Module
     {
-        internal InstanceNorm1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal InstanceNorm1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -41,12 +41,12 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public InstanceNorm1D InstanceNorm1D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public InstanceNorm1d InstanceNorm1D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_InstanceNorm1d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new InstanceNorm1D (handle, boxedHandle);
+                return new InstanceNorm1d (handle, boxedHandle);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a InstanceNorm2D module.
     /// </summary>
-    public class InstanceNorm2D : Module
+    public class InstanceNorm2d : Module
     {
-        internal InstanceNorm2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal InstanceNorm2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -41,12 +41,12 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public InstanceNorm2D InstanceNorm2D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public InstanceNorm2d InstanceNorm2D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_InstanceNorm2d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new InstanceNorm2D (handle, boxedHandle);
+                return new InstanceNorm2d (handle, boxedHandle);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a InstanceNorm3D module.
     /// </summary>
-    public class InstanceNorm3D : Module
+    public class InstanceNorm3d : Module
     {
-        internal InstanceNorm3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal InstanceNorm3d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -41,12 +41,12 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public InstanceNorm3D InstanceNorm3D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public InstanceNorm3d InstanceNorm3D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_InstanceNorm3d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                 if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                return new InstanceNorm3D (handle, boxedHandle);
+                return new InstanceNorm3d (handle, boxedHandle);
             }
         }
     }

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AdaptiveAvgPool1D module.
     /// </summary>
-    public class AdaptiveAvgPool1D : Module
+    public class AdaptiveAvgPool1d : Module
     {
-        internal AdaptiveAvgPool1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AdaptiveAvgPool1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">the target output size H</param>
         /// <returns></returns>
-        static public AdaptiveAvgPool1D AdaptiveAvgPool1D (long[] outputSize)
+        static public AdaptiveAvgPool1d AdaptiveAvgPool1D (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveAvgPool1d_ctor ((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AdaptiveAvgPool1D (handle, boxedHandle);
+                    return new AdaptiveAvgPool1d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AdaptiveAvgPool2D module.
     /// </summary>
-    public class AdaptiveAvgPool2D : Module
+    public class AdaptiveAvgPool2d : Module
     {
-        internal AdaptiveAvgPool2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AdaptiveAvgPool2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">The target output size (H,W) of the image of the form H x W.</param>
         /// <returns></returns>
-        static public AdaptiveAvgPool2D AdaptiveAvgPool2D (long[] outputSize)
+        static public AdaptiveAvgPool2d AdaptiveAvgPool2D (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveAvgPool2d_ctor ((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AdaptiveAvgPool2D (handle, boxedHandle);
+                    return new AdaptiveAvgPool2d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AdaptiveAvgPool3D module.
     /// </summary>
-    public class AdaptiveAvgPool3D : Module
+    public class AdaptiveAvgPool3d : Module
     {
-        internal AdaptiveAvgPool3D(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
+        internal AdaptiveAvgPool3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">The target output size of the image of the form H x W.</param>
         /// <returns></returns>
-        static public AdaptiveAvgPool3D AdaptiveAvgPool3D(long[] outputSize)
+        static public AdaptiveAvgPool3d AdaptiveAvgPool3D(long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveAvgPool3d_ctor((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AdaptiveAvgPool3D(handle, boxedHandle);
+                    return new AdaptiveAvgPool3d(handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AdaptiveMaxPool1D module.
     /// </summary>
-    public class AdaptiveMaxPool1D : Module
+    public class AdaptiveMaxPool1d : Module
     {
-        internal AdaptiveMaxPool1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AdaptiveMaxPool1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">The target output size H.</param>
         /// <returns></returns>
-        static public AdaptiveMaxPool1D AdaptiveMaxPool1D (long[] outputSize)
+        static public AdaptiveMaxPool1d AdaptiveMaxPool1D (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveMaxPool1d_ctor ((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AdaptiveMaxPool1D (handle, boxedHandle);
+                    return new AdaptiveMaxPool1d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AdaptiveMaxPool2D module.
     /// </summary>
-    public class AdaptiveMaxPool2D : Module
+    public class AdaptiveMaxPool2d : Module
     {
-        internal AdaptiveMaxPool2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AdaptiveMaxPool2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -36,13 +36,13 @@ namespace TorchSharp.NN
         /// <param name="outputSize">Applies a 2D adaptive max pooling over an input signal composed of several input planes.
         /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.</param>
         /// <returns></returns>
-        static public AdaptiveMaxPool2D AdaptiveMaxPool2D (long[] outputSize)
+        static public AdaptiveMaxPool2d AdaptiveMaxPool2D (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveMaxPool2d_ctor ((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AdaptiveMaxPool2D (handle, boxedHandle);
+                    return new AdaptiveMaxPool2d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AdaptiveMaxPool3D module.
     /// </summary>
-    public class AdaptiveMaxPool3D : Module
+    public class AdaptiveMaxPool3d : Module
     {
-        internal AdaptiveMaxPool3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AdaptiveMaxPool3d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -36,13 +36,13 @@ namespace TorchSharp.NN
         /// <param name="outputSize">The target output size of the image of the form D x H x W.
         /// Can be a tuple (D, H, W) or a single D for a cube D x D x D. D, H and W can be either a int, or null which means the size will be the same as that of the input.</param>
         /// <returns></returns>
-        static public AdaptiveMaxPool3D AdaptiveMaxPool3D (long[] outputSize)
+        static public AdaptiveMaxPool3d AdaptiveMaxPool3D (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveMaxPool3d_ctor ((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AdaptiveMaxPool3D (handle, boxedHandle);
+                    return new AdaptiveMaxPool3d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool1D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AvgPool1D module.
     /// </summary>
-    public class AvgPool1D : Module
+    public class AvgPool1d : Module
     {
-        internal AvgPool1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AvgPool1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,20 +35,20 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="stride">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public AvgPool1D AvgPool1D(long kernelSize, long? stride = null)
+        static public AvgPool1d AvgPool1D(long kernelSize, long? stride = null)
         {
             return stride.HasValue ?
                 AvgPool1D(new long[] { kernelSize }, new long[] { stride.Value }) :
                 AvgPool1D(new long[] { kernelSize }, null);
         }
 
-        static private AvgPool1D AvgPool1D (long[] kernelSize, long[] strides = null)
+        static private AvgPool1d AvgPool1D (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
                     var handle = THSNN_AvgPool1d_ctor ((IntPtr)pkernelSize, (IntPtr)pstrides, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AvgPool1D (handle, boxedHandle);
+                    return new AvgPool1d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool2D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AvgPool2D module.
     /// </summary>
-    public class AvgPool2D : Module
+    public class AvgPool2d : Module
     {
-        internal AvgPool2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AvgPool2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -36,13 +36,13 @@ namespace TorchSharp.NN
         /// <param name="strides">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
 
-        static public AvgPool2D AvgPool2D (long[] kernelSize, long[] strides = null)
+        static public AvgPool2d AvgPool2D (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
                     var handle = THSNN_AvgPool2d_ctor ((IntPtr)pkernelSize, kernelSize.Length, (IntPtr)pstrides, (strides == null ? 0 : strides.Length), out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AvgPool2D (handle, boxedHandle);
+                    return new AvgPool2d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/AvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool3D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a AvgPool3D module.
     /// </summary>
-    public class AvgPool3D : Module
+    public class AvgPool3d : Module
     {
-        internal AvgPool3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal AvgPool3d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="strides">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public AvgPool3D AvgPool3D (long[] kernelSize, long[] strides = null)
+        static public AvgPool3d AvgPool3D (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
                     var handle = THSNN_AvgPool3d_ctor ((IntPtr)pkernelSize, kernelSize.Length, (IntPtr)pstrides, (strides == null ? 0 : strides.Length), out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new AvgPool3D (handle, boxedHandle);
+                    return new AvgPool3d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/MaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool1D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a MaxPool1D module.
     /// </summary>
-    public class MaxPool1D : Module
+    public class MaxPool1d : Module
     {
-        internal MaxPool1D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal MaxPool1d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,20 +35,20 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the sliding window, must be > 0.</param>
         /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
-        static public MaxPool1D MaxPool1D (long kernelSize, long? stride = null)
+        static public MaxPool1d MaxPool1D (long kernelSize, long? stride = null)
         {
             return stride.HasValue ?
                 MaxPool1D(new long[] { kernelSize }, new long[] { stride.Value }) :
                 MaxPool1D(new long[] { kernelSize }, null);
         }
 
-        static private MaxPool1D MaxPool1D(long[] kernelSize, long[] strides = null)
+        static private MaxPool1d MaxPool1D(long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
                     var handle = THSNN_MaxPool1d_ctor((IntPtr)pkernelSize, (IntPtr)pstrides, out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new MaxPool1D(handle, boxedHandle);
+                    return new MaxPool1d(handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/MaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool2D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a MaxPool2D module.
     /// </summary>
-    public class MaxPool2D : Module
+    public class MaxPool2d : Module
     {
-        internal MaxPool2D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal MaxPool2d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the sliding window, must be > 0.</param>
         /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
-        static public MaxPool2D MaxPool2D (long[] kernelSize, long[] strides = null)
+        static public MaxPool2d MaxPool2D (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
                     var handle = THSNN_MaxPool2d_ctor ((IntPtr)pkernelSize, kernelSize.Length, (IntPtr)pstrides, (strides == null ? 0 : strides.Length), out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new MaxPool2D (handle, boxedHandle);
+                    return new MaxPool2d (handle, boxedHandle);
                 }
             }
         }

--- a/src/TorchSharp/NN/Pooling/MaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool3D.cs
@@ -8,9 +8,9 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a MaxPool3D module.
     /// </summary>
-    public class MaxPool3D : Module
+    public class MaxPool3d : Module
     {
-        internal MaxPool3D (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal MaxPool3d (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
@@ -35,13 +35,13 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the sliding window, must be > 0.</param>
         /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
-        static public MaxPool3D MaxPool3D (long[] kernelSize, long[] strides = null)
+        static public MaxPool3d MaxPool3D (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
                     var handle = THSNN_MaxPool3d_ctor ((IntPtr)pkernelSize, kernelSize.Length, (IntPtr)pstrides, (strides == null ? 0 : strides.Length), out var boxedHandle);
                     if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new MaxPool3D (handle, boxedHandle);
+                    return new MaxPool3d (handle, boxedHandle);
                 }
             }
         }

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -32,7 +32,7 @@ namespace TorchSharp
             if (File.Exists(".model.ts")) File.Delete(".model.ts");
             var conv = Conv2D(100, 10, 5);
             conv.Save(".model.ts");
-            var loaded = NN.Conv2D.Load(".model.ts");
+            var loaded = NN.Conv2d.Load(".model.ts");
             File.Delete(".model.ts");
             Assert.NotNull(loaded);
         }


### PR DESCRIPTION
Renamed 1D/2D/3D -> 1d/2d/3d to correspond with how layers are named in the Python and C++ APIs.

The code I recently added adhered to the few layers already in existence, which used 'D" instead of 'd' like the Python APIs do. This PR corrects that, so that the APIs look more like the ones available in Python.