### PR TITLE
Adding torch::fft operations.

### DIFF
--- a/src/Native/LibTorchSharp/CMakeLists.txt
+++ b/src/Native/LibTorchSharp/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     THSAutograd.cpp
 	THSConvolution.cpp
     THSData.cpp
+	THSFFT.cpp
     THSJIT.cpp
 	THSLinearAlgebra.cpp
 	THSLoss.cpp

--- a/src/Native/LibTorchSharp/THSFFT.cpp
+++ b/src/Native/LibTorchSharp/THSFFT.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+#include "THSTensor.h"
+
+#include <iostream>
+#include <fstream>
+
+Tensor THSTensor_fft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
+{
+    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    CATCH_TENSOR(torch::fft::fft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_ifft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
+{
+    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    CATCH_TENSOR(torch::fft::ifft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_fft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef({-2, -1}) : c10::IntArrayRef(dim, 2);
+
+    CATCH_TENSOR(torch::fft::fft2(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_ifft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+
+    CATCH_TENSOR(torch::fft::ifft2(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_fftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
+
+    CATCH_TENSOR(torch::fft::fftn(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_ifftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
+
+    CATCH_TENSOR(torch::fft::ifftn(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_hfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
+{
+    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    CATCH_TENSOR(torch::fft::hfft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_ihfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
+{
+    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    CATCH_TENSOR(torch::fft::ihfft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_rfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
+{
+    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    CATCH_TENSOR(torch::fft::rfft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_irfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
+{
+    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    CATCH_TENSOR(torch::fft::irfft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_rfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+
+    CATCH_TENSOR(torch::fft::rfft2(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_irfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+
+    CATCH_TENSOR(torch::fft::irfft2(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_rfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
+
+    CATCH_TENSOR(torch::fft::rfftn(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_irfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
+
+    CATCH_TENSOR(torch::fft::irfftn(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_fftfreq(const int64_t n, const double d, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(scalar_type))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+
+    CATCH_TENSOR(d == 0.0 ? torch::fft::fftfreq(n, options) : torch::fft::fftfreq(n, d, options));
+}
+
+Tensor THSTensor_rfftfreq(const int64_t n, const double d, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(scalar_type))
+        .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index))
+        .requires_grad(requires_grad);
+
+    CATCH_TENSOR(d == 0.0 ? torch::fft::rfftfreq(n, options) : torch::fft::rfftfreq(n, d, options));
+}
+
+Tensor THSTensor_fftshift(const Tensor tensor, const int64_t* dim, const int dim_length)
+{
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
+    CATCH_TENSOR(torch::fft::fftshift(*tensor, dArg));
+}
+
+Tensor THSTensor_ifftshift(const Tensor tensor, const int64_t* dim, const int dim_length)
+{
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
+    CATCH_TENSOR(torch::fft::ifftshift(*tensor, dArg));
+}

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -313,34 +313,6 @@ Tensor THSTensor_count_nonzero(const Tensor tensor, const int64_t* dim, const in
 }
 
 
-Tensor THSTensor_fft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm)
-{
-    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
-    auto normArg = (norm == NULL ? c10::optional<std::string>() : c10::optional<std::string>(norm));
-    CATCH_TENSOR(torch::fft::fft(*tensor, nArg, dim, normArg));
-}
-
-Tensor THSTensor_ifft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm)
-{
-    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
-    auto normArg = (norm == NULL ? c10::optional<std::string>() : c10::optional<std::string>(norm));
-    CATCH_TENSOR(torch::fft::ifft(*tensor, nArg, dim, normArg));
-}
-
-Tensor THSTensor_irfft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm)
-{
-    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
-    auto normArg = (norm == NULL ? c10::optional<std::string>() : c10::optional<std::string>(norm));
-    CATCH_TENSOR(torch::fft::irfft(*tensor, nArg, dim, normArg));
-}
-
-Tensor THSTensor_rfft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm)
-{
-    auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
-    auto normArg = (norm == NULL ? c10::optional<std::string>() : c10::optional<std::string>(norm));
-    CATCH_TENSOR(torch::fft::rfft(*tensor, nArg, dim, normArg));
-}
-
 Tensor THSTensor_flip(const Tensor tensor, const int64_t* sizes, const int length)
 {
     CATCH_TENSOR(tensor->flip(at::ArrayRef<int64_t>(sizes, length)));

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -403,14 +403,6 @@ EXPORT_API(Tensor) THSTensor_eye_out(const int64_t n, const int64_t m, const Ten
 
 EXPORT_API(Tensor) THSTensor_fill_(const Tensor tensor, Scalar value);
 
-EXPORT_API(Tensor) THSTensor_fft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm);
-
-EXPORT_API(Tensor) THSTensor_ifft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm);
-
-EXPORT_API(Tensor) THSTensor_irfft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm);
-
-EXPORT_API(Tensor) THSTensor_rfft(const Tensor tensor, const int64_t n, const int64_t dim, const char* norm);
-
 EXPORT_API(Tensor) THSTensor_flip(const Tensor tensor, const int64_t* sizes, const int length);
 
 EXPORT_API(Tensor) THSTensor_fliplr(const Tensor tensor);
@@ -1235,6 +1227,44 @@ EXPORT_API(Tensor) THSInit_xavier_normal_(Tensor tensor, double gain);
 EXPORT_API(Tensor) THSInit_xavier_uniform_(Tensor tensor, double gain);
 
 EXPORT_API(Tensor) THSInit_zeros_(Tensor tensor);
+
+// torch::fft:
+
+EXPORT_API(Tensor) THSTensor_fft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_ifft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_hfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_ihfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_fft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_ifft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_fftn(const Tensor tensor, const int64_t *s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_ifftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_rfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_irfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_rfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_irfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_rfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_irfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_fftfreq(const int64_t n, const double d, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
+
+EXPORT_API(Tensor) THSTensor_rfftfreq(const int64_t n, const double d, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
+
+EXPORT_API(Tensor) THSTensor_fftshift(const Tensor tensor, const int64_t* dim, const int dim_length);
+
+EXPORT_API(Tensor) THSTensor_ifftshift(const Tensor tensor, const int64_t* dim, const int dim_length);
 
 // Spectral Ops
 

--- a/src/TorchSharp/Tensor/TorchTensor.FFT.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.FFT.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace TorchSharp.Tensor
+{
+    // This file contains the mathematical operators on TorchTensor
+
+    public enum FFTNormType
+    {
+        Backward = 0,
+        Forward = 1,
+        Ortho = 2
+    }
+
+    public sealed partial class TorchTensor
+    {
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_fft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        public TorchTensor fft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
+        {
+            var res = THSTensor_fft(handle, n, dim, (sbyte)norm);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_ifft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        public TorchTensor ifft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
+        {
+            var res = THSTensor_ifft(handle, n, dim, (sbyte)norm);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_fft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        public TorchTensor fft2(long [] s = null, long [] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            if (this.Dimensions < 2) throw new ArgumentException("fft2() input should be at least 2D");
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_fft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_fftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        public TorchTensor fftn(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            var slen = (s == null) ? 0 : s.Length;
+            var dlen = (dim == null) ? 0 : dim.Length;
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_fftn(handle, (IntPtr)ps, slen, (IntPtr)pDim, dlen, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_ifftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        public TorchTensor ifftn(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            var slen = (s == null) ? 0 : s.Length;
+            var dlen = (dim == null) ? 0 : dim.Length;
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_ifftn(handle, (IntPtr)ps, slen, (IntPtr)pDim, dlen, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_ifft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        public TorchTensor ifft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            if (this.Dimensions < 2) throw new ArgumentException("ifft2() input should be at least 2D");
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_ifft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        public TorchTensor irfft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
+        {
+            var res = THSTensor_irfft(handle, n, dim, (sbyte)norm);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_rfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        public TorchTensor rfft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
+        {
+            var res = THSTensor_rfft(handle, n, dim, (sbyte)norm);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_rfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        public TorchTensor rfft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            if (this.Dimensions < 2) throw new ArgumentException("rfft2() input should be at least 2D");
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_rfft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_irfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        public TorchTensor irfft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            if (this.Dimensions < 2) throw new ArgumentException("irfft2() input should be at least 2D");
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_irfft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_rfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        public TorchTensor rfftn(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            var slen = (s == null) ? 0 : s.Length;
+            var dlen = (dim == null) ? 0 : dim.Length;
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_rfftn(handle, (IntPtr)ps, slen, (IntPtr)pDim, dlen, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_irfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        public TorchTensor irfftn(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            var slen = (s == null) ? 0 : s.Length;
+            var dlen = (dim == null) ? 0 : dim.Length;
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_irfftn(handle, (IntPtr)ps, slen, (IntPtr)pDim, dlen, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_hfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        public TorchTensor hfft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
+        {
+            var res = THSTensor_hfft(handle, n, dim, (sbyte)norm);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_ihfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        public TorchTensor ihfft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
+        {
+            var res = THSTensor_ihfft(handle, n, dim, (sbyte)norm);
+            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor(res);
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_fftshift(IntPtr tensor, IntPtr dim, int dim_length);
+
+        public TorchTensor fftshift(long[] dim = null)
+        {
+            var dlen = (dim == null) ? 0 : dim.Length;
+            unsafe {
+                fixed (long* pDim = dim) {
+                    var res = THSTensor_fftshift(handle, (IntPtr)pDim, dlen);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_ifftshift(IntPtr tensor, IntPtr dim, int dim_length);
+
+        public TorchTensor ifftshift(long[] dim = null)
+        {
+            var dlen = (dim == null) ? 0 : dim.Length;
+            unsafe {
+                fixed (long* pDim = dim) {
+                    var res = THSTensor_ifftshift(handle, (IntPtr)pDim, dlen);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+    }
+}

--- a/src/TorchSharp/Tensor/TorchTensor.FFT.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.FFT.cs
@@ -45,9 +45,26 @@ namespace TorchSharp.Tensor
         public TorchTensor fft2(long [] s = null, long [] dim = null, FFTNormType norm = FFTNormType.Backward)
         {
             if (this.Dimensions < 2) throw new ArgumentException("fft2() input should be at least 2D");
+            if (dim == null) dim = new long[] { -2, -1 };
             unsafe {
                 fixed (long* ps = s, pDim = dim) {
                     var res = THSTensor_fft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
+                    return new TorchTensor(res);
+                }
+            }
+        }
+
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_ifft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        public TorchTensor ifft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+        {
+            if (this.Dimensions < 2) throw new ArgumentException("ifft2() input should be at least 2D");
+            if (dim == null) dim = new long[] { -2, -1 };
+            unsafe {
+                fixed (long* ps = s, pDim = dim) {
+                    var res = THSTensor_ifft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
                     if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
                     return new TorchTensor(res);
                 }
@@ -87,21 +104,6 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_ifft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
-
-        public TorchTensor ifft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
-        {
-            if (this.Dimensions < 2) throw new ArgumentException("ifft2() input should be at least 2D");
-            unsafe {
-                fixed (long* ps = s, pDim = dim) {
-                    var res = THSTensor_ifft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
-                    if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-                    return new TorchTensor(res);
-                }
-            }
-        }
-
-        [DllImport("LibTorchSharp")]
         static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, sbyte norm);
 
         public TorchTensor irfft(long n = -1, long dim = -1, FFTNormType norm = FFTNormType.Backward)
@@ -127,6 +129,7 @@ namespace TorchSharp.Tensor
         public TorchTensor rfft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
         {
             if (this.Dimensions < 2) throw new ArgumentException("rfft2() input should be at least 2D");
+            if (dim == null) dim = new long[] { -2, -1 };
             unsafe {
                 fixed (long* ps = s, pDim = dim) {
                     var res = THSTensor_rfft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
@@ -142,6 +145,7 @@ namespace TorchSharp.Tensor
         public TorchTensor irfft2(long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
         {
             if (this.Dimensions < 2) throw new ArgumentException("irfft2() input should be at least 2D");
+            if (dim == null) dim = new long[] { -2, -1 };
             unsafe {
                 fixed (long* ps = s, pDim = dim) {
                     var res = THSTensor_irfft2(handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);

--- a/src/TorchSharp/Tensor/TorchTensor.Math.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.Math.cs
@@ -669,46 +669,6 @@ namespace TorchSharp.Tensor
         }
 
         [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_fft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
-
-        public TorchTensor fft(long? n, long dim = -1, string norm = "backward")
-        {
-            var res = THSTensor_fft(handle, n.GetValueOrDefault(-1), dim, norm);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
-        [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_ifft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
-
-        public TorchTensor ifft(long? n, long dim = -1, string norm = "backward")
-        {
-            var res = THSTensor_ifft(handle, n.GetValueOrDefault(-1), dim, norm);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
-        [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
-
-        public TorchTensor irfft(long? n, long dim = -1, string norm = "backward")
-        {
-            var res = THSTensor_irfft(handle, n.GetValueOrDefault(-1), dim, norm);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
-        [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_rfft(IntPtr tensor, long n, long dim, [MarshalAs(UnmanagedType.LPStr)] string norm);
-
-        public TorchTensor rfft(long? n, long dim = -1, string norm = "backward")
-        {
-            var res = THSTensor_rfft(handle, n.GetValueOrDefault(-1), dim, norm);
-            if (res == IntPtr.Zero) { Torch.CheckForErrors(); }
-            return new TorchTensor(res);
-        }
-
-        [DllImport("LibTorchSharp")]
         static extern IntPtr THSTensor_float_power(IntPtr tensor, IntPtr trg);
 
         /// <summary>

--- a/src/TorchSharp/Tensor/TorchTensor.Trig.cs
+++ b/src/TorchSharp/Tensor/TorchTensor.Trig.cs
@@ -25,7 +25,10 @@ namespace TorchSharp.Tensor
         /// </remarks>
         public TorchTensor angle()
         {
-            return new TorchTensor(THSTensor_angle(handle));
+            var res = THSTensor_angle(handle);
+            if (res == IntPtr.Zero)
+                Torch.CheckForErrors();
+            return new TorchTensor(res);
         }
 
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.generated.cs
@@ -1874,6 +1874,46 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the discrete Fourier Transform sample frequencies for a signal of size n.
+        /// </summary>
+        static public TorchTensor fftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.Float16, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.Float16, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the sample frequencies for rfft() with a signal of size n.
+        /// </summary>
+        static public TorchTensor rfftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.Float16, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.Float16, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_linspace(double start, double end, long steps, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
 
         /// <summary>
@@ -2379,6 +2419,46 @@ namespace TorchSharp.Tensor {
                     return new TorchTensor (handle);
                 }
             }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the discrete Fourier Transform sample frequencies for a signal of size n.
+        /// </summary>
+        static public TorchTensor fftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.BFloat16, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.BFloat16, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the sample frequencies for rfft() with a signal of size n.
+        /// </summary>
+        static public TorchTensor rfftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.BFloat16, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.BFloat16, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
         }
 
         [DllImport("LibTorchSharp")]
@@ -2890,6 +2970,46 @@ namespace TorchSharp.Tensor {
         }
 
         [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the discrete Fourier Transform sample frequencies for a signal of size n.
+        /// </summary>
+        static public TorchTensor fftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.Float32, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.Float32, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the sample frequencies for rfft() with a signal of size n.
+        /// </summary>
+        static public TorchTensor rfftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.Float32, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.Float32, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_linspace(double start, double end, long steps, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
 
         /// <summary>
@@ -3392,6 +3512,46 @@ namespace TorchSharp.Tensor {
                     return new TorchTensor (handle);
                 }
             }
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the discrete Fourier Transform sample frequencies for a signal of size n.
+        /// </summary>
+        static public TorchTensor fftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.Float64, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.Float64, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the sample frequencies for rfft() with a signal of size n.
+        /// </summary>
+        static public TorchTensor rfftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.Float64, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.Float64, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
         }
 
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/TorchTensorTyped.tt
+++ b/src/TorchSharp/Tensor/TorchTensorTyped.tt
@@ -324,6 +324,46 @@ if (type.IsFloatingPoint || type.IsComplex) {
 if (type.IsFloatingPoint) {
 #>
         [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the discrete Fourier Transform sample frequencies for a signal of size n.
+        /// </summary>
+        static public TorchTensor fftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.<#=type.Name#>, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_fftfreq (n, d, (sbyte)ScalarType.<#=type.Name#>, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
+
+        /// <summary>
+        /// Computes the sample frequencies for rfft() with a signal of size n.
+        /// </summary>
+        static public TorchTensor rfftfreq(long n, double d = 1.0, Device device = null, bool requiresGrad = false)
+        {
+            device = Torch.InitializeDevice(device);
+
+            var handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.<#=type.Name#>, (int) device.Type, device.Index, requiresGrad);
+            if (handle == IntPtr.Zero) {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                handle = THSTensor_rfftfreq (n, d, (sbyte)ScalarType.<#=type.Name#>, (int) device.Type, device.Index, requiresGrad);
+            }
+            if (handle == IntPtr.Zero) { Torch.CheckForErrors(); }
+            return new TorchTensor (handle);
+        }
+
+        [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_linspace(double start, double end, long steps, sbyte scalarType, int deviceType, int deviceIndex, bool requiresGrad);
 
         /// <summary>

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -2689,6 +2689,68 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void AbsTest()
+        {
+            var data = Float32Tensor.arange(-10.0f, 10.0f, 1.0f);
+            var expected = data.Data<float>().ToArray().Select(MathF.Abs).ToArray();
+            var res = data.abs();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
+        }
+
+        [Fact]
+        public void AbsTestC32()
+        {
+            var data = ComplexFloat32Tensor.rand(new long[] { 25 });
+            var expected = data.Data<(float R,float I)>().ToArray().Select(c => MathF.Sqrt(c.R* c.R + c.I*c.I)).ToArray();
+            var res = data.abs();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
+        }
+
+        [Fact]
+        public void AbsTestC64()
+        {
+            var data = ComplexFloat64Tensor.rand(new long[] { 25 });
+            var expected = data.Data<System.Numerics.Complex>().ToArray().Select(c => Math.Sqrt(c.Real * c.Real + c.Imaginary * c.Imaginary)).ToArray<double>();
+            var res = data.abs();
+            Assert.True(res.allclose(Float64Tensor.from(expected)));
+        }
+
+        [Fact]
+        public void AngleTestC32()
+        {
+            var data = ComplexFloat32Tensor.randn(new long[] { 25 });
+            var expected = data.Data<(float R, float I)>().ToArray().Select(c => {
+                var x = c.R;
+                var y = c.I;
+                return (x > 0 || y != 0) ? 2 * MathF.Atan(y / (MathF.Sqrt(x*x + y*y) + x)) : (x < 0 && y == 0) ? MathF.PI : 0;
+            }).ToArray();
+            var res = data.angle();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
+        }
+
+        [Fact]
+        public void AngleTestC64()
+        {
+            var data = ComplexFloat64Tensor.randn(new long[] { 25 });
+            var expected = data.Data<System.Numerics.Complex>().ToArray().Select(c => {
+                var x = c.Real;
+                var y = c.Imaginary;
+                return (x > 0 || y != 0) ? 2 * Math.Atan(y / (Math.Sqrt(x * x + y * y) + x)) : (x < 0 && y == 0) ? Math.PI : 0;
+            }).ToArray<double>();
+            var res = data.angle();
+            Assert.True(res.allclose(Float64Tensor.from(expected)));
+        }
+
+        [Fact]
+        public void SqrtTest()
+        {
+            var data = new float[] { 1.0f, 2.0f, 3.0f };
+            var expected = data.Select(MathF.Sqrt).ToArray();
+            var res = Float32Tensor.from(data).sqrt();
+            Assert.True(res.allclose(Float32Tensor.from(expected)));
+        }
+
+        [Fact]
         public void SinTest()
         {
             var data = new float[] { 1.0f, 2.0f, 3.0f };

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -3870,5 +3870,197 @@ namespace TorchSharp
             Assert.Equal(x.shape, vasc.shape);
 
         }
+
+        [Fact]
+        public void Float32FFT()
+        {
+            var input = Float32Tensor.arange(0, 4, 1);
+            var output = input.fft();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.ifft();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64FFT()
+        {
+            var input = Float64Tensor.arange(0, 4, 1);
+            var output = input.fft();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.ifft();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+
+        [Fact]
+        public void ComplexFloat32FFT()
+        {
+            var input = ComplexFloat32Tensor.arange(0, 4, 1);
+            var output = input.fft();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.ifft();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+
+        [Fact]
+        public void ComplexFloat64FFT()
+        {
+            var input = ComplexFloat64Tensor.arange(0, 4, 1);
+            var output = input.fft();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.ifft();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void Float32FFT2()
+        {
+            var input = Float32Tensor.rand(new long[] { 5, 5 });
+            var output = input.fft2();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.ifft2();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64FFT2()
+        {
+            var input = Float64Tensor.rand(new long[] { 5, 5 });
+            var output = input.fft2();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.ifft2();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void ComplexFloat32FFT2()
+        {
+            var input = ComplexFloat32Tensor.rand(new long[] { 5, 5 });
+            var output = input.fft2();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.ifft2();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+        [Fact]
+        public void ComplexFloat64FFT2()
+        {
+            var input = ComplexFloat64Tensor.rand(new long[] { 5, 5 });
+            var output = input.fftn();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.ifftn();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void Float32FFTN()
+        {
+            var input = Float32Tensor.rand(new long[] { 5, 5, 5, 5 });
+            var output = input.fftn();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.ifftn();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64FFTN()
+        {
+            var input = Float64Tensor.rand(new long[] { 5, 5, 5, 5 });
+            var output = input.fftn();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.ifftn();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void ComplexFloat32FFTN()
+        {
+            var input = ComplexFloat32Tensor.rand(new long[] { 5, 5, 5, 5 });
+            var output = input.fftn();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.ifftn();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+        [Fact]
+        public void ComplexFloat64FFTN()
+        {
+            var input = ComplexFloat64Tensor.rand(new long[] { 5, 5, 5, 5 });
+            var output = input.fftn();
+            Assert.Equal(input.shape, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.ifftn();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void Float32FFTFrequency()
+        {
+            var x = Float32Tensor.fftfreq(5);
+            Assert.Equal(ScalarType.Float32, x.Type);
+            Assert.Equal(1, x.dim());
+            Assert.Equal(5, x.shape[0]);
+        }
+
+        [Fact]
+        public void Float64FFTFrequency()
+        {
+            var x = Float64Tensor.fftfreq(5);
+            Assert.Equal(ScalarType.Float64, x.Type);
+            Assert.Equal(1, x.dim());
+            Assert.Equal(5, x.shape[0]);
+        }
+
+        [Fact]
+        public void Float32FFTShift()
+        {
+            var x = Float32Tensor.fftfreq(4);
+            var shifted = x.fftshift();
+            Assert.Equal(ScalarType.Float32, shifted.Type);
+            Assert.Equal(1, shifted.dim());
+            Assert.Equal(4, shifted.shape[0]);
+            var y = x.ifftshift();
+            Assert.Equal(ScalarType.Float32, y.Type);
+            Assert.Equal(1, y.dim());
+            Assert.Equal(4, y.shape[0]);
+        }
+
+        [Fact]
+        public void Float64FFTShift()
+        {
+            var x = Float64Tensor.fftfreq(4);
+            var shifted = x.fftshift();
+            Assert.Equal(ScalarType.Float64, shifted.Type);
+            Assert.Equal(1, shifted.dim());
+            Assert.Equal(4, shifted.shape[0]);
+            var y = x.ifftshift();
+            Assert.Equal(ScalarType.Float64, y.Type);
+            Assert.Equal(1, y.dim());
+            Assert.Equal(4, y.shape[0]);
+        }
     }
 }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -3957,6 +3957,53 @@ namespace TorchSharp
             Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
         }
 
+        [Fact]
+        public void Float32HFFT()
+        {
+            var input = Float32Tensor.arange(0, 4, 1);
+            var output = input.hfft();
+            Assert.Equal(6, output.shape[0]);
+            Assert.Equal(ScalarType.Float32, output.Type);
+
+            var inverted = output.ihfft();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64HFFT()
+        {
+            var input = Float64Tensor.arange(0, 4, 1);
+            var output = input.hfft();
+            Assert.Equal(6, output.shape[0]);
+            Assert.Equal(ScalarType.Float64, output.Type);
+
+            var inverted = output.ihfft();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void Float32RFFT()
+        {
+            var input = Float32Tensor.arange(0, 4, 1);
+            var output = input.rfft();
+            Assert.Equal(3, output.shape[0]);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.irfft();
+            Assert.Equal(ScalarType.Float32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64RFFT()
+        {
+            var input = Float64Tensor.arange(0, 4, 1);
+            var output = input.rfft();
+            Assert.Equal(3, output.shape[0]);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.irfft();
+            Assert.Equal(ScalarType.Float64, inverted.Type);
+        }
 
         [Fact]
         public void ComplexFloat32FFT()
@@ -3980,6 +4027,31 @@ namespace TorchSharp
             Assert.Equal(ScalarType.ComplexFloat64, output.Type);
 
             var inverted = output.ifft();
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void ComplexFloat32HFFT()
+        {
+            var input = ComplexFloat32Tensor.arange(0, 4, 1);
+            var output = input.hfft();
+            Assert.Equal(6, output.shape[0]);
+            Assert.Equal(ScalarType.Float32, output.Type);
+
+            var inverted = output.ihfft();
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.Type);
+        }
+
+
+        [Fact]
+        public void ComplexFloat64HFFT()
+        {
+            var input = ComplexFloat64Tensor.arange(0, 4, 1);
+            var output = input.hfft();
+            Assert.Equal(6, output.shape[0]);
+            Assert.Equal(ScalarType.Float64, output.Type);
+
+            var inverted = output.ihfft();
             Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
         }
 
@@ -4008,6 +4080,30 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void Float32RFFT2()
+        {
+            var input = Float32Tensor.rand(new long[] { 5, 5 });
+            var output = input.rfft2();
+            Assert.Equal(new long[] { 5, 3 }, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.irfft2();
+            Assert.Equal(ScalarType.Float32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64RFFT2()
+        {
+            var input = Float64Tensor.rand(new long[] { 5, 5 });
+            var output = input.rfft2();
+            Assert.Equal(new long[] { 5, 3 }, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.irfft2();
+            Assert.Equal(ScalarType.Float64, inverted.Type);
+        }
+
+        [Fact]
         public void ComplexFloat32FFT2()
         {
             var input = ComplexFloat32Tensor.rand(new long[] { 5, 5 });
@@ -4023,11 +4119,11 @@ namespace TorchSharp
         public void ComplexFloat64FFT2()
         {
             var input = ComplexFloat64Tensor.rand(new long[] { 5, 5 });
-            var output = input.fftn();
+            var output = input.fft2();
             Assert.Equal(input.shape, output.shape);
             Assert.Equal(ScalarType.ComplexFloat64, output.Type);
 
-            var inverted = output.ifftn();
+            var inverted = output.ifft2();
             Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
         }
 
@@ -4053,6 +4149,30 @@ namespace TorchSharp
 
             var inverted = output.ifftn();
             Assert.Equal(ScalarType.ComplexFloat64, inverted.Type);
+        }
+
+        [Fact]
+        public void Float32RFFTN()
+        {
+            var input = Float32Tensor.rand(new long[] { 5, 5, 5, 5 });
+            var output = input.rfftn();
+            Assert.Equal(new long[] { 5, 5, 5, 3 }, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, output.Type);
+
+            var inverted = output.irfftn();
+            Assert.Equal(ScalarType.Float32, inverted.Type);
+        }
+
+        [Fact]
+        public void Float64RFFTN()
+        {
+            var input = Float64Tensor.rand(new long[] { 5, 5, 5, 5 });
+            var output = input.rfftn();
+            Assert.Equal(new long[] { 5, 5, 5, 3 }, output.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, output.Type);
+
+            var inverted = output.irfftn();
+            Assert.Equal(ScalarType.Float64, inverted.Type);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds the operations from the 1.8 torch::fft namespace, which is useful for signal processing.
Also adding a few unit tests for complex abs and angle computation (useful for conversion to polar representation).