### PR TITLE
Fixes for double-freeing native tensor handles.

### DIFF
--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -376,9 +376,15 @@ namespace TorchSharp
                     if (distance != null) {
                         return (Tensor anchor, Tensor positive, Tensor negative) => {
                             DistanceFunctionNative func = (IntPtr x, IntPtr y) => {
-                                using (var x1 = new Tensor(x))
-                                using (var y1 = new Tensor(y))
-                                    return distance(x1, y1).Handle;
+                                var x1 = new Tensor(x);
+                                var y1 = new Tensor(y);
+                                var res = distance(x1, y1);
+
+                                GC.SuppressFinalize(x1);
+                                GC.SuppressFinalize(y1);
+                                GC.SuppressFinalize(res);
+
+                                return res.Handle;
                             };
                             var res = THSNN_triplet_margin_with_distance_loss(anchor.Handle, positive.Handle, negative.Handle, func, margin, swap, (long)reduction);
                             if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Optimizer.cs
+++ b/src/TorchSharp/NN/Optimizer.cs
@@ -101,9 +101,12 @@ namespace TorchSharp
                 {
                     if (closure == null) {
                         THSNN_Optimizer_step(handle, null);
-                    }
-                    else {
-                        THSNN_Optimizer_step(handle, () => closure().handle);
+                    } else {
+                        THSNN_Optimizer_step(handle, () => {
+                            var res = closure();
+                            GC.SuppressFinalize(res);
+                            return res.handle;
+                        });
                     }
                     torch.CheckForErrors();
                 }

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -121,7 +121,10 @@ namespace TorchSharp
             );
 
             using var @in = Float32Tensor.from(3);
-            using var @out = net.forward(@in);
+
+            for (var i = 0; i < 1000; i++) {
+                using var @out = net.forward(@in);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes three instances of native tensor handles being freed more than once, causing access violations.

It includes the fix surfaced in PR #316. 