### PR TITLE
Fixed issue #145

### DIFF
--- a/src/TorchSharp/Tensor/TorchTensor.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.cs
@@ -114,12 +114,13 @@ namespace TorchSharp.Tensor
         /// </summary>
         public Span<T> Data<T>()
         {
-            if (NumberOfElements > int.MaxValue)
-            {
+            if (NumberOfElements > int.MaxValue) {
                 throw new ArgumentException("Span only supports up to int.MaxValue elements.");
             }
-            unsafe
-            {
+            if (device_type != DeviceType.CPU) {
+                throw new InvalidOperationException("Reading data from non-CPU memory is not supported. Move or copy the tensor to the cpu before reading.");
+            }
+            unsafe {
                 var res = THSTensor_data(handle);
                 if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                 // NOTE: there is no safety here.
@@ -133,6 +134,9 @@ namespace TorchSharp.Tensor
 
             if (totalSize > int.MaxValue) {
                 throw new ArgumentException("Span only supports up to int.MaxValue elements.");
+            }
+            if (device_type != DeviceType.CPU) {
+                throw new InvalidOperationException("Reading data from non-CPU memory is not supported. Move or copy the tensor to the cpu before reading.");
             }
             unsafe {
                 var res = THSTensor_data(handle);

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\TorchSharpTest\TestLoadSave.cs" Link="TestLoadSave.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchSharp.cs" Link="TestTorchSharp.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensor.cs" Link="TestTorchTensor.cs" />
+    <Compile Include="..\TorchSharpTest\TestTorchTensorBugs.cs" Link="TestTorchTensorBugs.cs" />
     <Compile Include="..\TorchSharpTest\TestTraining.cs" Link="TestTraining.cs" />
   </ItemGroup>
 

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -2271,12 +2271,15 @@ namespace TorchSharp
 
             var z = tensorFunc(x, y);
 
-            var xData = x.Data<Tin>();
-            var xCloneData = xClone.Data<Tin>();
-            var yData = y.Data<Tin>();
-            var zData = z.Data<Tin>();
+            if (x.device_type == DeviceType.CPU) {
+                var xData = x.Data<Tin>();
+                var xCloneData = xClone.Data<Tin>();
+                var yData = y.Data<Tin>();
+                var zData = z.Data<Tin>();
 
-            Assert.True(xData == zData);
+                Assert.True(xData == zData);
+            }
+
             for (int i = 0; i < 10; i++) {
                 for (int j = 0; j < 10; j++) {
                     var xClonev = getFuncIn(xClone, i, j);

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using TorchSharp;
+using TorchSharp.Tensor;
+using Xunit;
+
+#nullable enable
+
+namespace TorchSharp
+{
+    // The tests in this file are all derived from reported GitHub Issues, serving
+    // as regression tests.
+
+    public class TestTorchTensorBugs
+    {
+        [Fact]
+        public void ValidateIssue145()
+        {
+            // TorchTensor.DataItem gives a hard crash on GPU tensor
+
+            if (Torch.IsCudaAvailable()) {
+                var scalar = Float32Tensor.from(3.14f, Device.CUDA);
+                Assert.Throws<InvalidOperationException>(() => scalar.DataItem<float>());
+                var tensor = Float32Tensor.zeros(new long[] { 10, 10 }, Device.CUDA);
+                Assert.Throws<InvalidOperationException>(() => tensor.Data<float>());
+                Assert.Throws<InvalidOperationException>(() => tensor.Bytes());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Instead of returning an invalid native pointer when data lives off-CPU, which will cause all kinds of havoc, throw a .NET exception as a preventative measure.

Fixes issue #145 