### PR TITLE
Adding the linalg namespace, and most of its operations.

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -2779,22 +2779,26 @@ Tensor THSLinalg_matrix_rank(const Tensor tensor, const double tol, const bool h
 
 Tensor THSLinalg_norm_str(const Tensor tensor, const char* p, const int64_t* dim, const int dim_length, const bool keepdim)
 {
-    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+    c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, dims, keepdim, c10::nullopt));
 }
 
 Tensor THSLinalg_norm_float(const Tensor tensor, const double p, const int64_t* dim, const int dim_length, const bool keepdim)
 {
-    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+    c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, dims, keepdim, c10::nullopt));
 }
 
 Tensor THSLinalg_norm_int(const Tensor tensor, const int p, const int64_t* dim, const int dim_length, const bool keepdim)
 {
-    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+    c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, dims, keepdim, c10::nullopt));
 }
 
 Tensor THSLinalg_norm_opt(const Tensor tensor, const int64_t* dim, const int dim_length, const bool keepdim)
 {
-    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, c10::nullopt, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+    c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, c10::nullopt, dims, keepdim, c10::nullopt));
 }
 
 Tensor THSLinalg_pinv(const Tensor tensor, const double rcond, const bool hermitian)
@@ -2814,5 +2818,6 @@ Tensor THSLinalg_tensorinv(const Tensor tensor, const int64_t ind)
 
 Tensor THSLinalg_tensorsolve(const Tensor tensor, Tensor other, const int64_t* dim, const int dim_length)
 {
-    CATCH_TENSOR(torch::linalg::tensorsolve(*tensor, *other, at::ArrayRef<int64_t>(dim, dim_length)));
+    c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
+    CATCH_TENSOR(torch::linalg::tensorsolve(*tensor, *other, dims));
 }

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -2722,3 +2722,97 @@ Tensor THSTensor_zeros(
     CATCH_TENSOR(torch::zeros(at::ArrayRef<int64_t>(sizes, length), options));
 }
 
+
+// torch.lingalg:
+
+Tensor THSLinalg_cholesky(const Tensor tensor)
+{
+    CATCH_TENSOR(torch::linalg::cholesky(*tensor));
+}
+
+Tensor THSLinalg_det(const Tensor tensor)
+{
+    CATCH_TENSOR(torch::linalg::linalg_det(*tensor));
+}
+
+Tensor THSLinalg_slogdet(const Tensor tensor, Tensor* logabsdet)
+{
+    std::tuple<at::Tensor, at::Tensor> res;
+    CATCH(res = torch::linalg::slogdet(*tensor););
+    *logabsdet = ResultTensor(std::get<1>(res));
+    return ResultTensor(std::get<0>(res));
+}
+
+Tensor THSLinalg_eigh(const Tensor tensor, const char UPLO, Tensor* eigenvectors)
+{
+    std::string _uplo;
+    _uplo.push_back(UPLO);
+    std::tuple<at::Tensor, at::Tensor> res;
+    CATCH(res = torch::linalg::eigh(*tensor, _uplo););
+    *eigenvectors = ResultTensor(std::get<1>(res));
+    return ResultTensor(std::get<0>(res));
+}
+
+Tensor THSLinalg_eigvalsh(const Tensor tensor, const char UPLO)
+{
+    std::string _uplo;
+    _uplo.push_back(UPLO);
+    CATCH_TENSOR(torch::linalg::eigvalsh(*tensor, _uplo));
+}
+
+Tensor THSLinalg_inv(const Tensor tensor)
+{
+    CATCH_TENSOR(torch::linalg::inv(*tensor));
+}
+
+Tensor THSLinalg_matrix_rank(const Tensor tensor, const double tol, const bool has_tol, const bool hermitian)
+{
+    if (has_tol)
+    {
+        CATCH_TENSOR(torch::linalg::matrix_rank(*tensor, tol, hermitian));
+    }
+    else
+    {
+        CATCH_TENSOR(torch::linalg::matrix_rank(*tensor, c10::nullopt, hermitian));
+    }
+}
+
+Tensor THSLinalg_norm_str(const Tensor tensor, const char* p, const int64_t* dim, const int dim_length, const bool keepdim)
+{
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+}
+
+Tensor THSLinalg_norm_float(const Tensor tensor, const double p, const int64_t* dim, const int dim_length, const bool keepdim)
+{
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+}
+
+Tensor THSLinalg_norm_int(const Tensor tensor, const int p, const int64_t* dim, const int dim_length, const bool keepdim)
+{
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, p, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+}
+
+Tensor THSLinalg_norm_opt(const Tensor tensor, const int64_t* dim, const int dim_length, const bool keepdim)
+{
+    CATCH_TENSOR(torch::linalg::linalg_norm(*tensor, c10::nullopt, at::ArrayRef<int64_t>(dim, dim_length), keepdim, c10::nullopt));
+}
+
+Tensor THSLinalg_pinv(const Tensor tensor, const double rcond, const bool hermitian)
+{
+    CATCH_TENSOR(torch::linalg::pinv(*tensor, rcond, hermitian));
+}
+
+Tensor THSLinalg_solve(const Tensor tensor, Tensor other)
+{
+    CATCH_TENSOR(torch::linalg::solve(*tensor, *other));
+}
+
+Tensor THSLinalg_tensorinv(const Tensor tensor, const int64_t ind)
+{
+    CATCH_TENSOR(torch::linalg::tensorinv(*tensor, ind));
+}
+
+Tensor THSLinalg_tensorsolve(const Tensor tensor, Tensor other, const int64_t* dim, const int dim_length)
+{
+    CATCH_TENSOR(torch::linalg::tensorsolve(*tensor, *other, at::ArrayRef<int64_t>(dim, dim_length)));
+}

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -964,3 +964,32 @@ EXPORT_API(Tensor) THSTensor_view(const Tensor tensor, const int64_t* shape, con
 EXPORT_API(Tensor) THSTensor_zeros(const int64_t* sizes, const int length, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_zeros_out(const int64_t* sizes, const int length, const Tensor out);
+
+// torch.linalg:
+
+EXPORT_API(Tensor) THSLinalg_cholesky(const Tensor tensor);
+
+EXPORT_API(Tensor) THSLinalg_det(const Tensor tensor);
+
+EXPORT_API(Tensor) THSLinalg_slogdet(const Tensor tensor, Tensor *logabsdet);
+
+EXPORT_API(Tensor) THSLinalg_eigh(const Tensor tensor, const char UPLO, Tensor* eigenvectors);
+
+EXPORT_API(Tensor) THSLinalg_eigvalsh(const Tensor tensor, const char UPLO);
+
+EXPORT_API(Tensor) THSLinalg_inv(const Tensor tensor);
+
+EXPORT_API(Tensor) THSLinalg_matrix_rank(const Tensor tensor, const double tol, const bool has_tol, const bool hermitian);
+
+EXPORT_API(Tensor) THSLinalg_norm_str(const Tensor tensor, const char* p, const int64_t* dim, const int dim_length, const bool keepdim);
+EXPORT_API(Tensor) THSLinalg_norm_float(const Tensor tensor, const double p, const int64_t* dim, const int dim_length, const bool keepdim);
+EXPORT_API(Tensor) THSLinalg_norm_int(const Tensor tensor, const int p, const int64_t* dim, const int dim_length, const bool keepdim);
+EXPORT_API(Tensor) THSLinalg_norm_opt(const Tensor tensor, const int64_t* dim, const int dim_length, const bool keepdim);
+
+EXPORT_API(Tensor) THSLinalg_pinv(const Tensor tensor, const double rcond, const bool hermitian);
+
+EXPORT_API(Tensor) THSLinalg_solve(const Tensor tensor, Tensor other);
+
+EXPORT_API(Tensor) THSLinalg_tensorinv(const Tensor tensor, const int64_t ind);
+
+EXPORT_API(Tensor) THSLinalg_tensorsolve(const Tensor tensor, Tensor other, const int64_t* dim, const int dim_length);

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -60,7 +60,7 @@ namespace TorchSharp
         [DllImport("LibTorchSharp")]
         static extern IntPtr THSLinalg_eigvalsh(IntPtr tensor, byte UPLO);
 
-        public static TorchTensor eigvalsh(TorchTensor input, char UPLO)
+        public static TorchTensor eigvalsh(TorchTensor input, char UPLO = 'L')
         {
             var res = THSLinalg_eigvalsh(input.Handle, (byte)UPLO);
             if (res == IntPtr.Zero)

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -101,7 +101,7 @@ namespace TorchSharp
         static extern IntPtr THSLinalg_norm_opt(IntPtr tensor, IntPtr dim, int dim_length, bool keepdim);
 
 
-        public static TorchTensor norm(TorchTensor input, string ord, long[]? dims, bool keepdim)
+        public static TorchTensor norm(TorchTensor input, string ord, long[]? dims = null, bool keepdim = false)
         {
             unsafe {
                 fixed (long* pdims = dims) {
@@ -112,7 +112,7 @@ namespace TorchSharp
             }
         }
 
-        public static TorchTensor norm(TorchTensor input, double ord, long[]? dims, bool keepdim)
+        public static TorchTensor norm(TorchTensor input, double ord, long[]? dims = null, bool keepdim = false)
         {
             unsafe {
                 fixed (long* pdims = dims) {
@@ -123,7 +123,7 @@ namespace TorchSharp
             }
         }
 
-        public static TorchTensor norm(TorchTensor input, int ord, long[]? dims, bool keepdim)
+        public static TorchTensor norm(TorchTensor input, int ord, long[]? dims = null, bool keepdim = false)
         {
             unsafe {
                 fixed (long* pdims = dims) {
@@ -134,7 +134,7 @@ namespace TorchSharp
             }
         }
 
-        public static TorchTensor norm(TorchTensor input, long[]? dims, bool keepdim)
+        public static TorchTensor norm(TorchTensor input, long[]? dims = null, bool keepdim = false)
         {
             unsafe {
                 fixed (long* pdims = dims) {

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using TorchSharp.Tensor;
+
+#nullable enable
+namespace TorchSharp
+{
+    public static class linalg
+    {
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_cholesky(IntPtr tensor);
+
+        public static TorchTensor cholesky(TorchTensor input)
+        {
+            var res = THSLinalg_cholesky(input.Handle);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_det(IntPtr tensor);
+
+        public static TorchTensor det(TorchTensor input)
+        {
+            var res = THSLinalg_det(input.Handle);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_slogdet(IntPtr tensor, out IntPtr pLogabsdet);
+
+        public static (TorchTensor, TorchTensor) slogdet(TorchTensor input)
+        {
+            var res = THSLinalg_slogdet(input.Handle, out var logabsdet);
+            if (res == IntPtr.Zero || logabsdet == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return (new TorchTensor(res), new TorchTensor(logabsdet));
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_eigh(IntPtr tensor, byte UPLO, out IntPtr pEigenvectors);
+
+        public static (TorchTensor,TorchTensor) eigh(TorchTensor input, char UPLO)
+        {
+            var res = THSLinalg_eigh(input.Handle, (byte)UPLO, out var vectors);
+            if (res == IntPtr.Zero || vectors == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return (new TorchTensor(res), new TorchTensor(vectors));
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_eigvalsh(IntPtr tensor, byte UPLO);
+
+        public static TorchTensor eigvalsh(TorchTensor input, char UPLO)
+        {
+            var res = THSLinalg_eigvalsh(input.Handle, (byte)UPLO);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_inv(IntPtr tensor);
+
+        public static TorchTensor inv(TorchTensor input)
+        {
+            var res = THSLinalg_inv(input.Handle);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_matrix_rank(IntPtr tensor, double tol, bool has_tol, bool hermitian);
+
+        public static TorchTensor matrix_rank(TorchTensor input, double? tol = null, bool hermitian = false)
+        {
+            unsafe {
+                var res = THSLinalg_matrix_rank(input.Handle, tol ?? double.NegativeInfinity, tol.HasValue, hermitian);
+                if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                return new TorchTensor(res);
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_norm_str(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string p, IntPtr dim, int dim_length, bool keepdim);
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_norm_float(IntPtr tensor, double p, IntPtr dim, int dim_length, bool keepdim);
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_norm_int(IntPtr tensor, int p, IntPtr dim, int dim_length, bool keepdim);
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_norm_opt(IntPtr tensor, IntPtr dim, int dim_length, bool keepdim);
+
+
+        public static TorchTensor norm(TorchTensor input, string ord, long[]? dims, bool keepdim)
+        {
+            unsafe {
+                fixed (long* pdims = dims) {
+                    var res = THSLinalg_norm_str(input.Handle, ord, (IntPtr)pdims, dims is null ? 0 : dims.Length, keepdim);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        public static TorchTensor norm(TorchTensor input, double ord, long[]? dims, bool keepdim)
+        {
+            unsafe {
+                fixed (long* pdims = dims) {
+                    var res = THSLinalg_norm_float(input.Handle, ord, (IntPtr)pdims, dims is null ? 0 : dims.Length, keepdim);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        public static TorchTensor norm(TorchTensor input, int ord, long[]? dims, bool keepdim)
+        {
+            unsafe {
+                fixed (long* pdims = dims) {
+                    var res = THSLinalg_norm_int(input.Handle, ord, (IntPtr)pdims, dims is null ? 0 : dims.Length, keepdim);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        public static TorchTensor norm(TorchTensor input, long[]? dims, bool keepdim)
+        {
+            unsafe {
+                fixed (long* pdims = dims) {
+                    var res = THSLinalg_norm_opt(input.Handle, (IntPtr)pdims, dims is null ? 0 : dims.Length, keepdim);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_pinv(IntPtr tensor, double rcond, bool hermitian);
+
+        public static TorchTensor pinv(TorchTensor input, double rcond = 1e-15, bool hermitian = false)
+        {
+            var res = THSLinalg_pinv(input.Handle, rcond, hermitian);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_solve(IntPtr tensor, IntPtr other);
+
+        public static TorchTensor solve(TorchTensor input, TorchTensor other)
+        {
+            var res = THSLinalg_solve(input.Handle, other.handle);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_tensorinv(IntPtr tensor, long ind);
+
+        public static TorchTensor tensorinv(TorchTensor input, long ind)
+        {
+            var res = THSLinalg_tensorinv(input.Handle, ind);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSLinalg_tensorsolve(IntPtr tensor, IntPtr other, IntPtr dim, int dim_length);
+
+        public static TorchTensor tensorsolve(TorchTensor input, TorchTensor other, long[] dims)
+        {
+            unsafe {
+                fixed (long* pdims = dims) {
+                    var res = THSLinalg_tensorsolve(input.Handle, other.Handle, (IntPtr)pdims, dims.Length);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+    }
+}

--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -1847,11 +1847,11 @@ namespace TorchSharp.Tensor
         [DllImport("LibTorchSharp")]
         static extern IntPtr THSTensor_count_nonzero(IntPtr tensor, IntPtr dim, int dim_len);
 
-        public TorchTensor count_nonzero(long[]? dim = null)
+        public TorchTensor count_nonzero(long[]? dims = null)
         {
             unsafe {
-                fixed (long* pdims = dim) {
-                    var res = THSTensor_count_nonzero(handle, ((pdims == null) ? IntPtr.Zero : (IntPtr)pdims), dim is null ? 0 : dim.Length);
+                fixed (long* pdims = dims) {
+                    var res = THSTensor_count_nonzero(handle, (IntPtr)pdims, dims is null ? 0 : dims.Length);
                     if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor(res);
                 }

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -122,6 +122,6 @@ namespace TorchSharp
 
         // Because some of the tests mess with global state, and are run in parallel, we need to
         // acquire a lock before testing setting the default RNG see.
-        private object _lock = new object();
+        private static object _lock = new object();
     }
 }

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -73,18 +73,21 @@ namespace TorchSharp
         [Fact]
         public void TestExplicitGenerators()
         {
-            // This tests that the default generator can be disposed, but will keep on going,
-            long a, b, c;
-            using (var gen = Torch.ManualSeed(4711)) {
-                a = gen.InitialSeed;
+            // This tests that the default generator can be disposed, but will keep on going.
+            lock (_lock) {
+
+                long a, b, c;
+                using (var gen = Torch.ManualSeed(4711)) {
+                    a = gen.InitialSeed;
+                }
+                using (TorchGenerator gen = TorchGenerator.Default, genA = new TorchGenerator(4355)) {
+                    b = gen.InitialSeed;
+                    c = genA.InitialSeed;
+                }
+                Assert.Equal(a, b);
+                Assert.NotEqual(a, c);
+                Assert.Equal(4355, c);
             }
-            using (TorchGenerator gen = TorchGenerator.Default, genA = new TorchGenerator(4355)) {
-                b = gen.InitialSeed;
-                c = genA.InitialSeed;
-            }
-            Assert.Equal(a, b);
-            Assert.NotEqual(a, c);
-            Assert.Equal(4355, c);
         }
 
         [Fact]

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -2152,5 +2152,50 @@ namespace TorchSharp
                         }
             }
         }
+
+
+        [Fact]
+        public void CholeskyTest()
+        {
+            var a = Float64Tensor.randn(new long[] { 3, 2, 2 });
+            a = a.matmul(a.transpose(-2, -1));
+            var l = linalg.cholesky(a);
+
+            Assert.True(a.allclose(l.matmul(l.transpose(-2, -1))));
+        }
+
+        [Fact]
+        public void DeterminantTest()
+        {
+            {
+                var a = Float32Tensor.from(
+                    new float[] { 0.9478f, 0.9158f, -1.1295f,
+                                  0.9701f, 0.7346f, -1.8044f,
+                                 -0.2337f, 0.0557f, 0.6929f }).view(3,3);
+                var l = linalg.det(a);
+                Assert.True(l.allclose(Float32Tensor.from(0.09335048f)));
+            }
+            {
+                var a = Float32Tensor.from(
+                    new float[] { 0.9254f, -0.6213f, -0.5787f, 1.6843f, 0.3242f, -0.9665f,
+                                  0.4539f, -0.0887f, 1.1336f, -0.4025f, -0.7089f, 0.9032f }).view(3, 2, 2);
+                var l = linalg.det(a);
+                Assert.True(l.allclose(Float32Tensor.from(new float[] { 1.19910491f, 0.4099378f, 0.7385352f })));
+            }
+        }
+
+        [Fact]
+        public void EighvalshTest()
+        {
+            {
+                var a = Float32Tensor.from(
+                    new float[] {  2.8050f, -0.3850f, -0.3850f, 3.2376f, -1.0307f, -2.7457f,
+                                  -2.7457f, -1.7517f, 1.7166f,  2.2207f, 2.2207f, -2.0898f }).view(3, 2, 2);
+                var expected = Float32Tensor.from(
+                    new float[] { 2.5797f, 3.46290016f, -4.16046524f, 1.37806475f, -3.11126733f, 2.73806715f }).view(3, 2);
+                var l = linalg.eigvalsh(a);
+                Assert.True(l.allclose(expected));
+            }
+        }
     }
 }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -2197,5 +2197,35 @@ namespace TorchSharp
                 Assert.True(l.allclose(expected));
             }
         }
+
+        [Fact]
+        public void LinalgNormTest()
+        {
+            {
+                var a = Float32Tensor.from(
+                    new float[] { -4.0f, -3.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f });
+                var b = a.reshape(3, 3);
+
+                Assert.True(linalg.norm(a).allclose(Float32Tensor.from(7.7460f)));
+                Assert.True(linalg.norm(b).allclose(Float32Tensor.from(7.7460f)));
+                Assert.True(linalg.norm(b, "fro").allclose(Float32Tensor.from(7.7460f)));
+
+                Assert.True(linalg.norm(a, float.PositiveInfinity).allclose(Float32Tensor.from(4.0f)));
+                Assert.True(linalg.norm(b, float.PositiveInfinity).allclose(Float32Tensor.from(9.0f)));
+                Assert.True(linalg.norm(a, float.NegativeInfinity).allclose(Float32Tensor.from(0.0f)));
+                Assert.True(linalg.norm(b, float.NegativeInfinity).allclose(Float32Tensor.from(2.0f)));
+
+                Assert.True(linalg.norm(a, 1).allclose(Float32Tensor.from(20.0f)));
+                Assert.True(linalg.norm(b, 1).allclose(Float32Tensor.from(7.0f)));
+                Assert.True(linalg.norm(a, -1).allclose(Float32Tensor.from(0.0f)));
+                Assert.True(linalg.norm(b, -1).allclose(Float32Tensor.from(6.0f)));
+
+                Assert.True(linalg.norm(a, 2).allclose(Float32Tensor.from(7.7460f)));
+                Assert.True(linalg.norm(b, 2).allclose(Float32Tensor.from(7.3485f)));
+                Assert.True(linalg.norm(a, 3).allclose(Float32Tensor.from(5.8480f)));
+                Assert.True(linalg.norm(a, -2).allclose(Float32Tensor.from(0.0f)));
+                Assert.True(linalg.norm(a, -3).allclose(Float32Tensor.from(0.0f)));
+            }
+        }
     }
 }


### PR DESCRIPTION
This starts the implementation of the 'torch.linalg' namespace. Not all of the Python operations are available in the C++ library that we currently depend on, so only the ones that are have been implemented.