### PR TITLE
Examples

### DIFF
--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -87,21 +87,21 @@ namespace TorchSharp.Examples
             public Model(string name, int numClasses, Device device = null) : base(name)
             {
                 features = Sequential(
-                    ("c1", Conv2D(3, 64, kernelSize: 3, stride: 2, padding: 1)),
+                    ("c1", Conv2d(3, 64, kernelSize: 3, stride: 2, padding: 1)),
                     ("r1", ReLU(inPlace: true)),
-                    ("mp1", MaxPool2D(kernelSize: new long[] { 2, 2 })),
-                    ("c2", Conv2D(64, 192, kernelSize: 3, padding: 1)),
+                    ("mp1", MaxPool2d(kernelSize: new long[] { 2, 2 })),
+                    ("c2", Conv2d(64, 192, kernelSize: 3, padding: 1)),
                     ("r2", ReLU(inPlace: true)),
-                    ("mp2", MaxPool2D(kernelSize: new long[] { 2, 2 })),
-                    ("c3", Conv2D(192, 384, kernelSize: 3, padding: 1)),
+                    ("mp2", MaxPool2d(kernelSize: new long[] { 2, 2 })),
+                    ("c3", Conv2d(192, 384, kernelSize: 3, padding: 1)),
                     ("r3", ReLU(inPlace: true)),
-                    ("c4", Conv2D(384, 256, kernelSize: 3, padding: 1)),
+                    ("c4", Conv2d(384, 256, kernelSize: 3, padding: 1)),
                     ("r4", ReLU(inPlace: true)),
-                    ("c5", Conv2D(256, 256, kernelSize: 3, padding: 1)),
+                    ("c5", Conv2d(256, 256, kernelSize: 3, padding: 1)),
                     ("r5", ReLU(inPlace: true)),
-                    ("mp3", MaxPool2D(kernelSize: new long[] { 2, 2 })));
+                    ("mp3", MaxPool2d(kernelSize: new long[] { 2, 2 })));
 
-                avgPool = AdaptiveAvgPool2D(new long[] { 2, 2 });
+                avgPool = AdaptiveAvgPool2d(new long[] { 2, 2 });
 
                 classifier = Sequential(
                     ("d1", Dropout()),

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
+using System.IO;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
 using TorchSharp.Tensor;
@@ -12,12 +14,21 @@ namespace TorchSharp.Examples
     /// <summary>
     /// Modified version of original AlexNet to fix CIFAR10 32x32 images.
     /// </summary>
+    /// <remarks>
+    /// The dataset for this example can be found at: http://yann.lecun.com/exdb/mnist/
+    /// Download the binary file, and place it in a dedicated folder, e.g. 'CIFAR10,' then edit
+    /// the '_dataLocation' definition below to point at the right folder.
+    ///
+    /// Note: so far, CIFAR10 is supported, but not CIFAR100.
+    /// </remarks>
     class AlexNet
     {
-        private readonly static int _epochs = 5;
-        private readonly static long _trainBatchSize = 100;
-        private readonly static long _testBatchSize = 10000;
-        private readonly static string _dataLocation = @"../../../../src/Examples/Data";
+        private readonly static string _dataset = "CIFAR10";
+        private readonly static string _dataLocation = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), "..", "Downloads", _dataset);
+
+        private static int _epochs = 100;
+        private static int _trainBatchSize = 64;
+        private static int _testBatchSize = 128;
 
         private readonly static int _logInterval = 10;
         private readonly static int _numClasses = 10;
@@ -26,20 +37,43 @@ namespace TorchSharp.Examples
         {
             Torch.SetSeed(1);
 
-            using (var train = Data.Loader.CIFAR10(_dataLocation, _trainBatchSize))
-            using (var test = Data.Loader.CIFAR10(_dataLocation, _testBatchSize, false))
-            using (var model = new Model("model", _numClasses))
+            var device = Torch.IsCudaAvailable() ? Device.CUDA : Device.CPU;
+            Console.WriteLine();
+            Console.WriteLine($"\tRunning AlexNet with {_dataset} on {device.Type.ToString()}");
+            Console.WriteLine();
+
+            if (device.Type == DeviceType.CUDA) {
+                _trainBatchSize *= 8;
+                _testBatchSize *= 8;
+                _epochs *= 16;
+            }
+
+            var sourceDir = _dataLocation;
+            var targetDir = Path.Combine(_dataLocation, "test_data");
+
+            if (!Directory.Exists(targetDir)) {
+                Directory.CreateDirectory(targetDir);
+                Utils.Decompress.ExtractTGZ(Path.Combine(sourceDir, "cifar-10-binary.tar.gz"), targetDir);
+            }
+
+            using (var train = new CIFARReader(targetDir, false, _trainBatchSize, shuffle: true, device: device))
+            using (var test = new CIFARReader(targetDir, true, _testBatchSize, device: device))
+            using (var model = new Model("model", _numClasses, device))
             using (var optimizer = NN.Optimizer.Adam(model.parameters(), 0.001)) {
+
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
                 for (var epoch = 1; epoch <= _epochs; epoch++) {
-                    Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size());
-                    Test(model, nll_loss(), test, test.Size());
+                    Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size);
+                    Test(model, nll_loss(), test, test.Size);
+                    GC.Collect();
+
+                    if (sw.Elapsed.TotalSeconds > 3600) break;
                 }
 
                 sw.Stop();
-                Console.WriteLine($"Elapsed time {sw.ElapsedMilliseconds}.");
+                Console.WriteLine($"Elapsed time {sw.Elapsed.TotalSeconds} s.");
                 Console.ReadLine();
             }
         }
@@ -50,22 +84,22 @@ namespace TorchSharp.Examples
             private readonly AdaptiveAvgPool2d avgPool;
             private readonly Sequential classifier;
 
-            public Model(string name, int numClasses) : base(name)
+            public Model(string name, int numClasses, Device device = null) : base(name)
             {
                 features = Sequential(
                     ("c1", Conv2D(3, 64, kernelSize: 3, stride: 2, padding: 1)),
                     ("r1", ReLU(inPlace: true)),
-                    ("mp1", MaxPool2D(kernelSize: new long[] { 2 })),
+                    ("mp1", MaxPool2D(kernelSize: new long[] { 2, 2 })),
                     ("c2", Conv2D(64, 192, kernelSize: 3, padding: 1)),
                     ("r2", ReLU(inPlace: true)),
-                    ("mp2", MaxPool2D(kernelSize: new long[] { 2 })),
+                    ("mp2", MaxPool2D(kernelSize: new long[] { 2, 2 })),
                     ("c3", Conv2D(192, 384, kernelSize: 3, padding: 1)),
                     ("r3", ReLU(inPlace: true)),
                     ("c4", Conv2D(384, 256, kernelSize: 3, padding: 1)),
                     ("r4", ReLU(inPlace: true)),
                     ("c5", Conv2D(256, 256, kernelSize: 3, padding: 1)),
                     ("r5", ReLU(inPlace: true)),
-                    ("mp3", MaxPool2D(kernelSize: new long[] { 2 })));
+                    ("mp3", MaxPool2D(kernelSize: new long[] { 2, 2 })));
 
                 avgPool = AdaptiveAvgPool2D(new long[] { 2, 2 });
 
@@ -76,12 +110,16 @@ namespace TorchSharp.Examples
                     ("d2", Dropout()),
                     ("l2", Linear(4096, 4096)),
                     ("r3", ReLU(inPlace: true)),
+                    ("d3", Dropout()),
                     ("l3", Linear(4096, numClasses))
                 );
 
                 RegisterModule("features", features);
                 RegisterModule("avg", avgPool);
                 RegisterModule("classify", classifier);
+
+                if (device != null && device.Type == DeviceType.CUDA)
+                    this.to(device);
             }
 
             public override TorchTensor forward(TorchTensor input)
@@ -109,27 +147,30 @@ namespace TorchSharp.Examples
             long total = 0;
             long correct = 0;
 
+            Console.WriteLine($"Epoch: {epoch}...");
+
             foreach (var (data, target) in dataLoader) {
                 optimizer.zero_grad();
 
                 using (var prediction = model.forward(data))
-                using (var output = loss(LogSoftMax(prediction, 1), target)) {
+                using (var output = loss(LogSoftmax(prediction, 1), target)) {
                     output.backward();
 
                     optimizer.step();
 
-                    var predicted = prediction.argmax(1);
                     total += target.shape[0];
-                    correct += predicted.eq(target).sum().ToInt64();
+
+                    using (var predicted = prediction.argmax(1))
+                    using (var eq = predicted.eq(target))
+                    using (var sum = eq.sum()) {
+                        correct += sum.ToInt64();
+                    }
 
                     if (batchId % _logInterval == 0) {
-                        Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.ToSingle()} Acc: { (float)correct / total }");
+                        Console.WriteLine($"\rTrain: epoch {epoch} [{batchId * batchSize} / {size}] Loss: {output.ToSingle().ToString("0.0000")} Acc: { ((float)correct / total).ToString("0.0000") }");
                     }
 
                     batchId++;
-
-                    data.Dispose();
-                    target.Dispose();
                 }
             }
         }
@@ -144,24 +185,25 @@ namespace TorchSharp.Examples
 
             double testLoss = 0;
             long correct = 0;
+            int batchCount = 0;
 
             foreach (var (data, target) in dataLoader) {
                 using (var prediction = model.forward(data))
-                using (var output = loss(LogSoftMax(prediction, 1), target)) {
+                using (var output = loss(LogSoftmax(prediction, 1), target)) {
+
                     testLoss += output.ToSingle();
+                    batchCount += 1;
 
-                    var pred = prediction.argmax(1);
-
-                    correct += pred.eq(target).sum().ToInt64();
-
-                    data.Dispose();
-                    target.Dispose();
-                    pred.Dispose();
+                    using (var predicted = prediction.argmax(1))
+                    using (var eq = predicted.eq(target))
+                    using (var sum = eq.sum()) {
+                        correct += sum.ToInt64();
+                    }
                 }
 
             }
 
-            Console.WriteLine($"\rTest set: Average loss {testLoss} | Accuracy {(float)correct / size}");
+            Console.WriteLine($"\rTest set: Average loss {(testLoss/batchCount).ToString("0.0000")} | Accuracy {((float)correct / size).ToString("0.0000")}");
         }
     }
 }

--- a/src/Examples/BigEndianReader.cs
+++ b/src/Examples/BigEndianReader.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+
+namespace TorchSharp.Examples.Utils
+{
+    public class BigEndianReader
+    {
+        public BigEndianReader(BinaryReader baseReader)
+        {
+            mBaseReader = baseReader;
+        }
+
+        public int ReadInt32()
+        {
+            return BitConverter.ToInt32(ReadBigEndianBytes(4), 0);
+        }
+
+        public byte[] ReadBigEndianBytes(int count)
+        {
+            byte[] bytes = new byte[count];
+            for (int i = count - 1; i >= 0; i--)
+                bytes[i] = mBaseReader.ReadByte();
+
+            return bytes;
+        }
+
+        public byte[] ReadBytes(int count)
+        {
+            return mBaseReader.ReadBytes(count);
+        }
+
+        public void Close()
+        {
+            mBaseReader.Close();
+        }
+
+        public Stream BaseStream {
+            get { return mBaseReader.BaseStream; }
+        }
+
+        private BinaryReader mBaseReader;
+    }
+}

--- a/src/Examples/CIFARReader .cs
+++ b/src/Examples/CIFARReader .cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using TorchSharp.Tensor;
+
+namespace TorchSharp.Examples
+{
+    /// <summary>
+    /// Data reader utility for datasets that follow the MNIST data set's layout:
+    ///
+    /// A number of single-channel (grayscale) images are laid out in a flat file with four 32-bit integers at the head.
+    /// The format is documented at the bottom of the page at: http://yann.lecun.com/exdb/mnist/
+    /// </summary>
+    class CIFARReader : IEnumerable<(TorchTensor, TorchTensor)>, IDisposable
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="path">Path to the folder containing the image files.</param>
+        /// <param name="test">True if this is a test set, otherwise false.</param>
+        /// <param name="batch_size">The batch size</param>
+        /// <param name="shuffle">Randomly shuffle the images.</param>
+        /// <param name="device">The device, i.e. CPU or GPU to place the output tensors on.</param>
+        public CIFARReader(string path, bool test, int batch_size = 32, bool shuffle = false, Device device = null)
+        {
+            // The MNIST data set is small enough to fit in memory, so let's load it there.
+
+            var dataPath = Path.Combine(path, "cifar-10-batches-bin");
+
+            if (test) {
+                Size = ReadSingleFile(Path.Combine(dataPath, "test_batch.bin"), batch_size, shuffle, device);
+            } else {
+                Size += ReadSingleFile(Path.Combine(dataPath, "data_batch_1.bin"), batch_size, shuffle, device);
+                Size += ReadSingleFile(Path.Combine(dataPath, "data_batch_2.bin"), batch_size, shuffle, device);
+                Size += ReadSingleFile(Path.Combine(dataPath, "data_batch_3.bin"), batch_size, shuffle, device);
+                Size += ReadSingleFile(Path.Combine(dataPath, "data_batch_4.bin"), batch_size, shuffle, device);
+                Size += ReadSingleFile(Path.Combine(dataPath, "data_batch_5.bin"), batch_size, shuffle, device);
+            }
+        }
+
+        private int ReadSingleFile(string path, int batch_size, bool shuffle, Device device)
+        {
+            const int height = 32;
+            const int width = 32;
+            const int channels = 3;
+            const int count = 10000;
+
+            byte[] dataBytes = File.ReadAllBytes(path);
+
+            if (dataBytes.Length != (1 + channels * height * width) * count)
+                throw new InvalidDataException($"Not a proper CIFAR10 file: {path}");
+
+            // Set up the indices array.
+            Random rnd = new Random();
+            var indices = !shuffle ?
+                Enumerable.Range(0, count).ToArray() :
+                Enumerable.Range(0, count).OrderBy(c => rnd.Next()).ToArray();
+
+            var imgSize = channels * height * width;
+
+            // Go through the data and create tensors
+            for (var i = 0; i < count;) {
+
+                var take = Math.Min(batch_size, Math.Max(0, count - i));
+
+                if (take < 1) break;
+
+                var dataTensor = Float32Tensor.zeros(new long[] { take, imgSize }, device);
+                var lablTensor = Int64Tensor.zeros(new long[] { take }, device);
+
+                // Take
+                for (var j = 0; j < take; j++) {
+                    var idx = indices[i++];
+                    var lblStart = idx * (1 + imgSize);
+                    var imgStart = lblStart + 1;
+
+                    lablTensor[j] = Int64Tensor.from(dataBytes[lblStart]);
+
+                    var floats = dataBytes[imgStart..(imgStart + imgSize)].Select(b => (float)b).ToArray();
+                    using (var inputTensor = Float32Tensor.from(floats))
+                        dataTensor.index_put_(new TorchTensorIndex[] { TorchTensorIndex.Single(j) }, inputTensor);
+                }
+
+                data.Add(dataTensor.reshape(take, channels, height, width));
+                dataTensor.Dispose();
+                labels.Add(lablTensor);
+            }
+
+            return count;
+        }
+
+        public int Size { get; set; }
+
+        private List<TorchTensor> data = new List<TorchTensor>();
+        private List<TorchTensor> labels = new List<TorchTensor>();
+
+        public IEnumerator<(TorchTensor, TorchTensor)> GetEnumerator()
+        {
+            return new CIFAREnumerator(data, labels);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Dispose()
+        {
+            data.ForEach(d => d.Dispose());
+            labels.ForEach(d => d.Dispose());
+        }
+
+        private class CIFAREnumerator : IEnumerator<(TorchTensor, TorchTensor)>
+        {
+            public CIFAREnumerator(List<TorchTensor> data, List<TorchTensor> labels)
+            {
+                this.data = data;
+                this.labels = labels;
+            }
+
+            public (TorchTensor, TorchTensor) Current {
+                get {
+                    return (data[curIdx], labels[curIdx]);
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                curIdx += 1;
+                return curIdx < data.Count;
+            }
+
+            public void Reset()
+            {
+                curIdx = 0;
+            }
+
+            private int curIdx = 0;
+            private List<TorchTensor> data = null;
+            private List<TorchTensor> labels = null;
+        }
+    }
+}

--- a/src/Examples/Decompress.cs
+++ b/src/Examples/Decompress.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using System.Linq;
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
+
+namespace TorchSharp.Examples.Utils
+{
+    public static class Decompress
+    {
+        public static void DecompressGZipFile(string gzipFileName, string targetDir)
+        {
+            byte[] buf = new byte[4096];
+
+            using (var fs = File.OpenRead(gzipFileName))
+            using (var gzipStream = new GZipInputStream(fs)) {
+
+                string fnOut = Path.Combine(targetDir, Path.GetFileNameWithoutExtension(gzipFileName));
+
+                using (var fsOut = File.Create(fnOut)) {
+                    StreamUtils.Copy(gzipStream, fsOut, buf);
+                }
+            }
+        }
+        public static void ExtractTGZ(string gzArchiveName, string destFolder)
+        {
+            var flag = gzArchiveName.Split(Path.DirectorySeparatorChar).Last().Split('.').First() + ".bin";
+            if (File.Exists(Path.Combine(destFolder, flag))) return;
+
+            Console.WriteLine($"Extracting.");
+            var task = Task.Run(() => {
+                using (var inStream = File.OpenRead(gzArchiveName)) {
+                    using (var gzipStream = new GZipInputStream(inStream)) {
+#pragma warning disable CS0618 // Type or member is obsolete
+                        using (TarArchive tarArchive = TarArchive.CreateInputTarArchive(gzipStream))
+#pragma warning restore CS0618 // Type or member is obsolete
+                            tarArchive.ExtractContents(destFolder);
+                    }
+                }
+            });
+
+            while (!task.IsCompleted) {
+                Thread.Sleep(200);
+                Console.Write(".");
+            }
+
+            File.Create(Path.Combine(destFolder, flag));
+            Console.WriteLine("");
+            Console.WriteLine("Extraction completed.");
+        }
+
+    }
+}

--- a/src/Examples/Decompress.cs
+++ b/src/Examples/Decompress.cs
@@ -7,6 +7,9 @@ using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 
+//NOTE: This code was inspired by code found int the SciSharpStack-Examples repository.
+//      https://github.com/SciSharp/SciSharp-Stack-Examples
+
 namespace TorchSharp.Examples.Utils
 {
     public static class Decompress

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -2,13 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TestUsesLibTorch>true</TestUsesLibTorch>
+    <TestCuda>true</TestCuda>
     <TargetFramework>net5.0</TargetFramework>
     <TestUsesLibTorch>true</TestUsesLibTorch>
     <UseMLCodeAnalyzer>false</UseMLCodeAnalyzer>
     <UseStyleCopAnalyzer>false</UseStyleCopAnalyzer>
     <StartupObject>TorchSharp.Examples.AlexNet</StartupObject>
     <IsPackable>false</IsPackable>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TorchSharp\TorchSharp.csproj" />

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -98,12 +98,12 @@ namespace TorchSharp.Examples
         private static Sequential GetModel(Device device)
         {
             var seq = Sequential(
-                ("conv1", Conv2D(1, 10, 5)),
-                ("pool1", MaxPool2D(kernelSize: new long[] { 2, 2 })),
+                ("conv1", Conv2d(1, 10, 5)),
+                ("pool1", MaxPool2d(kernelSize: new long[] { 2, 2 })),
                 ("relu1", ReLU()),
-                ("conv2", Conv2D(10, 20, 5)),
+                ("conv2", Conv2d(10, 20, 5)),
                 ("dropout1", FeatureAlphaDropout()),
-                ("pool2", MaxPool2D(kernelSize: new long[] { 2, 2 })),
+                ("pool2", MaxPool2d(kernelSize: new long[] { 2, 2 })),
                 ("relu2", ReLU()),
                 ("flatten", Flatten()),
                 ("fc1", Linear(320, 64)),
@@ -119,13 +119,13 @@ namespace TorchSharp.Examples
 
         private class Model : CustomModule
         {
-            private Conv2d conv1 = Conv2D(1, 10, 5);
-            private Conv2d conv2 = Conv2D(10, 20, 5);
+            private Conv2d conv1 = Conv2d(1, 10, 5);
+            private Conv2d conv2 = Conv2d(10, 20, 5);
             private Linear fc1 = Linear(320, 50);
             private Linear fc2 = Linear(50, 10);
 
-            private MaxPool2D pool1 = MaxPool2D(kernelSize: new long[] { 2, 2 });
-            private MaxPool2D pool2 = MaxPool2D(kernelSize: new long[] { 2, 2 });
+            private MaxPool2d pool1 = MaxPool2d(kernelSize: new long[] { 2, 2 });
+            private MaxPool2d pool2 = MaxPool2d(kernelSize: new long[] { 2, 2 });
 
             private ReLU relu1 = ReLU();
             private ReLU relu2 = ReLU();

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
+using System.IO;
+using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
 using System.Collections.Generic;
 using System.Diagnostics;
 using TorchSharp.Tensor;
@@ -9,22 +14,66 @@ using static TorchSharp.NN.Functions;
 
 namespace TorchSharp.Examples
 {
+    /// <summary>
+    /// Simple MNIST Convolutional model.
+    /// </summary>
+    /// <remarks>
+    /// There are at least two interesting data sets to use with this example:
+    /// 
+    /// 1. The classic MNIST set of 60000 images of handwritten digits.
+    ///
+    ///     It is available at: http://yann.lecun.com/exdb/mnist/
+    ///     
+    /// 2. The 'fashion-mnist' data set, which has the exact same file names and format as MNIST, but is a harder
+    ///    data set to train on. It's just as large as MNIST, and has the same 60/10 split of training and test
+    ///    data.
+    ///    It is available at: https://github.com/zalandoresearch/fashion-mnist/tree/master/data/fashion
+    ///
+    /// In each case, there are four .gz files to download. Place them in a folder and then point the '_dataLocation'
+    /// constant below at the folder location.
+    /// </remarks>
     public class MNIST
     {
-        private readonly static int _epochs = 10;
-        private readonly static long _trainBatchSize = 64;
-        private readonly static long _testBatchSize = 1000;
-        private readonly static string _dataLocation = @"../../../../src/Examples/Data";
+        private readonly static string _dataLocation = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), "..", "Downloads", "fashion-mnist");
 
-        private readonly static int _logInterval = 10;
+        private static int _epochs = 10;
+        private static int _trainBatchSize = 64;
+        private static int _testBatchSize = 128;
+
+        private readonly static int _logInterval = 100;
 
         static void Main(string[] args)
+
         {
             Torch.SetSeed(1);
 
-            using (var train = Data.Loader.MNIST(_dataLocation, _trainBatchSize))
-            using (var test = Data.Loader.MNIST(_dataLocation, _testBatchSize, false))
-            using (var model = new Model("model"))
+            var cwd = Environment.CurrentDirectory;
+
+            //var device = Device.CPU; //Torch.IsCudaAvailable() ? Device.CUDA : Device.CPU;
+            var device = Torch.IsCudaAvailable() ? Device.CUDA : Device.CPU;
+            Console.WriteLine($"Running on {device.Type.ToString()}");
+
+            if (device.Type == DeviceType.CUDA) {
+                _trainBatchSize *= 4;
+                _testBatchSize *= 4;
+                _epochs *= 16;
+            }
+
+            var sourceDir = _dataLocation;
+            var targetDir = Path.Combine(_dataLocation, "test_data");
+
+            if (!Directory.Exists(targetDir)) {
+                Directory.CreateDirectory(targetDir);
+                Utils.Decompress.DecompressGZipFile(Path.Combine(sourceDir, "train-images-idx3-ubyte.gz"), targetDir);
+                Utils.Decompress.DecompressGZipFile(Path.Combine(sourceDir, "train-labels-idx1-ubyte.gz"), targetDir);
+                Utils.Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-images-idx3-ubyte.gz"), targetDir);
+                Utils.Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-labels-idx1-ubyte.gz"), targetDir);
+            }
+
+            using (var train = new MNISTReader(targetDir, "train", _trainBatchSize, device: device, shuffle: true))
+            using (var test = new MNISTReader(targetDir, "t10k", _testBatchSize, device: device))
+            //using (var model = new Model("model", device))
+            using (var model = GetModel(device))
             using (var optimizer = NN.Optimizer.SGD(model.parameters(), 0.01, 0.5))
             {
                 Stopwatch sw = new Stopwatch();
@@ -32,14 +81,40 @@ namespace TorchSharp.Examples
 
                 for (var epoch = 1; epoch <= _epochs; epoch++)
                 {
-                    Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size());
-                    Test(model, nll_loss(reduction: NN.Reduction.Sum), test, test.Size());
+                    Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train.Size);
+                    Test(model, nll_loss(reduction: NN.Reduction.Sum), test, test.Size);
+
+                    Console.WriteLine($"Pre-GC memory:  {GC.GetTotalMemory(false)}");
+                    GC.Collect();
+                    Console.WriteLine($"Post-GC memory: {GC.GetTotalMemory(false)}");
                 }
 
                 sw.Stop();
-                Console.WriteLine($"Elapsed time {sw.ElapsedMilliseconds}.");
+                Console.WriteLine($"Elapsed time: {sw.Elapsed.TotalSeconds} s.");
                 Console.ReadLine();
             }
+        }
+
+        private static Sequential GetModel(Device device)
+        {
+            var seq = Sequential(
+                ("conv1", Conv2D(1, 10, 5)),
+                ("pool1", MaxPool2D(kernelSize: new long[] { 2, 2 })),
+                ("relu1", ReLU()),
+                ("conv2", Conv2D(10, 20, 5)),
+                ("dropout1", FeatureAlphaDropout()),
+                ("pool2", MaxPool2D(kernelSize: new long[] { 2, 2 })),
+                ("relu2", ReLU()),
+                ("flatten", Flatten()),
+                ("fc1", Linear(320, 64)),
+                ("relu3", ReLU()),
+                ("dropout2", Dropout()),
+                ("fc2", Linear(64, 10)),
+                ("logsm", LogSoftmax(1)));
+
+            return (device != null && device.Type == DeviceType.CUDA) ?
+                seq.to(device) as Sequential :
+                seq;
         }
 
         private class Model : CustomModule
@@ -49,39 +124,64 @@ namespace TorchSharp.Examples
             private Linear fc1 = Linear(320, 50);
             private Linear fc2 = Linear(50, 10);
 
-            public Model(string name) : base(name)
+            private MaxPool2D pool1 = MaxPool2D(kernelSize: new long[] { 2, 2 });
+            private MaxPool2D pool2 = MaxPool2D(kernelSize: new long[] { 2, 2 });
+
+            private ReLU relu1 = ReLU();
+            private ReLU relu2 = ReLU();
+            private ReLU relu3 = ReLU();
+
+            private FeatureAlphaDropout dropout1 = FeatureAlphaDropout();
+            private Dropout dropout2 = Dropout();
+
+            private Flatten flatten = Flatten();
+            private LogSoftmax logsm = LogSoftmax(1);
+
+
+            public Model(string name, Device device = null) : base(name)
             {
                 RegisterModule("conv1", conv1);
                 RegisterModule("conv2", conv2);
                 RegisterModule("lin1", fc1);
                 RegisterModule("lin2", fc2);
+                RegisterModule("pool1", pool1);
+                RegisterModule("pool2", pool2);
+                RegisterModule("relu1", relu1);
+                RegisterModule("relu2", relu2);
+                RegisterModule("relu3", relu3);
+                RegisterModule("drop1", dropout1);
+                RegisterModule("drop2", dropout2);
+                RegisterModule("logsoft", logsm);
+
+                if (device != null && device.Type == DeviceType.CUDA)
+                    this.to(device);
             }
 
             public override TorchTensor forward(TorchTensor input)
             {
                 using (var l11 = conv1.forward(input))
-                using (var l12 = MaxPool2D (l11, kernelSize: new long[]{ 2 }))
-                using (var l13 = ReLU(l12))
+                using (var l12 = pool1.forward(l11))
+                using (var l13 = relu1.forward(l12))
 
                 using (var l21 = conv2.forward(l13))
-                using (var l22 = FeatureAlphaDropout(l21))
-                using (var l23 = MaxPool2D (l22, kernelSize: new long[] { 2 }))
-                using (var l24 = ReLU(l23))
+                using (var l22 = pool2.forward(l21))
+                using (var l23 = dropout1.forward(l22))
+                using (var l24 = relu2.forward(l23))
 
-                using (var x = l24.view(new long[] { -1, 320 }))
+                using (var x = flatten.forward(l24))
 
                 using (var l31 = fc1.forward(x))
-                using (var l32 = ReLU(l31))
-                using (var l33 = Dropout(l32))
+                using (var l32 = relu3.forward(l31))
+                using (var l33 = dropout2.forward(l32))
 
                 using (var l41 = fc2.forward(l33))
-
-                    return LogSoftMax(l41, 1);
+                return logsm.forward(l41);
             }
         }
 
+
         private static void Train(
-            Model model,
+            Sequential model,
             NN.Optimizer optimizer,
             Loss loss,
             IEnumerable<(TorchTensor, TorchTensor)> dataLoader,
@@ -93,6 +193,7 @@ namespace TorchSharp.Examples
 
             int batchId = 1;
 
+            Console.WriteLine($"Epoch: {epoch}...");
             foreach (var (data, target) in dataLoader)
             {
                 optimizer.zero_grad();
@@ -110,15 +211,12 @@ namespace TorchSharp.Examples
                     }
 
                     batchId++;
-
-                    data.Dispose();
-                    target.Dispose();
                 }
             }
         }
 
         private static void Test(
-            Model model,
+            Sequential model,
             Loss loss,
             IEnumerable<(TorchTensor, TorchTensor)> dataLoader,
             long size)
@@ -132,15 +230,12 @@ namespace TorchSharp.Examples
             {
                 using (var prediction = model.forward(data))
                 using (var output = loss(prediction, target))
-                {
+                    {
                     testLoss += output.ToSingle();
 
                     var pred = prediction.argmax(1);
+                    correct += pred.eq(target).sum().ToInt32();
 
-                    correct += pred.eq(target).sum().ToInt32(); // Memory leak here
-
-                    data.Dispose();
-                    target.Dispose();
                     pred.Dispose();
                 }
 

--- a/src/Examples/MNISTReader.cs
+++ b/src/Examples/MNISTReader.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using TorchSharp.Tensor;
+
+namespace TorchSharp.Examples
+{
+    /// <summary>
+    /// Data reader utility for datasets that follow the MNIST data set's layout:
+    ///
+    /// A number of single-channel (grayscale) images are laid out in a flat file with four 32-bit integers at the head.
+    /// The format is documented at the bottom of the page at: http://yann.lecun.com/exdb/mnist/
+    /// </summary>
+    class MNISTReader : IEnumerable<(TorchTensor, TorchTensor)>, IDisposable
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="path">Path to the folder containing the image files.</param>
+        /// <param name="prefix">The file name prefix, either 'train' or 't10k' (the latter being the test data set).</param>
+        /// <param name="batch_size">The batch size</param>
+        /// <param name="shuffle">Randomly shuffle the images.</param>
+        /// <param name="device">The device, i.e. CPU or GPU to place the output tensors on.</param>
+        public MNISTReader(string path, string prefix, int batch_size = 32, bool shuffle = false, Device device = null)
+        {
+            // The MNIST data set is small enough to fit in memory, so let's load it there.
+
+            var dataPath = Path.Combine(path, prefix + "-images-idx3-ubyte");
+            var labelPath = Path.Combine(path, prefix + "-labels-idx1-ubyte");
+
+            var count = -1;
+            var height = 0;
+            var width = 0;
+
+            byte[] dataBytes = null;
+            byte[] labelBytes = null;
+
+            using (var file = File.Open(dataPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var rdr = new System.IO.BinaryReader(file)) {
+
+                var reader = new Utils.BigEndianReader(rdr);
+                var x = reader.ReadInt32(); // Magic number
+                count = reader.ReadInt32();
+
+                height = reader.ReadInt32();
+                width = reader.ReadInt32();
+
+                // Read all the data into memory.
+                dataBytes = reader.ReadBytes(height * width * count);
+            }
+
+            using (var file = File.Open(labelPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var rdr = new System.IO.BinaryReader(file)) {
+
+                var reader = new Utils.BigEndianReader(rdr);
+                var x = reader.ReadInt32(); // Magic number
+                var lblcnt = reader.ReadInt32();
+
+                if (lblcnt != count) throw new InvalidDataException("Image data and label counts are different.");
+
+                // Read all the data into memory.
+                labelBytes = reader.ReadBytes(lblcnt);
+            }
+
+            // Set up the indices array.
+            Random rnd = new Random();
+            var indices = !shuffle ?
+                Enumerable.Range(0, count).ToArray() :
+                Enumerable.Range(0, count).OrderBy(c => rnd.Next()).ToArray();
+
+            var imgSize = height * width;
+
+            // Go through the data and create tensors
+            for (var i = 0; i < count;) {
+
+                var take = Math.Min(batch_size, Math.Max(0, count - i));
+
+                if (take < 1) break;
+
+                var dataTensor = Float32Tensor.zeros(new long[] { take, imgSize}, device);
+                var lablTensor = Int64Tensor.zeros(new long[] { take }, device);
+
+                // Take
+                for (var j = 0; j < take; j++) {
+                    var idx = indices[i++];
+                    var imgStart = idx * imgSize;
+
+                    var floats = dataBytes[imgStart.. (imgStart+imgSize)].Select(b => (float)b).ToArray();
+                    using (var inputTensor = Float32Tensor.from(floats))
+                        dataTensor.index_put_(new TorchTensorIndex [] { TorchTensorIndex.Single(j) }, inputTensor);
+                    lablTensor[j] = Int64Tensor.from(labelBytes[idx]);
+                }
+
+                data.Add(dataTensor.reshape(take, 1, height, width));
+                dataTensor.Dispose();
+                labels.Add(lablTensor);
+            }
+
+            Size = count;
+        }
+
+        public int Size { get; set; }
+
+        private List<TorchTensor> data = new List<TorchTensor>();
+        private List<TorchTensor> labels = new List<TorchTensor>();
+
+        public IEnumerator<(TorchTensor, TorchTensor)> GetEnumerator()
+        {
+            return new MNISTEnumerator(data, labels);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Dispose()
+        {
+            data.ForEach(d => d.Dispose());
+            labels.ForEach(d => d.Dispose());
+        }
+
+        private class MNISTEnumerator : IEnumerator<(TorchTensor, TorchTensor)>
+        {
+            public MNISTEnumerator(List<TorchTensor> data, List<TorchTensor> labels)
+            {
+                this.data = data;
+                this.labels = labels;
+            }
+
+            public (TorchTensor, TorchTensor) Current {
+                get {
+                    return (data[curIdx], labels[curIdx]);
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                curIdx += 1;
+                return curIdx < data.Count;
+            }
+
+            public void Reset()
+            {
+                curIdx = 0;
+            }
+
+            private int curIdx = 0;
+            private List<TorchTensor> data = null;
+            private List<TorchTensor> labels = null;
+        }
+    }
+}

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -1745,6 +1745,37 @@ Tensor THSNN_poisson_loss(const Tensor input, const Tensor target, const bool lo
     )
 }
 
+Tensor THSNN_kl_div_loss(const Tensor input, const Tensor target, const int64_t reduction, const bool log_target)
+{
+    CATCH_RETURN_Tensor(
+        auto opts = torch::nn::functional::KLDivFuncOptions().log_target(log_target);
+        ApplyReduction(opts, reduction);
+    
+        res = ResultTensor(torch::nn::functional::kl_div(*input, *target, opts));
+    )
+}
+
+Tensor THSNN_smooth_l1_loss(const Tensor input, const Tensor target, const int64_t reduction, const double beta)
+{
+    CATCH_RETURN_Tensor(
+        auto opts = torch::nn::functional::SmoothL1LossFuncOptions();
+        ApplyReduction(opts, reduction);
+
+        res = ResultTensor(torch::nn::functional::smooth_l1_loss(*input, *target, opts));
+    )
+}
+
+Tensor THSNN_soft_margin_loss(const Tensor input, const Tensor target, const int64_t reduction)
+{
+    CATCH_RETURN_Tensor(
+        auto opts = torch::nn::functional::SoftMarginLossFuncOptions();
+        ApplyReduction(opts, reduction);
+
+        res = ResultTensor(torch::nn::functional::soft_margin_loss(*input, *target, opts));
+    )
+}
+
+
 Optimizer THSNN_Adagrad_ctor(const Tensor* parameters, const int length, const double learning_rate, const double lr_decay, const double weight_decay, const double initial_accumulator_value, const double eps)
 {
     auto params = toTensors<at::Tensor>((torch::Tensor**)parameters, length);

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -262,6 +262,9 @@ EXPORT_API(Tensor) THSNN_l1_loss(const Tensor inputwrapper, const Tensor targetw
 EXPORT_API(Tensor) THSNN_mse_loss(const Tensor inputwrapper, const Tensor targetwrapper, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_nll_loss(const Tensor inputwrapper, const Tensor targetwrapper, const Tensor weightwrapper, const int64_t reduction);
 EXPORT_API(Tensor) THSNN_poisson_loss(const Tensor input, const Tensor target, const bool logInput, const bool full, const double eps, const int64_t reduction);
+EXPORT_API(Tensor) THSNN_kl_div_loss(const Tensor input, const Tensor target, const int64_t reduction, const bool log_target);
+EXPORT_API(Tensor) THSNN_smooth_l1_loss(const Tensor input, const Tensor target, const int64_t reduction, const double beta);
+EXPORT_API(Tensor) THSNN_soft_margin_loss(const Tensor input, const Tensor target, const int64_t reduction);
 
 // Optimizers
 

--- a/src/TorchSharp/NN/Activation/LogSoftMax.cs
+++ b/src/TorchSharp/NN/Activation/LogSoftMax.cs
@@ -8,18 +8,18 @@ namespace TorchSharp.NN
     /// <summary>
     /// This class is used to represent a log softmax module.
     /// </summary>
-    public class LogSoftMax : Module
+    public class LogSoftmax : Module
     {
-        internal LogSoftMax (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
+        internal LogSoftmax (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle)
         {
         }
 
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_LogSoftMax_forward (Module.HType handle, IntPtr tensor);
+        private static extern IntPtr THSNN_LogSoftmax_forward(Module.HType handle, IntPtr tensor);
 
         public TorchTensor forward (TorchTensor tensor)
         {
-            var res = THSNN_LogSoftMax_forward (handle, tensor.Handle);
+            var res = THSNN_LogSoftmax_forward (handle, tensor.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (res);
         }
@@ -27,21 +27,21 @@ namespace TorchSharp.NN
     public static partial class Modules
     {
         [DllImport ("LibTorchSharp")]
-        extern static IntPtr THSNN_LogSoftMax_ctor (long dimension, out IntPtr pBoxedModule);
+        extern static IntPtr THSNN_LogSoftmax_ctor (long dimension, out IntPtr pBoxedModule);
 
-        static public LogSoftMax LogSoftMax (long dimension)
+        static public LogSoftmax LogSoftmax (long dimension)
         {
-            var handle = THSNN_LogSoftMax_ctor (dimension, out var boxedHandle);
+            var handle = THSNN_LogSoftmax_ctor(dimension, out var boxedHandle);
             if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new LogSoftMax (handle, boxedHandle);
+            return new LogSoftmax (handle, boxedHandle);
         }
     }
 
     public static partial class Functions
     {
-        static public TorchTensor LogSoftMax (TorchTensor x, long dimension)
+        static public TorchTensor LogSoftmax (TorchTensor x, long dimension)
         {
-            using (var l = Modules.LogSoftMax (dimension)) {
+            using (var l = Modules.LogSoftmax (dimension)) {
                 return l.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Convolution/Conv1D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv1D.cs
@@ -80,7 +80,7 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public Conv1d Conv1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public Conv1d Conv1d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_Conv1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -103,9 +103,9 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public TorchTensor Conv1D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public TorchTensor Conv1d(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.Conv1D (inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
+            using (var d = Modules.Conv1d(inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Convolution/Conv2D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv2D.cs
@@ -71,7 +71,7 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
-        static public Conv2d Conv2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public Conv2d Conv2d (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_Conv2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -94,9 +94,9 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
-        static public TorchTensor Conv2D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public TorchTensor Conv2d (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.Conv2D (inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
+            using (var d = Modules.Conv2d (inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Convolution/Conv3D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv3D.cs
@@ -71,7 +71,7 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
-        static public Conv3d Conv3D(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public Conv3d Conv3d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -94,9 +94,9 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns></returns>
-        static public TorchTensor Conv3D(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public TorchTensor Conv3d(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.Conv3D(inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
+            using (var d = Modules.Conv3d(inputChannel, outputChannel, kernelSize, stride, padding, dilation, paddingMode, groups, bias)) {
                 return d.forward(x);
             }
         }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
@@ -73,7 +73,7 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public ConvTranspose1d ConvTranspose1D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public ConvTranspose1d ConvTranspose1d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_ConvTranspose1d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -97,9 +97,9 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public TorchTensor ConvTranspose1D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public TorchTensor ConvTranspose1d(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.ConvTranspose1D (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
+            using (var d = Modules.ConvTranspose1d(inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
@@ -73,7 +73,7 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public ConvTranspose2d ConvTranspose2D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public ConvTranspose2d ConvTranspose2d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_ConvTranspose2d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -97,9 +97,9 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public TorchTensor ConvTranspose2D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public TorchTensor ConvTranspose2d(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.ConvTranspose2D (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
+            using (var d = Modules.ConvTranspose2d(inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
@@ -73,7 +73,7 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public ConvTranspose3d ConvTranspose3D (long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public ConvTranspose3d ConvTranspose3d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
             var res = THSNN_ConvTranspose3d_ctor (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
@@ -97,9 +97,9 @@ namespace TorchSharp.NN
         /// <param name="groups">Number of blocked connections from input channels to output channels. Default: 1</param>
         /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
         /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-        static public TorchTensor ConvTranspose3D (TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
+        static public TorchTensor ConvTranspose3d(TorchTensor x, long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true)
         {
-            using (var d = Modules.ConvTranspose3D (inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
+            using (var d = Modules.ConvTranspose3d(inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, paddingMode, groups, bias)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -99,6 +99,43 @@ namespace TorchSharp.NN
                 return new TorchTensor (res);
             };
         }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_kl_div_loss(IntPtr input, IntPtr target, long reduction, bool logTarget);
+
+        public static Loss kl_div_loss(bool logTarget = true, Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => {
+                var res = THSNN_kl_div_loss(src.Handle, target.Handle, (long)reduction, logTarget);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            };
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_smooth_l1_loss(IntPtr srct, IntPtr trgt, long reduction, double beta);
+
+        public static Loss smooth_l1_loss(bool logInput = true, Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => {
+                // Currently, the 'beta' parameter is being ignored by the native layer, so we just pass the default.
+                var res = THSNN_smooth_l1_loss(src.Handle, target.Handle, (long)reduction, 1.0);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            };
+        }
+
+        [DllImport("LibTorchSharp")]
+        private static extern IntPtr THSNN_soft_margin_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+        public static Loss soft_margin_loss(Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => {
+                var res = THSNN_soft_margin_loss(src.Handle, target.Handle, (long)reduction);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            };
+        }
     }
     public enum Reduction : long
     {

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public BatchNorm1d BatchNorm1D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public BatchNorm1d BatchNorm1d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_BatchNorm1d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
@@ -65,9 +65,9 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public TorchTensor BatchNorm1D (TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public TorchTensor BatchNorm1d(TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
-            using (var d = Modules.BatchNorm1D (features, eps, momentum, affine, track_running_stats)) {
+            using (var d = Modules.BatchNorm1d(features, eps, momentum, affine, track_running_stats)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public BatchNorm2d BatchNorm2D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public BatchNorm2d BatchNorm2d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_BatchNorm2d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
@@ -66,9 +66,9 @@ namespace TorchSharp.NN
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
 
-        static public TorchTensor BatchNorm2D (TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public TorchTensor BatchNorm2d(TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
-            using (var d = Modules.BatchNorm2D (features, eps, momentum, affine, track_running_stats)) {
+            using (var d = Modules.BatchNorm2d(features, eps, momentum, affine, track_running_stats)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public BatchNorm3d BatchNorm3D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public BatchNorm3d BatchNorm3d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_BatchNorm3d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
@@ -65,9 +65,9 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public TorchTensor BatchNorm3D (TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public TorchTensor BatchNorm3d(TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
-            using (var d = Modules.BatchNorm3D (features, eps, momentum, affine, track_running_stats)) {
+            using (var d = Modules.BatchNorm3d(features, eps, momentum, affine, track_running_stats)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public InstanceNorm1d InstanceNorm1D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public InstanceNorm1d InstanceNorm1d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_InstanceNorm1d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
@@ -65,9 +65,9 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public TorchTensor InstanceNorm1D (TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public TorchTensor InstanceNorm1d(TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
-            using (var d = Modules.InstanceNorm1D (features, eps, momentum, affine, track_running_stats)) {
+            using (var d = Modules.InstanceNorm1d(features, eps, momentum, affine, track_running_stats)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public InstanceNorm2d InstanceNorm2D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public InstanceNorm2d InstanceNorm2d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_InstanceNorm2d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
@@ -66,9 +66,9 @@ namespace TorchSharp.NN
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
 
-        static public TorchTensor InstanceNorm2D (TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public TorchTensor InstanceNorm2d(TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
-            using (var d = Modules.InstanceNorm2D (features, eps, momentum, affine, track_running_stats)) {
+            using (var d = Modules.InstanceNorm2d(features, eps, momentum, affine, track_running_stats)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
@@ -41,7 +41,7 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public InstanceNorm3d InstanceNorm3D (long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public InstanceNorm3d InstanceNorm3d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
             unsafe {
                 var handle = THSNN_InstanceNorm3d_ctor (features, eps, momentum, affine, track_running_stats, out var boxedHandle);
@@ -65,9 +65,9 @@ namespace TorchSharp.NN
         /// this module does not track such statistics, and initializes statistics buffers running_mean and running_var as None.
         /// When these buffers are None, this module always uses batch statistics. in both training and eval modes. Default: true</param>
         /// <returns></returns>
-        static public TorchTensor InstanceNorm3D (TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
+        static public TorchTensor InstanceNorm3d(TorchTensor x, long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true)
         {
-            using (var d = Modules.InstanceNorm3D (features, eps, momentum, affine, track_running_stats)) {
+            using (var d = Modules.InstanceNorm3d(features, eps, momentum, affine, track_running_stats)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">the target output size H</param>
         /// <returns></returns>
-        static public AdaptiveAvgPool1d AdaptiveAvgPool1D (long[] outputSize)
+        static public AdaptiveAvgPool1d AdaptiveAvgPool1d(long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
@@ -49,9 +49,9 @@ namespace TorchSharp.NN
 
     public static partial class Functions
     {
-        static public TorchTensor AdaptiveAvgPool1D (TorchTensor x, long[] kernelSize)
+        static public TorchTensor AdaptiveAvgPool1d(TorchTensor x, long[] kernelSize)
         {
-            using (var d = Modules.AdaptiveAvgPool1D (kernelSize)) {
+            using (var d = Modules.AdaptiveAvgPool1d(kernelSize)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">The target output size (H,W) of the image of the form H x W.</param>
         /// <returns></returns>
-        static public AdaptiveAvgPool2d AdaptiveAvgPool2D (long[] outputSize)
+        static public AdaptiveAvgPool2d AdaptiveAvgPool2d (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
@@ -56,9 +56,9 @@ namespace TorchSharp.NN
         /// <param name="x">The input signal tensor.</param>
         /// <param name="outputSize">The target output size (H,W) of the image of the form H x W.</param>
         /// <returns></returns>
-        static public TorchTensor AdaptiveAvgPool2D (TorchTensor x, long[] outputSize)
+        static public TorchTensor AdaptiveAvgPool2d (TorchTensor x, long[] outputSize)
         {
-            using (var d = Modules.AdaptiveAvgPool2D (outputSize)) {
+            using (var d = Modules.AdaptiveAvgPool2d (outputSize)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">The target output size of the image of the form H x W.</param>
         /// <returns></returns>
-        static public AdaptiveAvgPool3d AdaptiveAvgPool3D(long[] outputSize)
+        static public AdaptiveAvgPool3d AdaptiveAvgPool3d(long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
@@ -56,9 +56,9 @@ namespace TorchSharp.NN
         /// <param name="x">The input signal tensor.</param>
         /// <param name="outputSize">The target output size of the image of the form H x W.</param>
         /// <returns></returns>
-        static public TorchTensor AdaptiveAvgPool3D(TorchTensor x, long[] outputSize)
+        static public TorchTensor AdaptiveAvgPool3d(TorchTensor x, long[] outputSize)
         {
-            using (var d = Modules.AdaptiveAvgPool3D(outputSize)) {
+            using (var d = Modules.AdaptiveAvgPool3d(outputSize)) {
                 return d.forward(x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="outputSize">The target output size H.</param>
         /// <returns></returns>
-        static public AdaptiveMaxPool1d AdaptiveMaxPool1D (long[] outputSize)
+        static public AdaptiveMaxPool1d AdaptiveMaxPool1d (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
@@ -56,9 +56,9 @@ namespace TorchSharp.NN
         /// <param name="x"></param>
         /// <param name="outputSize">The target output size H.</param>
         /// <returns></returns>
-        static public TorchTensor AdaptiveMaxPool1D (TorchTensor x, long[] outputSize)
+        static public TorchTensor AdaptiveMaxPool1d (TorchTensor x, long[] outputSize)
         {
-            using (var d = Modules.AdaptiveMaxPool1D (outputSize)) {
+            using (var d = Modules.AdaptiveMaxPool1d (outputSize)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
@@ -36,7 +36,7 @@ namespace TorchSharp.NN
         /// <param name="outputSize">Applies a 2D adaptive max pooling over an input signal composed of several input planes.
         /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.</param>
         /// <returns></returns>
-        static public AdaptiveMaxPool2d AdaptiveMaxPool2D (long[] outputSize)
+        static public AdaptiveMaxPool2d AdaptiveMaxPool2d (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
@@ -58,9 +58,9 @@ namespace TorchSharp.NN
         /// <param name="outputSize">Applies a 2D adaptive max pooling over an input signal composed of several input planes.
         /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.</param>
         /// <returns></returns>
-        static public TorchTensor AdaptiveMaxPool2D (TorchTensor x, long[] outputSize)
+        static public TorchTensor AdaptiveMaxPool2d (TorchTensor x, long[] outputSize)
         {
-            using (var d = Modules.AdaptiveMaxPool2D (outputSize)) {
+            using (var d = Modules.AdaptiveMaxPool2d (outputSize)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
@@ -36,7 +36,7 @@ namespace TorchSharp.NN
         /// <param name="outputSize">The target output size of the image of the form D x H x W.
         /// Can be a tuple (D, H, W) or a single D for a cube D x D x D. D, H and W can be either a int, or null which means the size will be the same as that of the input.</param>
         /// <returns></returns>
-        static public AdaptiveMaxPool3d AdaptiveMaxPool3D (long[] outputSize)
+        static public AdaptiveMaxPool3d AdaptiveMaxPool3d (long[] outputSize)
         {
             unsafe {
                 fixed (long* pkernelSize = outputSize) {
@@ -58,9 +58,9 @@ namespace TorchSharp.NN
         /// <param name="outputSize">The target output size of the image of the form D x H x W.
         /// Can be a tuple (D, H, W) or a single D for a cube D x D x D. D, H and W can be either a int, or null which means the size will be the same as that of the input.</param>
         /// <returns></returns>
-        static public TorchTensor AdaptiveMaxPool3D (TorchTensor x, long[] outputSize)
+        static public TorchTensor AdaptiveMaxPool3d (TorchTensor x, long[] outputSize)
         {
-            using (var d = Modules.AdaptiveMaxPool3D (outputSize)) {
+            using (var d = Modules.AdaptiveMaxPool3d (outputSize)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool1D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="stride">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public AvgPool1d AvgPool1D(long kernelSize, long? stride = null)
+        static public AvgPool1d AvgPool1d(long kernelSize, long? stride = null)
         {
             return stride.HasValue ?
                 AvgPool1D(new long[] { kernelSize }, new long[] { stride.Value }) :
@@ -63,9 +63,9 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="stride">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public TorchTensor AvgPool1D (TorchTensor x, long kernelSize, long? stride = null)
+        static public TorchTensor AvgPool1d (TorchTensor x, long kernelSize, long? stride = null)
         {
-            using (var d = Modules.AvgPool1D (kernelSize, stride)) {
+            using (var d = Modules.AvgPool1d (kernelSize, stride)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool2D.cs
@@ -36,7 +36,7 @@ namespace TorchSharp.NN
         /// <param name="strides">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
 
-        static public AvgPool2d AvgPool2D (long[] kernelSize, long[] strides = null)
+        static public AvgPool2d AvgPool2d (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
@@ -57,9 +57,9 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="strides">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public TorchTensor AvgPool2D (TorchTensor x, long[] kernelSize, long[] strides = null)
+        static public TorchTensor AvgPool2d (TorchTensor x, long[] kernelSize, long[] strides = null)
         {
-            using (var d = Modules.AvgPool2D (kernelSize, strides)) {
+            using (var d = Modules.AvgPool2d (kernelSize, strides)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/AvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool3D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="strides">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public AvgPool3d AvgPool3D (long[] kernelSize, long[] strides = null)
+        static public AvgPool3d AvgPool3d (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
@@ -56,9 +56,9 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the window</param>
         /// <param name="strides">The stride of the window. Default value is kernel_size</param>
         /// <returns></returns>
-        static public TorchTensor AvgPool3D (TorchTensor x, long[] kernelSize, long[] strides = null)
+        static public TorchTensor AvgPool3d (TorchTensor x, long[] kernelSize, long[] strides = null)
         {
-            using (var d = Modules.AvgPool3D (kernelSize, strides)) {
+            using (var d = Modules.AvgPool3d (kernelSize, strides)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/MaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool1D.cs
@@ -38,11 +38,11 @@ namespace TorchSharp.NN
         static public MaxPool1d MaxPool1D (long kernelSize, long? stride = null)
         {
             return stride.HasValue ?
-                MaxPool1D(new long[] { kernelSize }, new long[] { stride.Value }) :
-                MaxPool1D(new long[] { kernelSize }, null);
+                MaxPool1d(new long[] { kernelSize }, new long[] { stride.Value }) :
+                MaxPool1d(new long[] { kernelSize }, null);
         }
 
-        static private MaxPool1d MaxPool1D(long[] kernelSize, long[] strides = null)
+        static private MaxPool1d MaxPool1d(long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
@@ -64,7 +64,7 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the sliding window, must be > 0.</param>
         /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
-        static public TorchTensor MaxPool1D (TorchTensor x, long kernelSize, long? stride = null)
+        static public TorchTensor MaxPool1d (TorchTensor x, long kernelSize, long? stride = null)
         {
             using (var d = Modules.MaxPool1D (kernelSize, stride)) {
                 return d.forward (x);

--- a/src/TorchSharp/NN/Pooling/MaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool2D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the sliding window, must be > 0.</param>
         /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
-        static public MaxPool2d MaxPool2D (long[] kernelSize, long[] strides = null)
+        static public MaxPool2d MaxPool2d (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
@@ -57,9 +57,9 @@ namespace TorchSharp.NN
         /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
 
-        static public TorchTensor MaxPool2D (TorchTensor x, long[] kernelSize, long[] strides = null)
+        static public TorchTensor MaxPool2d (TorchTensor x, long[] kernelSize, long[] strides = null)
         {
-            using (var d = Modules.MaxPool2D (kernelSize, strides)) {
+            using (var d = Modules.MaxPool2d (kernelSize, strides)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/NN/Pooling/MaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool3D.cs
@@ -35,7 +35,7 @@ namespace TorchSharp.NN
         /// <param name="kernelSize">The size of the sliding window, must be > 0.</param>
         /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
-        static public MaxPool3d MaxPool3D (long[] kernelSize, long[] strides = null)
+        static public MaxPool3d MaxPool3d (long[] kernelSize, long[] strides = null)
         {
             unsafe {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides) {
@@ -57,9 +57,9 @@ namespace TorchSharp.NN
         /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
         /// <returns></returns>
 
-        static public TorchTensor MaxPool3D (TorchTensor x, long[] kernelSize, long[] strides = null)
+        static public TorchTensor MaxPool3d (TorchTensor x, long[] kernelSize, long[] strides = null)
         {
-            using (var d = Modules.MaxPool3D (kernelSize, strides)) {
+            using (var d = Modules.MaxPool3d (kernelSize, strides)) {
                 return d.forward (x);
             }
         }

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -25,11 +25,13 @@ namespace TorchSharp
 
         public static void SetSeed(long seed)
         {
+            TryInitializeDeviceType(DeviceType.CUDA);
             THSTorch_manual_seed(seed);
         }
 
         public static TorchGenerator ManualSeed(long seed)
         {
+            TryInitializeDeviceType(DeviceType.CUDA);
             return new TorchGenerator(THSGenerator_manual_seed(seed));
         }
 

--- a/src/TorchSharp/TorchGenerator.cs
+++ b/src/TorchSharp/TorchGenerator.cs
@@ -32,6 +32,7 @@ namespace TorchSharp
 
         public TorchGenerator ManualSeed(long seed)
         {
+            Torch.TryInitializeDeviceType(DeviceType.CUDA);
             THSGenerator_gen_manual_seed(Handle, seed);
             return this;
         }
@@ -39,6 +40,7 @@ namespace TorchSharp
         public long Seed()
         {
             long seed = DateTime.UtcNow.Ticks;
+            Torch.TryInitializeDeviceType(DeviceType.CUDA);
             THSGenerator_gen_manual_seed(Handle, seed);
             return seed;
         }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -710,11 +710,11 @@ namespace TorchSharp
 
         #region Convolution
         [Fact]
-        public void TestConv1D()
+        public void TestConv1d()
         {
             var shape = new long[] { 16, 3, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv1D(3, 64, 3);
+            var conv = Conv1d(3, 64, 3);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -722,9 +722,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv1DGetWeight()
+        public void TestConv1dGetWeight()
         {
-            var conv = Conv1D(3, 64, 3);
+            var conv = Conv1d(3, 64, 3);
             var weight = conv.Weight;
             var bias = conv.Bias;
             Assert.NotNull(weight);
@@ -733,9 +733,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv1DEditWeightAndBias()
+        public void TestConv1dEditWeightAndBias()
         {
-            var conv = Conv1D(3, 64, 3);
+            var conv = Conv1d(3, 64, 3);
 
             conv.Bias = Float32Tensor.randn(new long[] { 64 });
             var weights = Float32Tensor.randn(new long[] { 64, 3, 3 });
@@ -753,11 +753,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv1DStride()
+        public void TestConv1dStride()
         {
             var shape = new long[] { 16, 3, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv1D(3, 64, 3, stride: 2);
+            var conv = Conv1d(3, 64, 3, stride: 2);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -765,18 +765,18 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv1DPadding()
+        public void TestConv1dPadding()
         {
             var shape = new long[] { 16, 3, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
 
-            using (var conv = Conv1D(3, 64, 3, padding: 1))
+            using (var conv = Conv1d(3, 64, 3, padding: 1))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
                 Assert.Equal(28, output.shape[2]);
             }
-            using (var conv = Conv1D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
+            using (var conv = Conv1d(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
@@ -785,11 +785,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv2D()
+        public void TestConv2d()
         {
             var shape = new long[] { 16, 3, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv2D(3, 64, 3);
+            var conv = Conv2d(3, 64, 3);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -798,9 +798,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv2DGetWeight()
+        public void TestConv2dGetWeight()
         {
-            var conv = Conv2D(3, 64, 3);
+            var conv = Conv2d(3, 64, 3);
             var weight = conv.Weight;
             var bias = conv.Bias;
             Assert.NotNull(weight);
@@ -809,9 +809,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv2DEditWeightAndBias()
+        public void TestConv2dEditWeightAndBias()
         {
-            var conv = Conv2D(3, 64, 3);
+            var conv = Conv2d(3, 64, 3);
 
             conv.Bias = Float32Tensor.randn(new long[] { 64 });
             var weights = Float32Tensor.randn(new long[] { 64, 3, 3, 3 });
@@ -829,11 +829,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv2DStride()
+        public void TestConv2dStride()
         {
             var shape = new long[] { 16, 3, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv2D(3, 64, 3, stride: 2);
+            var conv = Conv2d(3, 64, 3, stride: 2);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -842,18 +842,18 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv2DPadding()
+        public void TestConv2dPadding()
         {
             var shape = new long[] { 16, 3, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            using (var conv = Conv2D(3, 64, 3, padding: 1))
+            using (var conv = Conv2d(3, 64, 3, padding: 1))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
                 Assert.Equal(28, output.shape[2]);
                 Assert.Equal(28, output.shape[3]);
             }
-            using (var conv = Conv2D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
+            using (var conv = Conv2d(3, 64, 3, padding: 1, paddingMode: PaddingModes.Reflect))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
@@ -863,11 +863,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv3D()
+        public void TestConv3d()
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv3D(3, 64, 3);
+            var conv = Conv3d(3, 64, 3);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -877,9 +877,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv3DGetWeight()
+        public void TestConv3dGetWeight()
         {
-            var conv = Conv3D(3, 64, 3);
+            var conv = Conv3d(3, 64, 3);
             var weight = conv.Weight;
             var bias = conv.Bias;
             Assert.NotNull(weight);
@@ -888,9 +888,9 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv3DEditWeightAndBias()
+        public void TestConv3dEditWeightAndBias()
         {
-            var conv = Conv3D(3, 64, 3);
+            var conv = Conv3d(3, 64, 3);
 
             conv.Bias = Float32Tensor.randn(new long[] { 64 });
             var weights = Float32Tensor.randn(new long[] { 64, 3, 3, 3 });
@@ -908,11 +908,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv3DStride()
+        public void TestConv3dStride()
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = Conv3D(3, 64, 3, stride: 2);
+            var conv = Conv3d(3, 64, 3, stride: 2);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -922,11 +922,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConv3DPadding()
+        public void TestConv3dPadding()
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            using (var conv = Conv3D(3, 64, 3, padding: 1))
+            using (var conv = Conv3d(3, 64, 3, padding: 1))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
@@ -934,7 +934,7 @@ namespace TorchSharp
                 Assert.Equal(28, output.shape[3]);
                 Assert.Equal(28, output.shape[4]);
             }
-            using (var conv = Conv3D(3, 64, 3, padding: 1, paddingMode: PaddingModes.Replicate))
+            using (var conv = Conv3d(3, 64, 3, padding: 1, paddingMode: PaddingModes.Replicate))
             using (var output = conv.forward(t)) {
                 Assert.Equal(16, output.shape[0]);
                 Assert.Equal(64, output.shape[1]);
@@ -945,11 +945,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConvTranspose1D()
+        public void TestConvTranspose1d()
         {
             var shape = new long[] { 16, 3, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = ConvTranspose1D(3, 64, 3);
+            var conv = ConvTranspose1d(3, 64, 3);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -957,11 +957,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConvTranspose2D()
+        public void TestConvTranspose2d()
         {
             var shape = new long[] { 16, 3, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = ConvTranspose2D(3, 64, 3);
+            var conv = ConvTranspose2d(3, 64, 3);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -970,11 +970,11 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestConvTranspose3D()
+        public void TestConvTranspose3d()
         {
             var shape = new long[] { 16, 3, 28, 28, 28 };
             TorchTensor t = Float32Tensor.rand(shape);
-            var conv = ConvTranspose3D(3, 64, 3);
+            var conv = ConvTranspose3d(3, 64, 3);
             var output = conv.forward(t);
             Assert.Equal(16, output.shape[0]);
             Assert.Equal(64, output.shape[1]);
@@ -1036,7 +1036,7 @@ namespace TorchSharp
         public void AvgPool2DObjectInitialized()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 2, 2, 2 });
-            var obj = AvgPool2D(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
+            var obj = AvgPool2d(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
         }
 
@@ -1100,7 +1100,7 @@ namespace TorchSharp
         public void MaxPool2DObjectInitialized()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 2, 2, 2 });
-            var obj = MaxPool2D(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
+            var obj = MaxPool2d(ones, new long[] { 2, 2 }, new long[] { 2, 2 });
             Assert.Equal(typeof(TorchTensor), obj.GetType());
         }
 
@@ -1134,7 +1134,7 @@ namespace TorchSharp
         public void TestMaxPool2D_1()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4 });
-            using (var pool = MaxPool2D(new long[] { 2, 2 })) {
+            using (var pool = MaxPool2d(new long[] { 2, 2 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 2, 2 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0].ToSingle());
@@ -1148,7 +1148,7 @@ namespace TorchSharp
         public void TestMaxPool2D_2()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4 });
-            using (var pool = MaxPool2D(new long[] { 2, 2 }, new long[] { 1, 1 })) {
+            using (var pool = MaxPool2d(new long[] { 2, 2 }, new long[] { 1, 1 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 3, 3 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0].ToSingle());
@@ -1167,7 +1167,7 @@ namespace TorchSharp
         public void TestMaxPool3D_1()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4, 8 });
-            using (var pool = MaxPool3D(new long[] { 2, 2, 2 })) {
+            using (var pool = MaxPool3d(new long[] { 2, 2, 2 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 2, 2, 4 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0, 0].ToSingle());
@@ -1181,7 +1181,7 @@ namespace TorchSharp
         public void TestMaxPool3D_2()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4, 8 });
-            using (var pool = MaxPool3D(new long[] { 2, 2, 2 }, new long[] { 1, 1, 1 })) {
+            using (var pool = MaxPool3d(new long[] { 2, 2, 2 }, new long[] { 1, 1, 1 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 3, 3, 7 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0, 0].ToSingle());
@@ -1200,7 +1200,7 @@ namespace TorchSharp
         public void TestAvgPool1D_1()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 3, 4 });
-            using (var pool = AvgPool1D(2)) {
+            using (var pool = AvgPool1d(2)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 3, 2 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0].ToSingle());
@@ -1212,7 +1212,7 @@ namespace TorchSharp
         public void TestAvgPool1D_2()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 3, 4 });
-            using (var pool = AvgPool1D(2, 1)) {
+            using (var pool = AvgPool1d(2, 1)) {
                 var pooled = pool.forward(ones);
 
                 Assert.Equal(new long[] { 16, 3, 3 }, pooled.shape);
@@ -1226,7 +1226,7 @@ namespace TorchSharp
         public void TestAvgPool2D_1()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4 });
-            using (var pool = AvgPool2D(new long[] { 2, 2 })) {
+            using (var pool = AvgPool2d(new long[] { 2, 2 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 2, 2 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0].ToSingle());
@@ -1240,7 +1240,7 @@ namespace TorchSharp
         public void TestAvgPool2D_2()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4 });
-            using (var pool = AvgPool2D(new long[] { 2, 2 }, new long[] { 1, 1 })) {
+            using (var pool = AvgPool2d(new long[] { 2, 2 }, new long[] { 1, 1 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 3, 3 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0].ToSingle());
@@ -1255,7 +1255,7 @@ namespace TorchSharp
             }
 
             ones = Float32Tensor.ones(new long[] { 16, 4, 4, 4 });
-            using (var pool = AvgPool2D(new long[] { 2, 2 }, new long[] { 1, 1 })) {
+            using (var pool = AvgPool2d(new long[] { 2, 2 }, new long[] { 1, 1 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 4, 3, 3 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0, 0].ToSingle());
@@ -1274,7 +1274,7 @@ namespace TorchSharp
         public void TestAvgPool3D_1()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4, 8 });
-            using (var pool = AvgPool3D(new long[] { 2, 2, 2 })) {
+            using (var pool = AvgPool3d(new long[] { 2, 2, 2 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 2, 2, 4 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0, 0].ToSingle());
@@ -1288,7 +1288,7 @@ namespace TorchSharp
         public void TestAvgPool3D_2()
         {
             TorchTensor ones = Float32Tensor.ones(new long[] { 16, 4, 4, 8 });
-            using (var pool = AvgPool3D(new long[] { 2, 2, 2 }, new long[] { 1, 1, 1 })) {
+            using (var pool = AvgPool3d(new long[] { 2, 2, 2 }, new long[] { 1, 1, 1 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 3, 3, 7 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0, 0].ToSingle());
@@ -1303,7 +1303,7 @@ namespace TorchSharp
             }
 
             ones = Float32Tensor.ones(new long[] { 16, 3, 4, 4, 8 });
-            using (var pool = AvgPool3D(new long[] { 2, 2, 2 }, new long[] { 1, 1, 1 })) {
+            using (var pool = AvgPool3d(new long[] { 2, 2, 2 }, new long[] { 1, 1, 1 })) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(new long[] { 16, 3, 3, 3, 7 }, pooled.shape);
                 Assert.Equal(1, pooled[0, 0, 0, 0, 0].ToSingle());
@@ -1324,7 +1324,7 @@ namespace TorchSharp
         public void TestBatchNorm1D()
         {
             var ones = Float32Tensor.ones(new long[] { 16, 3, 28 });
-            using (var pool = BatchNorm1D(3)) {
+            using (var pool = BatchNorm1d(3)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(ones.shape, pooled.shape);
                 Assert.Throws<ArgumentException>(() => pool.forward(Float32Tensor.ones(new long[] { 16 })));
@@ -1336,7 +1336,7 @@ namespace TorchSharp
         public void TestBatchNorm2D()
         {
             var ones = Float32Tensor.ones(new long[] { 16, 3, 28, 28 });
-            using (var pool = BatchNorm2D(3)) {
+            using (var pool = BatchNorm2d(3)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(ones.shape, pooled.shape);
                 Assert.Throws<ArgumentException>(() => pool.forward(Float32Tensor.ones(new long[] { 16, 2, 2 })));
@@ -1348,7 +1348,7 @@ namespace TorchSharp
         public void TestBatchNorm3D()
         {
             var ones = Float32Tensor.ones(new long[] { 16, 3, 12, 28, 28 });
-            using (var pool = BatchNorm3D(3)) {
+            using (var pool = BatchNorm3d(3)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(ones.shape, pooled.shape);
                 Assert.Throws<ArgumentException>(() => pool.forward(Float32Tensor.ones(new long[] { 16, 2, 2, 2 })));
@@ -1360,7 +1360,7 @@ namespace TorchSharp
         public void TestInstanceNorm1D()
         {
             var ones = Float32Tensor.ones(new long[] { 16, 3, 28 });
-            using (var pool = InstanceNorm1D(3)) {
+            using (var pool = InstanceNorm1d(3)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(ones.shape, pooled.shape);
                 Assert.Throws<ArgumentException>(() => pool.forward(Float32Tensor.ones(new long[] { 16 })));
@@ -1372,7 +1372,7 @@ namespace TorchSharp
         public void TestInstanceNorm2D()
         {
             var ones = Float32Tensor.ones(new long[] { 16, 3, 28, 28 });
-            using (var pool = InstanceNorm2D(3)) {
+            using (var pool = InstanceNorm2d(3)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(ones.shape, pooled.shape);
                 Assert.Throws<ArgumentException>(() => pool.forward(Float32Tensor.ones(new long[] { 16, 2, 2 })));
@@ -1384,7 +1384,7 @@ namespace TorchSharp
         public void TestInstanceNorm3D()
         {
             var ones = Float32Tensor.ones(new long[] { 16, 3, 12, 28, 28 });
-            using (var pool = InstanceNorm3D(3)) {
+            using (var pool = InstanceNorm3d(3)) {
                 var pooled = pool.forward(ones);
                 Assert.Equal(ones.shape, pooled.shape);
                 Assert.Throws<ArgumentException>(() => pool.forward(Float32Tensor.ones(new long[] { 16, 2, 2, 2 })));

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -485,6 +485,42 @@ namespace TorchSharp
                 Assert.Single(values);
             }
         }
+
+        [Fact]
+        public void TestKLDivLoss()
+        {
+            using (TorchTensor input = Float32Tensor.randn(new long[] { 3 }))
+            using (TorchTensor target = Float32Tensor.randn(new long[] { 3 })) {
+                var outTensor = kl_div_loss()(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestSmoothL1Loss()
+        {
+            using (TorchTensor input = Float32Tensor.randn(new long[] { 3 }))
+            using (TorchTensor target = Float32Tensor.randn(new long[] { 3 })) {
+                var outTensor = smooth_l1_loss()(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestSoftMarginLoss()
+        {
+            using (TorchTensor input = Float32Tensor.randn(new long[] { 3 }))
+            using (TorchTensor target = Float32Tensor.randn(new long[] { 3 })) {
+                var outTensor = soft_margin_loss()(input, target);
+                var values = outTensor.Data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
         #endregion
 
         #region Gradients

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -30,7 +30,7 @@ namespace TorchSharp
         public void TestSaveLoadConv2D()
         {
             if (File.Exists(".model.ts")) File.Delete(".model.ts");
-            var conv = Conv2D(100, 10, 5);
+            var conv = Conv2d(100, 10, 5);
             conv.Save(".model.ts");
             var loaded = NN.Conv2d.Load(".model.ts");
             File.Delete(".model.ts");

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -429,7 +429,7 @@ namespace TorchSharp
         [Fact]
         public void TestTrainingConv2d()
         {
-            var conv1 = Conv2D(3, 4, 3, stride: 2);
+            var conv1 = Conv2d(3, 4, 3, stride: 2);
             var lin1 = Linear(4 * 13 * 13, 32);
             var lin2 = Linear(32, 10);
 
@@ -474,7 +474,7 @@ namespace TorchSharp
             if (Torch.IsCudaAvailable()) {
                 var device = Device.CUDA;
 
-                using (Module conv1 = Conv2D(3, 4, 3, stride: 2),
+                using (Module conv1 = Conv2d(3, 4, 3, stride: 2),
                       lin1 = Linear(4 * 13 * 13, 32),
                       lin2 = Linear(32, 10))
 


### PR DESCRIPTION
Fixed up the MNIST and AlexNet examples, adding .NET-implemented dataset readers for MNIST (and Fashion MNIST) as well as CIFAR10.
Corrected an issue regarding the sequencing of SetSeed() and IsCudaAvailable() -- setting the seed first disabled CUDA use.
Added a couple of loss functions and unit tests.