### PR TITLE
Fixing native code memory leak.

### DIFF
--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -32,14 +32,16 @@ namespace TorchSharp.NN
 
             protected override bool ReleaseHandle ()
             {
-                THSNN_Module_dispose (this);
+                if (!IsInvalid) THSNN_Module_dispose (this);
+                SetHandle(IntPtr.Zero);
                 return true;
             }
 
             protected override void Dispose (bool disposing)
             {
                 if (disposing) {
-                    ReleaseHandle ();
+                    ReleaseHandle();
+                    GC.SuppressFinalize(this);
                 }
             }
         }
@@ -87,8 +89,9 @@ namespace TorchSharp.NN
         protected void Dispose (bool disposing)
         {
             if (disposing) {
-                handle.Dispose ();
-                handle.SetHandleAsInvalid ();
+                if (!handle.IsInvalid) handle.Dispose();
+                boxedModule?.Dispose();
+                handle.SetHandleAsInvalid();
             }
         }
 
@@ -338,14 +341,16 @@ namespace TorchSharp.NN
 
             protected override bool ReleaseHandle ()
             {
-                THSNN_AnyModule_dispose (this);
+                if (!IsInvalid) THSNN_AnyModule_dispose(this);
+                handle = IntPtr.Zero;
                 return true;
             }
 
             protected override void Dispose (bool disposing)
             {
                 if (disposing) {
-                    ReleaseHandle ();
+                    ReleaseHandle();
+                    GC.SuppressFinalize(this);
                 }
             }
         }
@@ -377,7 +382,7 @@ namespace TorchSharp.NN
         protected void Dispose (bool disposing)
         {
             if (disposing) {
-                handle.Dispose ();
+                if (!handle.IsInvalid) handle.Dispose();
                 handle.SetHandleAsInvalid ();
             }
         }

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -41,7 +41,6 @@ namespace TorchSharp.NN
             {
                 if (disposing) {
                     ReleaseHandle();
-                    GC.SuppressFinalize(this);
                 }
             }
         }
@@ -89,9 +88,9 @@ namespace TorchSharp.NN
         protected void Dispose (bool disposing)
         {
             if (disposing) {
-                if (!handle.IsInvalid) handle.Dispose();
-                boxedModule?.Dispose();
+                handle.Dispose();
                 handle.SetHandleAsInvalid();
+                boxedModule?.Dispose();
             }
         }
 
@@ -350,7 +349,6 @@ namespace TorchSharp.NN
             {
                 if (disposing) {
                     ReleaseHandle();
-                    GC.SuppressFinalize(this);
                 }
             }
         }
@@ -382,7 +380,7 @@ namespace TorchSharp.NN
         protected void Dispose (bool disposing)
         {
             if (disposing) {
-                if (!handle.IsInvalid) handle.Dispose();
+                handle.Dispose();
                 handle.SetHandleAsInvalid ();
             }
         }


### PR DESCRIPTION
Each .NET Module instance potentially has two handles to the native module. Both of them have to be released when the instance is disposed.

Fixes #233.