### PR TITLE
Examples: Seq-to-Seq using a Transformer.

### DIFF
--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -36,10 +36,10 @@ namespace TorchSharp.Examples
         private const long nhead = 2;
         private const double dropout = 0.2;
 
-        private const int batch_size = 32;
+        private const int batch_size = 64;
         private const int eval_batch_size = 32;
 
-        private const int epochs = 25;
+        private const int epochs = 50;
 
         static void Main(string[] args)
 
@@ -75,7 +75,7 @@ namespace TorchSharp.Examples
 
             var model = new TransformerModel(ntokens, emsize, nhead, nhid, nlayers, dropout).to(device);
             var loss = cross_entropy_loss();
-            var lr = 5.0;
+            var lr = 2.50;
             var optimizer = NN.Optimizer.SGD(model.parameters(), lr);
             var scheduler = NN.Optimizer.StepLR(optimizer, 1, 0.95, last_epoch: 15);
 

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -125,17 +125,15 @@ namespace TorchSharp.Examples
                     src_mask = model.GenerateSquareSubsequentMask(data.shape[0]);
                 }
 
-                using (var output = model.forward(data, src_mask))
-                using (var loss = criterion(output.view(-1, ntokens), targets)) {
+                var output = model.forward(data, src_mask);
+                var loss = criterion(output.view(-1, ntokens), targets);
+                {
                     loss.backward();
                     model.parameters().clip_grad_norm(0.5);
                     optimizer.step();
 
                     total_loss += loss.to(Device.CPU).DataItem<float>();
                 }
-
-                data.Dispose();
-                targets.Dispose();
 
                 GC.Collect();
 
@@ -162,10 +160,9 @@ namespace TorchSharp.Examples
                     src_mask.Dispose();
                     src_mask = model.GenerateSquareSubsequentMask(data.shape[0]);
                 }
-                using (var output = model.forward(data, src_mask))
-                using (var loss = criterion(output.view(-1, ntokens), targets)) {
-                    total_loss += data.shape[0] * loss.to(Device.CPU).DataItem<float>();
-                }
+                var output = model.forward(data, src_mask);
+                var loss = criterion(output.view(-1, ntokens), targets); 
+                total_loss += data.shape[0] * loss.to(Device.CPU).DataItem<float>();
 
                 data.Dispose();
                 targets.Dispose();
@@ -192,9 +189,8 @@ namespace TorchSharp.Examples
         static TorchTensor Batchify(TorchTensor data, int batch_size)
         {
             var nbatch = data.shape[0] / batch_size;
-            using (var d1 = data.narrow(0, 0, nbatch * batch_size))
-            using (var d2 = d1.view(batch_size, -1).t())
-                return d2.contiguous();
+            var d2 = data.narrow(0, 0, nbatch * batch_size).view(batch_size, -1).t();
+            return d2.contiguous();
         }
 
         static (TorchTensor, TorchTensor) GetBatch(TorchTensor source, int index, int bptt)
@@ -255,10 +251,9 @@ namespace TorchSharp.Examples
 
             public TorchTensor forward(TorchTensor t, TorchTensor mask)
             {
-                using(var fwd = encoder.forward(t))
-                using (var src = pos_encoder.forward(fwd * MathF.Sqrt(ninputs)))
-                using(var enc = transformer_encoder.forward(src, mask))
-                    return decoder.forward(enc);
+                var src = pos_encoder.forward(encoder.forward(t) * MathF.Sqrt(ninputs));
+                var enc = transformer_encoder.forward(src, mask);
+                return decoder.forward(enc);
             }
 
             public new TransformerModel to(Device device)
@@ -290,8 +285,8 @@ namespace TorchSharp.Examples
 
             public override TorchTensor forward(TorchTensor t)
             {
-                using (var x = t + pe[TorchTensorIndex.Slice(null, t.shape[0]), TorchTensorIndex.Slice()])
-                    return dropout.forward(x);
+                var x = t + pe[TorchTensorIndex.Slice(null, t.shape[0]), TorchTensorIndex.Slice()];
+                return dropout.forward(x);
             }
         }
     }

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -241,6 +241,12 @@ EXPORT_API(Tensor)   THSNN_Embedding_forward(const NNModule module, const Tensor
 EXPORT_API(Tensor)   THSNN_Embedding_weight(const NNModule module);
 EXPORT_API(void)     THSNN_Embedding_set_weight(const NNModule module, const Tensor weights);
 
+EXPORT_API(NNModule) THSNN_EmbeddingBag_ctor(const int64_t num_embeddings, const int64_t embedding_dims, const double max_norm, const bool has_mn, const double norm_type, const bool scale_grad_by_freq, const int64_t mode, const bool sparse, const bool include_last_offset, NNAnyModule* outAsAnyModule);
+EXPORT_API(NNModule) THSNN_EmbeddingBag_from_pretrained(const Tensor embeddings, const bool freeze, const double max_norm, const bool has_mn, const double norm_type, const bool scale_grad_by_freq, const int64_t mode, const bool sparse, const bool include_last_offset, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor)   THSNN_EmbeddingBag_forward(const NNModule module, const Tensor input, const Tensor offsets, const Tensor per_sample_weights);
+EXPORT_API(Tensor)   THSNN_EmbeddingBag_weight(const NNModule module);
+EXPORT_API(void)     THSNN_EmbeddingBag_set_weight(const NNModule module, const Tensor weights);
+
 // Transformer
 
 EXPORT_API(NNModule) THSNN_Transformer_ctor(const int64_t d_model, const int64_t nhead, const int64_t num_encoder_layers, const int64_t num_decoder_layers, const int64_t dim_feedforward, const double dropout, const int64_t activation, NNAnyModule* outAsAnyModule);

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -26,7 +26,7 @@ namespace TorchSharp.NN
             if (input.Dimensions == 1 && offsets is null) throw new ArgumentException("'offsets' must be non-null for a 1-D input.");
             if (input.Dimensions == 2 && !(offsets is null)) throw new ArgumentException("'offsets' must be null for a 2-D input.");
 
-            if (input.Type == ScalarType.Int32) throw new NotImplementedException("EmbeddingBag for 32-bit integers -- there's some issue in the native runtime that prevents this from working.");
+            if (input.Dimensions == 2 && input.Type == ScalarType.Int32) throw new NotImplementedException("EmbeddingBag for 32-bit integers -- there's some issue in the native runtime that prevents this from working.");
 
             var res = THSNN_EmbeddingBag_forward(handle, input.Handle, (offsets is null) ? IntPtr.Zero : offsets.Handle, (perSampleWeights is null) ? IntPtr.Zero : perSampleWeights.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -5,62 +5,76 @@ using TorchSharp.Tensor;
 
 namespace TorchSharp.NN
 {
-    public class Embedding : Module
+    public enum EmbeddingBagMode
     {
-        internal Embedding (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
+        Sum = 0,
+        Mean = 1,
+        Max = 2
+    }
+
+    public class EmbeddingBag : Module
+    {
+        internal EmbeddingBag (IntPtr handle, IntPtr boxedHandle) : base (handle, boxedHandle) { }
 
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_Embedding_forward (Module.HType module, IntPtr tensor);
+        private static extern IntPtr THSNN_EmbeddingBag_forward (Module.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
 
-        public TorchTensor forward (TorchTensor input)
+        public TorchTensor forward (TorchTensor input, TorchTensor offsets = null, TorchTensor perSampleWeights = null)
         {
-            var res = THSNN_Embedding_forward(handle, input.Handle);
+            if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
+            if (!(offsets is null) && input.Type != offsets.Type) throw new ArgumentException("input and offsets must have the same element type.");
+            if (input.Dimensions == 1 && offsets is null) throw new ArgumentException("'offsets' must be non-null for a 1-D input.");
+            if (input.Dimensions == 2 && !(offsets is null)) throw new ArgumentException("'offsets' must be null for a 2-D input.");
+
+            if (input.Type == ScalarType.Int32) throw new NotImplementedException("EmbeddingBag for 32-bit integers -- there's some issue in the native runtime that prevents this from working.");
+
+            var res = THSNN_EmbeddingBag_forward(handle, input.Handle, (offsets is null) ? IntPtr.Zero : offsets.Handle, (perSampleWeights is null) ? IntPtr.Zero : perSampleWeights.Handle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
             return new TorchTensor (res);
         }
 
         [DllImport("LibTorchSharp")]
-        extern static IntPtr THSNN_Embedding_weight(Module.HType module);
+        extern static IntPtr THSNN_EmbeddingBag_weight(Module.HType module);
 
         [DllImport("LibTorchSharp")]
-        extern static void THSNN_Embedding_set_weight(Module.HType module, IntPtr tensor);
+        extern static void THSNN_EmbeddingBag_set_weight(Module.HType module, IntPtr tensor);
 
         public TorchTensor Weight {
             get {
-                var res = THSNN_Embedding_weight(handle);
+                var res = THSNN_EmbeddingBag_weight(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 return new TorchTensor(res);
             }
             set {
-                THSNN_Embedding_set_weight(handle, value.Handle);
+                THSNN_EmbeddingBag_set_weight(handle, value.Handle);
                 Torch.CheckForErrors();
             }
         }
 
         [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSNN_Embedding_from_pretrained(IntPtr embeddings, bool freeze, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
+        private static extern IntPtr THSNN_EmbeddingBag_from_pretrained(IntPtr embeddings, bool freeze, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, long mode, bool sparse, bool include_last_offset, out IntPtr pBoxedModule);
 
         /// <summary>
         /// A simple lookup table that stores embeddings of a fixed dictionary and size.
         /// This module is often used to store word embeddings and retrieve them using indices. The input to the module is a list of indices, and the output is the corresponding word embeddings.
         /// </summary>
-        /// <param name="embeddings">FloatTensor containing weights for the Embedding in two dimensions. First dimension is being passed to Embedding as num_embeddings, second as embedding_dim.</param>
+        /// <param name="embeddings">FloatTensor containing weights for the EmbeddingBag in two dimensions. First dimension is being passed to EmbeddingBag as num_embeddings, second as embedding_dim.</param>
         /// <param name="freeze">If true (the default), the tensor does not get updated in the learning</param>
-        /// <param name="padding_idx">If given, pads the output with the embedding vector at padding_idx (initialized to zeros) whenever it encounters the index.</param>
         /// <param name="max_norm">If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm.</param>
         /// <param name="norm_type">The p of the p-norm to compute for the max_norm option. Default 2.</param>
         /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
+        /// <param name="mode"></param>
         /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
+        /// <param name="include_last_offset"></param>
         /// <returns></returns>
         /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
-        public static Embedding from_pretrained(TorchTensor embeddings, bool freeze = true, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
+        public static EmbeddingBag from_pretrained(TorchTensor embeddings, bool freeze = true, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, EmbeddingBagMode mode = EmbeddingBagMode.Mean, bool sparse = false, bool include_last_offset = false)
         {
-            var res = THSNN_Embedding_from_pretrained(embeddings.Handle, freeze,
-                padding_idx.HasValue ? padding_idx.Value : -1, padding_idx.HasValue,
+            var res = THSNN_EmbeddingBag_from_pretrained(embeddings.Handle, freeze,
                 max_norm.HasValue ? max_norm.Value : 0.0, max_norm.HasValue,
-                norm_type, scale_grad_by_freq, sparse, out var boxedHandle);
+                norm_type, scale_grad_by_freq, (long)mode, sparse, include_last_offset, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Embedding(res, boxedHandle);
+            return new EmbeddingBag(res, boxedHandle);
 
         }
 
@@ -68,7 +82,7 @@ namespace TorchSharp.NN
     public static partial class Modules
     {
         [DllImport ("LibTorchSharp")]
-        private static extern IntPtr THSNN_Embedding_ctor (long num_embeddings, long embedding_dims, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
+        private static extern IntPtr THSNN_EmbeddingBag_ctor (long num_embeddings, long embedding_dims, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, long mode, bool sparse, bool include_last_offset, out IntPtr pBoxedModule);
 
         /// <summary>
         /// A simple lookup table that stores embeddings of a fixed dictionary and size.
@@ -76,21 +90,23 @@ namespace TorchSharp.NN
         /// </summary>
         /// <param name="num_embeddings">Size of the dictionary of embeddings, the vocabulary size.</param>
         /// <param name="embedding_dims">The size of each embedding vector</param>
-        /// <param name="padding_idx">If given, pads the output with the embedding vector at padding_idx (initialized to zeros) whenever it encounters the index.</param>
         /// <param name="max_norm">If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm.</param>
         /// <param name="norm_type">The p of the p-norm to compute for the max_norm option. Default 2.</param>
         /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
+        /// <param name="mode">"sum", "mean" or "max". Specifies the way to reduce the bag.
+        /// "sum" computes the weighted sum, taking per_sample_weights into consideration.
+        /// "mean" computes the average of the values in the bag, "max" computes the max value over each bag. Default: "mean"</param>
         /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
+        /// <param name="include_last_offset">if true, offsets has one additional element, where the last element is equivalent to the size of indices.</param>
         /// <returns></returns>
         /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
-        static public Embedding Embedding (long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
+        static public EmbeddingBag EmbeddingBag (long num_embeddings, long embedding_dims, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, EmbeddingBagMode mode = EmbeddingBagMode.Mean, bool sparse = false, bool include_last_offset = false)
         {
-            var res = THSNN_Embedding_ctor (num_embeddings, embedding_dims,
-                padding_idx.HasValue ? padding_idx.Value : -1, padding_idx.HasValue,
+            var res = THSNN_EmbeddingBag_ctor (num_embeddings, embedding_dims,
                 max_norm.HasValue ? max_norm.Value : 0.0, max_norm.HasValue,
-                norm_type, scale_grad_by_freq, sparse, out var boxedHandle);
+                norm_type, scale_grad_by_freq, (long)mode, sparse, include_last_offset, out var boxedHandle);
             if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new Embedding (res, boxedHandle);
+            return new EmbeddingBag (res, boxedHandle);
         }
     }
     public static partial class Functions
@@ -102,16 +118,19 @@ namespace TorchSharp.NN
         /// <param name="x">An input tensor of arbitrary shape.</param>
         /// <param name="num_embeddings">Size of the dictionary of embeddings, the vocabulary size.</param>
         /// <param name="embedding_dims">The size of each embedding vector</param>
-        /// <param name="padding_idx">If given, pads the output with the embedding vector at padding_idx (initialized to zeros) whenever it encounters the index.</param>
         /// <param name="max_norm">If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm.</param>
         /// <param name="norm_type">The p of the p-norm to compute for the max_norm option. Default 2.</param>
         /// <param name="scale_grad_by_freq">If given, this will scale gradients by the inverse of frequency of the words in the mini-batch. Default: false.</param>
+        /// <param name="mode">"sum", "mean" or "max". Specifies the way to reduce the bag.
+        /// "sum" computes the weighted sum, taking per_sample_weights into consideration.
+        /// "mean" computes the average of the values in the bag, "max" computes the max value over each bag. Default: "mean"</param>
         /// <param name="sparse">If true, gradient w.r.t. weight matrix will be a sparse tensor. Default: false</param>
+        /// <param name="include_last_offset">if true, offsets has one additional element, where the last element is equivalent to the size of indices.</param>
         /// <returns></returns>
         /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
-        static public TorchTensor Embedding (TorchTensor x, long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false)
+        static public TorchTensor EmbeddingBag (TorchTensor x, long num_embeddings, long embedding_dims, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, EmbeddingBagMode mode = EmbeddingBagMode.Mean, bool sparse = false, bool include_last_offset = false)
         {
-            using (var d = Modules.Embedding(num_embeddings, embedding_dims, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse)) {
+            using (var d = Modules.EmbeddingBag(num_embeddings, embedding_dims, max_norm, norm_type, scale_grad_by_freq, mode, sparse, include_last_offset)) {
                 return d.forward (x);
             }
         }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1524,6 +1524,53 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestEmbeddingBagDefaults()
+        {
+            var ones = Int64Tensor.ones(new long[] { 16, 12 });
+            using (var emb = EmbeddingBag(1000, 12)) {
+                var output = emb.forward(ones);
+                Assert.Equal(new long[] { 16, 12 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void TestEmbeddingBagWithMaxNormAndSum()
+        {
+            var ones = Int64Tensor.ones(new long[] { 16, 12 });
+            using (var emb = EmbeddingBag(1000, 128, max_norm: 1.5, mode: EmbeddingBagMode.Sum)) {
+                var output = emb.forward(ones);
+                Assert.Equal(new long[] { 16, 128 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void TestEmbeddingBagSetWeights()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            using (var emb = EmbeddingBag(1000, 12)) {
+                var weights = Float32Tensor.randn(new long[] { 1000, 12 });
+                emb.Weight = weights;
+
+                Assert.Equal(emb.Weight.shape.Length, weights.shape.Length);
+                Assert.Equal(emb.Weight.shape[0], weights.shape[0]);
+                Assert.Equal(emb.Weight.shape[1], weights.shape[1]);
+            }
+        }
+
+        [Fact]
+        public void TestEmbeddingBagFromPretrained()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            var weights = Float32Tensor.randn(new long[] { 1000, 12 });
+
+            using (var emb = NN.EmbeddingBag.from_pretrained(weights)) {
+                Assert.Equal(emb.Weight.shape.Length, weights.shape.Length);
+                Assert.Equal(emb.Weight.shape[0], weights.shape[0]);
+                Assert.Equal(emb.Weight.shape[1], weights.shape[1]);
+            }
+        }
+
+        [Fact]
         public void TestOneHotEncoding1()
         {
             var ones = Int64Tensor.from(new long[] { 1, 2, 0, 0, 3, 4, 2, 2 });

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1544,6 +1544,17 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestEmbeddingBagWithOffsets()
+        {
+            var ones = Int32Tensor.ones(new long[] { 16 });
+            var offsets = Int32Tensor.from(new int[] { 0, 8 });
+            using (var emb = EmbeddingBag(1000, 128, max_norm: 1.5, mode: EmbeddingBagMode.Sum)) {
+                var output = emb.forward(ones, offsets);
+                Assert.Equal(new long[] { offsets.shape[0], 128 }, output.shape);
+            }
+        }
+
+        [Fact]
         public void TestEmbeddingBagSetWeights()
         {
             var ones = Int32Tensor.ones(new long[] { 16 });


### PR DESCRIPTION
Adding EmbeddingBag module, and fixing the seq2seq example -- with GC.Collect() between every batch, there is no need for all the usings.