### PR TITLE
Added torch.nn.init namespace.

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -2926,3 +2926,97 @@ Tensor THSLinalg_tensorsolve(const Tensor tensor, Tensor other, const int64_t* d
     c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
     CATCH_TENSOR(torch::linalg::tensorsolve(*tensor, *other, dims));
 }
+
+torch::nn::init::NonlinearityType get_nl_type(const int64_t nl)
+{
+    switch (nl)
+    {
+    default:
+    case 0:  return torch::kLinear;
+    case 1:  return torch::kConv1D;
+    case 2:  return torch::kConv2D;
+    case 3:  return torch::kConv3D;
+    case 4:  return torch::kConvTranspose1D;
+    case 5:  return torch::kConvTranspose2D;
+    case 6:  return torch::kConvTranspose3D;
+    case 7:  return torch::kSigmoid;
+    case 8:  return torch::kTanh;
+    case 9:  return torch::kReLU;
+    case 10: return torch::kLeakyReLU;
+    }
+}
+
+double THSInit_calculate_gain(int64_t nonlinearity, double param)
+{
+    CATCH_RETURN(double, 0.0, torch::nn::init::calculate_gain(get_nl_type(nonlinearity), param))
+}
+
+torch::nn::init::FanModeType get_fan_mode(int64_t mode)
+{
+    return mode == 0 ? torch::nn::init::FanModeType(torch::kFanIn) : torch::nn::init::FanModeType(torch::kFanOut);
+}
+
+Tensor THSInit_constant_(Tensor tensor, Scalar value)
+{
+    CATCH_TENSOR(torch::nn::init::constant_(*tensor, *value))
+}
+
+Tensor THSInit_dirac_(Tensor tensor)
+{
+    CATCH_TENSOR(torch::nn::init::dirac_(*tensor))
+}
+
+Tensor THSInit_eye_(Tensor tensor)
+{
+    CATCH_TENSOR(torch::nn::init::eye_(*tensor))
+}
+
+Tensor THSInit_normal_(Tensor tensor, double mean, double std)
+{
+    CATCH_TENSOR(torch::nn::init::normal_(*tensor, mean, std))
+}
+
+Tensor THSInit_ones_(Tensor tensor)
+{
+    CATCH_TENSOR(torch::nn::init::ones_(*tensor))
+}
+
+Tensor THSInit_orthogonal_(Tensor tensor, double gain)
+{
+    CATCH_TENSOR(torch::nn::init::orthogonal_(*tensor, gain))
+}
+
+Tensor THSInit_sparse_(Tensor tensor, double sparsity, double std)
+{
+    CATCH_TENSOR(torch::nn::init::sparse_(*tensor, sparsity, std))
+}
+
+Tensor THSInit_uniform_(Tensor tensor, double low, double high)
+{
+    CATCH_TENSOR(torch::nn::init::uniform_(*tensor, low, high))
+}
+
+Tensor THSInit_kaiming_normal_(Tensor tensor, double a, const int64_t mode, const int64_t nonlinearity)
+{
+    CATCH_TENSOR(torch::nn::init::kaiming_normal_(*tensor, a, mode == 0 ? torch::nn::init::FanModeType(torch::kFanIn) : torch::nn::init::FanModeType(torch::kFanOut),  get_nl_type(nonlinearity)))
+}
+
+Tensor THSInit_kaiming_uniform_(Tensor tensor, double a, const int64_t mode, const int64_t nonlinearity)
+{
+    CATCH_TENSOR(torch::nn::init::kaiming_uniform_(*tensor, a, mode == 0 ? torch::nn::init::FanModeType(torch::kFanIn) : torch::nn::init::FanModeType(torch::kFanOut), get_nl_type(nonlinearity)))
+}
+
+Tensor THSInit_xavier_normal_(Tensor tensor, double gain)
+{
+    CATCH_TENSOR(torch::nn::init::xavier_normal_(*tensor, gain))
+}
+
+Tensor THSInit_xavier_uniform_(Tensor tensor, double gain)
+{
+    CATCH_TENSOR(torch::nn::init::xavier_uniform_(*tensor, gain))
+}
+
+Tensor THSInit_zeros_(Tensor tensor)
+{
+    CATCH_TENSOR(torch::nn::init::zeros_(*tensor))
+}

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1035,3 +1035,33 @@ EXPORT_API(Tensor) THSLinalg_solve(const Tensor tensor, Tensor other);
 EXPORT_API(Tensor) THSLinalg_tensorinv(const Tensor tensor, const int64_t ind);
 
 EXPORT_API(Tensor) THSLinalg_tensorsolve(const Tensor tensor, Tensor other, const int64_t* dim, const int dim_length);
+
+// torch.nn.init:
+
+EXPORT_API(double) THSInit_calculate_gain(int64_t nonlinearity, double param);
+
+EXPORT_API(Tensor) THSInit_constant_(Tensor tensor, Scalar value);
+
+EXPORT_API(Tensor) THSInit_dirac_(Tensor tensor);
+
+EXPORT_API(Tensor) THSInit_eye_(Tensor matrix);
+
+EXPORT_API(Tensor) THSInit_normal_(Tensor tensor, double mean, double std);
+
+EXPORT_API(Tensor) THSInit_ones_(Tensor tensor);
+
+EXPORT_API(Tensor) THSInit_orthogonal_(Tensor tensor, double gain);
+
+EXPORT_API(Tensor) THSInit_sparse_(Tensor tensor, double sparsity, double std);
+
+EXPORT_API(Tensor) THSInit_uniform_(Tensor tensor, double low, double high);
+
+EXPORT_API(Tensor) THSInit_kaiming_normal_(Tensor tensor, double a, const int64_t mode, const int64_t nonlinearity);
+
+EXPORT_API(Tensor) THSInit_kaiming_uniform_(Tensor tensor, double a, const int64_t mode, const int64_t nonlinearity);
+
+EXPORT_API(Tensor) THSInit_xavier_normal_(Tensor tensor, double gain);
+
+EXPORT_API(Tensor) THSInit_xavier_uniform_(Tensor tensor, double gain);
+
+EXPORT_API(Tensor) THSInit_zeros_(Tensor tensor);

--- a/src/TorchSharp/NN/Init.cs
+++ b/src/TorchSharp/NN/Init.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using TorchSharp.Tensor;
 
@@ -6,21 +6,176 @@ namespace TorchSharp.NN
 {
     public static class Init
     {
-        [DllImport("LibTorchSharp")]
-        private static extern void THSNN_initUniform(IntPtr src, double low, double high);
-
-        public static void Uniform(TorchTensor tensor, double low = 0, double high = 1)
+        public enum NonlinearityType
         {
-            THSNN_initUniform(tensor.Handle, low, high);
+            Linear = 0,
+            Conv1D = 1,
+            Conv2D = 2,
+            Conv3D = 3,
+            ConvTranspose1D = 4,
+            ConvTranspose2D = 5,
+            ConvTranspose3D = 6,
+            Sigmoid = 7,
+            Tanh = 8,
+            ReLU = 9,
+            LeakyReLU = 10
         }
 
-        [DllImport("LibTorchSharp")]
-        private static extern void THSNN_initKaimingUniform(IntPtr src, double a);
-
-        public static void KaimingUniform(TorchTensor tensor, double a = 0)
+        public enum FanInOut
         {
-            THSNN_initKaimingUniform(tensor.Handle, a);
+            FanIn = 0,
+            FanOut = 1
         }
+
+        /// <summary>
+        /// Return the recommended gain value for the given nonlinearity function.
+        /// </summary>
+        public static double calculate_gain(NonlinearityType nonlinearity, double param = 0.0)
+        {
+            return THSInit_calculate_gain((long)nonlinearity, param);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with the value 1
+        /// </summary>
+        public static TorchTensor ones(TorchTensor tensor)
+        {
+            var res = THSInit_ones_(tensor.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with the value 0
+        /// </summary>
+        public static TorchTensor zeros(TorchTensor tensor)
+        {
+            var res = THSInit_zeros_(tensor.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the {3, 4, 5}-dimensional input Tensor with the Dirac delta function.
+        /// Preserves the identity of the inputs in Convolutional layers, where as many input channels are preserved as possible.
+        /// </summary>
+        public static TorchTensor dirac(TorchTensor tensor)
+        {
+            var res = THSInit_dirac_(tensor.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the 2-dimensional input Tensor with the identity matrix.
+        /// Preserves the identity of the inputs in Linear layers, where as many inputs are preserved as possible.
+        /// </summary>
+        public static TorchTensor eye(TorchTensor tensor)
+        {
+            var res = THSInit_eye_(tensor.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with the value 'val'
+        /// </summary>
+        public static TorchTensor constant(TorchTensor tensor, TorchScalar val)
+        {
+            var res = THSInit_constant_(tensor.Handle, val.Handle);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values drawn from the uniform distribution
+        /// </summary>
+        public static TorchTensor uniform(TorchTensor tensor, double low = 0, double high = 1)
+        {
+            var res = THSInit_uniform_(tensor.Handle, low, high);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values drawn from the normal distribution
+        /// </summary>
+        public static TorchTensor normal(TorchTensor tensor, double mean = 0, double std = 1)
+        {
+            var res = THSInit_normal_(tensor.Handle, mean, std);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with a (semi) orthogonal matrix, as described in 'Exact solutions to the nonlinear dynamics of learning in deep linear neural networks'
+        /// </summary>
+        public static TorchTensor orthogonal(TorchTensor tensor, double gain = 1.0)
+        {
+            var res = THSInit_orthogonal_(tensor.Handle, gain);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the 2D input Tensor as a sparse matrix, where the non-zero elements will be drawn from the normal distribution N(0,std)
+        /// </summary>
+        public static TorchTensor sparse(TorchTensor tensor, double sparsity, double std = 0.01)
+        {
+            var res = THSInit_sparse_(tensor.Handle, sparsity, std);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values according to the method described in 'Delving deep into rectifiers: Surpassing human-level performance on ImageNet classification'
+        /// </summary>
+        public static TorchTensor kaiming_uniform(TorchTensor tensor, double a = 0, FanInOut mode = FanInOut.FanIn, NonlinearityType nonlinearity = NonlinearityType.LeakyReLU)
+        {
+            var res = THSInit_kaiming_uniform_(tensor.Handle, a, (long)mode, (long)nonlinearity);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values according to the method described in 'Delving deep into rectifiers: Surpassing human-level performance on ImageNet classification'
+        /// </summary>
+        public static TorchTensor kaiming_normal(TorchTensor tensor, double a = 0, FanInOut mode = FanInOut.FanIn, NonlinearityType nonlinearity = NonlinearityType.LeakyReLU)
+        {
+            var res = THSInit_kaiming_normal_(tensor.Handle, a, (long)mode, (long)nonlinearity);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values according to the method described in 'Understanding the difficulty of training deep feedforward neural networks'
+        /// </summary>
+        public static TorchTensor xavier_uniform(TorchTensor tensor, double gain = 1.0)
+        {
+            var res = THSInit_xavier_uniform_(tensor.Handle, gain);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values according to the method described in 'Understanding the difficulty of training deep feedforward neural networks'
+        /// </summary>
+        public static TorchTensor glorot_uniform(TorchTensor tensor, double gain = 1.0) => xavier_uniform(tensor, gain);
+
+        /// <summary>
+        /// Fills the input Tensor with values according to the method described in 'Understanding the difficulty of training deep feedforward neural networks'
+        /// </summary>
+        public static TorchTensor xavier_normal(TorchTensor tensor, double gain = 1.0)
+        {
+            var res = THSInit_xavier_uniform_(tensor.Handle, gain);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        /// <summary>
+        /// Fills the input Tensor with values according to the method described in 'Understanding the difficulty of training deep feedforward neural networks'
+        /// </summary>
+        public static TorchTensor glorot_normal(TorchTensor tensor, double gain = 1.0) => glorot_normal(tensor, gain);
 
         public static (long fanIn, long fanOut) CalculateFanInAndFanOut<T>(TorchTensor tensor)
         {
@@ -46,5 +201,22 @@ namespace TorchSharp.NN
                 return (numInputFMaps * receptiveFieldSize, numOutputFMaps * receptiveFieldSize);
             }
         }
+
+        [DllImport("LibTorchSharp")] private static extern double THSInit_calculate_gain(long nonlinearity, double param);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_constant_(IntPtr tensor, IntPtr value);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_dirac_(IntPtr tensor);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_eye_(IntPtr matrix);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_normal_(IntPtr tensor, double mean, double std);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_ones_(IntPtr tensor);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_orthogonal_(IntPtr tensor, double gain);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_sparse_(IntPtr tensor, double sparsity, double std);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_uniform_(IntPtr tensor, double low, double high);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_kaiming_normal_(IntPtr tensor, double a, long mode, long nonlinearity);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_kaiming_uniform_(IntPtr tensor, double a, long mode, long nonlinearity);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_xavier_normal_(IntPtr tensor, double gain);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_xavier_uniform_(IntPtr tensor, double gain);
+        [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_zeros_(IntPtr tensor);
+
+
     }
 }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -489,10 +489,144 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestCalculateGain()
+        {
+            Assert.Equal(1, NN.Init.calculate_gain(NN.Init.NonlinearityType.Linear));
+            Assert.Equal(1, NN.Init.calculate_gain(NN.Init.NonlinearityType.Conv1D));
+            Assert.Equal(1, NN.Init.calculate_gain(NN.Init.NonlinearityType.Conv2D));
+            Assert.Equal(1, NN.Init.calculate_gain(NN.Init.NonlinearityType.Conv3D));
+            Assert.Equal(1, NN.Init.calculate_gain(NN.Init.NonlinearityType.Sigmoid));
+            Assert.Equal(5.0/3.0, NN.Init.calculate_gain(NN.Init.NonlinearityType.Tanh));
+            Assert.Equal(Math.Sqrt(2.0), NN.Init.calculate_gain(NN.Init.NonlinearityType.ReLU));
+        }
+
+        [Fact]
+        public void InitZeros()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.zeros(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitOnes()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.ones(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitDirac()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.dirac(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitEye()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.eye(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitConstant()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.constant(tensor, Math.PI)) { }
+            }
+        }
+
+        [Fact]
         public void InitUniform()
         {
             using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
-                NN.Init.Uniform(tensor);
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.uniform(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitNormal()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.normal(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitOrthogonal()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.orthogonal(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitSparse()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.sparse(tensor, 0.25)) { }
+            }
+        }
+
+        [Fact]
+        public void InitKaimingUniform()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.kaiming_uniform(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitKaimingNormal()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.kaiming_normal(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitXavierUniform()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.xavier_uniform(tensor)) { }
+            }
+        }
+
+        [Fact]
+        public void InitXavierNormal()
+        {
+            using (TorchTensor tensor = Float32Tensor.zeros(new long[] { 2, 2 })) {
+                // Really just testing that the native interop works and that the fact
+                // that there are two handles to the tensor is okay.
+                using (var res = NN.Init.xavier_normal(tensor)) { }
             }
         }
 


### PR DESCRIPTION
The torch.nn.init namespace was only partially implemented. This PR brings it up to date with the PyTorch 1.8.0 release.