### PR TITLE
build libtorch cpu mac packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -75,14 +75,15 @@
   <!-- use stable versions for libtorch packages based on LibTorch version number scheme-->
   <!-- we manually update these -->
   <PropertyGroup Condition="'$(MSBuildProjectName.IndexOf(`libtorch-`))' != '-1'">
-    <LibTorchPackageVersion>1.8.0.7</LibTorchPackageVersion>
+    <LibTorchPackageVersion>1.8.0.8</LibTorchPackageVersion>
     <VersionPrefix>$(LibTorchPackageVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- turned on/off manually in separate CI jobs -->
-    <SkipCuda>false</SkipCuda>
+    <SkipCuda Condition="'$(TargetOS)' == 'mac'">true</SkipCuda>
+    <SkipCuda Condition="'$(TargetOS)' != 'mac'">false</SkipCuda>
     <SkipTests>false</SkipTests>
     
     <!-- By default only TorchSharp and no libtorch-cpu or libtorch-cuda packages are built.  The CI file controls these via 'BuildLibTorchPackages' -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,15 +42,6 @@ jobs:
       vmImage: 'ubuntu-16.04'
     container: UbuntuContainer
 
-# - template: /build/ci/job-template.yml
-#   parameters:
-#     prepScript: brew update && brew install libomp && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
-#     name: MacOS_x64
-#     buildScript: ./dotnet build /p:SkipCuda=true -c 
-#     testScript: ./dotnet test /p:SkipCuda=true -c 
-#     pool:
-#       vmImage: 'macos-10.15'
-
 - template: /build/ci/job-template.yml
   parameters:
     prepScript: echo "no prep needed"
@@ -184,6 +175,9 @@ jobs:
       sourceFolder: $(Pipeline.Workspace)/LinuxAssets/libtorch-cpu
       targetFolder: $(Build.SourcesDirectory)/bin/obj/packprep/$(BuildConfig)/libtorch-cpu
   
+  - script: rmdir /s /q  $(Pipeline.Workspace)\LinuxAssets
+    displayName: Free up space (LinuxAssets in workspace)
+
     # Download all bits contributing to the packages from the Mac build
   - download: current
     artifact: MacAssets
@@ -200,8 +194,8 @@ jobs:
       sourceFolder: $(Pipeline.Workspace)/MacAssets/libtorch-cpu
       targetFolder: $(Build.SourcesDirectory)/bin/obj/packprep/$(BuildConfig)/libtorch-cpu
   
-  - script: rmdir /s /q  $(Pipeline.Workspace)\LinuxAssets
-    displayName: Free up space (linux assets in workspace)
+  - script: rmdir /s /q  $(Pipeline.Workspace)\MacAssets
+    displayName: Free up space (MacAssets in workspace)
 
   - download: current
     artifact: WindowsAssets

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   
   # Set this to 'true' to build the libtorch-* packages as part of master branch CI and
   # push them to the artifacts feed of the Azure CI project
-  BuildLibTorchPackages: false
+  BuildLibTorchPackages: true
 
 resources:
   containers:
@@ -137,8 +137,8 @@ jobs:
   pool:
     vmImage: 'macos-10.15'
   steps:
-  - script: dotnet build -c $(BuildConfig) /p:SkipCuda=true
-    displayName: Build
+  - script: dotnet build -c $(BuildConfig) src/TorchSharp/TorchSharp.csproj /p:SkipTests=true /p:IncludeTorchSharpPackage=true /p:IncludeLibTorchCpuPackage=$(BuildLibTorchPackages) /p:IncludeLibTorchCudaPackages=false
+    displayName: Build mac
 
   - publish: $(Build.SourcesDirectory)/bin/obj/packprep/$(BuildConfig)
     artifact: MacAssets


### PR DESCRIPTION
This should in theory create libtorch cpu Mac packages one merged into master.  

The Linux and Windows pacakges libtorch CPU and CUDA will also be built with version bump to 1.8.0.8
