### PR TITLE
Removing CustomModule; bugfixes

### DIFF
--- a/src/Examples/AdversarialExampleGeneration.cs
+++ b/src/Examples/AdversarialExampleGeneration.cs
@@ -135,7 +135,7 @@ namespace TorchSharp.Examples
                 using (var output = model.forward(data))
                 using (var loss = criterion(output, target)) {
 
-                    model.ZeroGrad();
+                    model.zero_grad();
                     loss.backward();
 
                     var perturbed = Attack(data, ε, data.grad());

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -78,7 +78,7 @@ namespace TorchSharp.Examples
             }
         }
 
-        private class Model : CustomModule
+        private class Model : Module
         {
             private readonly Module features;
             private readonly Module avgPool;

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -104,7 +104,7 @@ namespace TorchSharp.Examples
             model.save(dataset + ".model.bin");
         }
 
-        internal class Model : CustomModule
+        internal class Model : Module
         {
             private Module conv1 = Conv2d(1, 32, 3);
             private Module conv2 = Conv2d(32, 64, 3);

--- a/src/Examples/Program.cs
+++ b/src/Examples/Program.cs
@@ -10,12 +10,12 @@ namespace TorchSharp.Examples
     {
         public static void Main(string[] args)
         {
-            //MNIST.Main(args);
-            //AdversarialExampleGeneration.Main(args);
-            //AlexNet.Main(args);
-            //SequenceToSequence.Main(args);
-            //TextClassification.Main(args);
-            ImageTransforms.Main(args);
+            MNIST.Main(args);
+            AdversarialExampleGeneration.Main(args);
+            AlexNet.Main(args);
+            SequenceToSequence.Main(args);
+            TextClassification.Main(args);
+            //ImageTransforms.Main(args);
         }
     }
 }

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -195,9 +195,9 @@ namespace TorchSharp.Examples
             return (data, target);
         }
 
-        class TransformerModel : CustomModule
+        class TransformerModel : Module
         {
-            private Modules.TransformerEncoder transformer_encoder;
+            private Module transformer_encoder;
             private PositionalEncoding pos_encoder;
             private Modules.Embedding encoder;
             private Modules.Linear decoder;
@@ -241,7 +241,7 @@ namespace TorchSharp.Examples
                 throw new NotImplementedException("single-argument forward()");
             }
 
-            public Tensor forward(Tensor t, Tensor mask)
+            public override Tensor forward(Tensor t, Tensor mask)
             {
                 var src = pos_encoder.forward(encoder.forward(t) * MathF.Sqrt(ninputs));
                 var enc = transformer_encoder.forward(src, mask);
@@ -256,7 +256,7 @@ namespace TorchSharp.Examples
             }
         }
 
-        class PositionalEncoding : CustomModule
+        class PositionalEncoding : Module
         {
             private Module dropout;
             private Tensor pe;

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -149,7 +149,7 @@ namespace TorchSharp.Examples
         }
     }
 
-    class TextClassificationModel : CustomModule
+    class TextClassificationModel : Module
     {
         private Modules.EmbeddingBag embedding;
         private Modules.Linear fc;
@@ -177,7 +177,7 @@ namespace TorchSharp.Examples
             throw new NotImplementedException();
         }
 
-        public Tensor forward(Tensor input, Tensor offsets)
+        public override Tensor forward(Tensor input, Tensor offsets)
         {
             return fc.forward(embedding.forward(input, offsets));
         }

--- a/src/FSharp.Examples/AdversarialExampleGeneration.fs
+++ b/src/FSharp.Examples/AdversarialExampleGeneration.fs
@@ -70,7 +70,7 @@ let test (model:MNIST.Model) (eps:float) (dataLoader:MNISTReader) size =
             use estimate = input --> model
             use loss = criterion estimate labels
 
-            model.ZeroGrad()
+            model.zero_grad()
             loss.backward()
 
             use perturbed = attack input (eps.ToScalar()) (input.grad())

--- a/src/FSharp.Examples/AlexNet.fs
+++ b/src/FSharp.Examples/AlexNet.fs
@@ -42,7 +42,7 @@ let getDataFiles sourceDir targetDir =
         Utils.Decompress.ExtractTGZ(Path.Combine(sourceDir, "cifar-10-binary.tar.gz"), targetDir)
 
 type Model(name,device:torch.Device) as this =
-    inherit CustomModule(name)
+    inherit Module(name)
 
     let features = Sequential(("c1", Conv2d(3L, 64L, kernelSize=3L, stride=2L, padding=1L) :> Module),
                               ("r1", ReLU(inPlace=true) :> Module),

--- a/src/FSharp.Examples/MNIST.fs
+++ b/src/FSharp.Examples/MNIST.fs
@@ -53,7 +53,7 @@ let getDataFiles sourceDir targetDir =
         Utils.Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-labels-idx1-ubyte.gz"), targetDir)
 
 type Model(name,device:torch.Device) as this =
-    inherit CustomModule(name)
+    inherit Module(name)
 
     let conv1 = Conv2d(1L, 32L, 3L)
     let conv2 = Conv2d(32L, 64L, 3L)

--- a/src/FSharp.Examples/SequenceToSequence.fs
+++ b/src/FSharp.Examples/SequenceToSequence.fs
@@ -48,7 +48,7 @@ let device = if hasCUDA then torch.CUDA else torch.CPU
 let criterion x y = functional.cross_entropy_loss(reduction=Reduction.Mean).Invoke(x,y)
 
 type PositionalEncoding(dmodel, maxLen) as this =
-    inherit CustomModule("PositionalEncoding")
+    inherit Module("PositionalEncoding")
 
     let dropout = Dropout(dropout)
     let mutable pe = torch.Float32Tensor.zeros([| maxLen; dmodel|])
@@ -74,7 +74,7 @@ type PositionalEncoding(dmodel, maxLen) as this =
         dropout.forward(x)
 
 type TransformerModel(ntokens, device:torch.Device) as this =
-    inherit CustomModule("Transformer")
+    inherit Module("Transformer")
 
     let pos_encoder = new PositionalEncoding(emsize, 5000L)
     let encoder_layers = TransformerEncoderLayer(emsize, nheads, nhidden, dropout)
@@ -98,7 +98,7 @@ type TransformerModel(ntokens, device:torch.Device) as this =
 
     override _.forward(input) = raise (NotImplementedException("single-argument forward()"))
 
-    member _.forward(t, mask) =
+    override _.forward(t, mask) =
         let src = pos_encoder.forward(encoder.forward(t) * sqrEmSz)
         let enc = transformer_encoder.forward(src, mask)
         decoder.forward(enc)

--- a/src/FSharp.Examples/TextClassification.fs
+++ b/src/FSharp.Examples/TextClassification.fs
@@ -43,7 +43,7 @@ let device = if hasCUDA then torch.CUDA else torch.CPU
 let criterion x y = functional.cross_entropy_loss().Invoke(x,y)
 
 type TextClassificationModel(vocabSize, embedDim, nClasses, device:torch.Device) as this =
-    inherit CustomModule("Transformer")
+    inherit Module("Transformer")
 
     let embedding = EmbeddingBag(vocabSize, embedDim, sparse=false)
     let fc = Linear(embedDim, nClasses)
@@ -62,7 +62,7 @@ type TextClassificationModel(vocabSize, embedDim, nClasses, device:torch.Device)
 
     override _.forward(input) = raise (NotImplementedException("single-argument forward()"))
 
-    member _.forward(input, offsets) =
+    override _.forward(input, offsets) =
         embedding.forward(input, offsets) --> fc
 
 let train epoch (trainData:IEnumerable<torch.Tensor*torch.Tensor*torch.Tensor>) (model:TextClassificationModel) (optimizer:torch.optim.Optimizer) =

--- a/src/Native/LibTorchSharp/THSModule.cpp
+++ b/src/Native/LibTorchSharp/THSModule.cpp
@@ -38,6 +38,11 @@ void THSNN_Module_to_device(NNModule module, int64_t device, int64_t index)
     (*module)->to(torch::Device(dev, index));
 }
 
+void THSNN_Module_to_dtype(NNModule module, int8_t dtype)
+{
+    (*module)->to((at::ScalarType)dtype);
+}
+
 void THSNN_Module_dispose(const NNModule module)
 {
     delete module; // NOTE: this only deletes the shared_ptr
@@ -79,9 +84,9 @@ Tensor THSNN_Module_get_parameter(const NNModule module, const char* name)
     CATCH_TENSOR(*(*module)->named_parameters().find(name));
 }
 
-void THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator1)(size_t length))
+void THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator1)(size_t length), bool recurse)
 {
-    auto parameters = (*module)->parameters();
+    auto parameters = (*module)->parameters(recurse);
     Tensor* result1 = allocator1(parameters.size());
 
     for (size_t i = 0; i < parameters.size(); i++)

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -15,7 +15,7 @@ EXPORT_API(void)        THSNN_Module_get_named_parameters(const NNModule module,
 EXPORT_API(void)        THSNN_Module_get_named_buffers(const NNModule module, Tensor* (*allocator1)(size_t length), const char** (*allocator2)(size_t length));
 EXPORT_API(void)        THSNN_Module_get_named_children(const NNModule module, NNModule* (*allocator1)(size_t length), const char** (*allocator2)(size_t length));
 EXPORT_API(void)        THSNN_Module_get_named_modules(const NNModule module, NNModule* (*allocator1)(size_t length), const char** (*allocator2)(size_t length));
-EXPORT_API(void)        THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator1)(size_t length));
+EXPORT_API(void)        THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator1)(size_t length), bool recurse);
 EXPORT_API(int)         THSNN_Module_is_training(NNModule module);
 EXPORT_API(void)        THSNN_Module_train(NNModule module);
 EXPORT_API(void)        THSNN_Module_eval(NNModule module);
@@ -29,6 +29,7 @@ EXPORT_API(void)        THSNN_Module_register_buffer(const NNModule module, cons
 EXPORT_API(void)        THSNN_Module_register_module(const NNModule module, const char* name, const NNModule submodule);
 EXPORT_API(void)        THSNN_Module_dispose(const NNModule module);
 EXPORT_API(void)        THSNN_Module_to_device(NNModule module, int64_t device, int64_t index);
+EXPORT_API(void)        THSNN_Module_to_dtype(NNModule module, int8_t dtype);
 
 EXPORT_API(void)        THSNN_AnyModule_dispose(const NNAnyModule module);
 //EXPORT_API(NNModule)    THSNN_AnyModule_get(const NNAnyModule module);

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -26,7 +26,7 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_Bilinear_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
 
-            public Tensor forward(Tensor input1, Tensor input2)
+            public override Tensor forward(Tensor input1, Tensor input2)
             {
                 var res = THSNN_Bilinear_forward(handle, input1.Handle, input2.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -74,6 +74,14 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_Bilinear_ctor(long in1_features, long in2_features, long output_size, bool bias, out IntPtr pBoxedModule);
 
+            /// <summary>
+            /// Applies a bilinear transformation to the incoming data
+            /// </summary>
+            /// <param name="in1Features">size of each first input sample</param>
+            /// <param name="in2Features">size of each second input sample</param>
+            /// <param name="outputSize">size of each output sample</param>
+            /// <param name="hasBias">If set to false, the layer will not learn an additive bias</param>
+            /// <returns></returns>
             static public Bilinear Bilinear(long in1Features, long in2Features, long outputSize, bool hasBias = true)
             {
                 var res = THSNN_Bilinear_ctor(in1Features, in2Features, outputSize, hasBias, out var boxedHandle);
@@ -83,10 +91,22 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                static public Tensor bilinear(Tensor x1, Tensor x2, long in1Features, long in2Features, long outputSize, bool hasBias = true)
+                /// <summary>
+                /// Applies a bilinear transformation to the incoming data
+                /// </summary>
+                /// <returns></returns>
+                static public Tensor bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias = null)
                 {
-                    using (var d = nn.Bilinear(in1Features, in2Features, outputSize, hasBias)) {
-                        return d.forward(x1, x2);
+                    var in1Features = input1.shape[input1.shape.Length - 1];
+                    var in2Features = input2.shape[input2.shape.Length - 1];
+                    var outFeatures = weight.shape[0];
+
+                    using (var d = nn.Bilinear(in1Features, in2Features, outFeatures, bias is not null)) {
+                        d.Weight = weight;
+                        if (bias is not null) {
+                            d.Bias = bias;
+                        }
+                        return d.forward(input1, input2);
                     }
                 }
             }

--- a/src/TorchSharp/NN/CosineSimilarity.cs
+++ b/src/TorchSharp/NN/CosineSimilarity.cs
@@ -21,7 +21,7 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_CosineSimilarity_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
 
-            public Tensor forward(Tensor input1, Tensor input2)
+            public override Tensor forward(Tensor input1, Tensor input2)
             {
                 var res = THSNN_CosineSimilarity_forward(handle, input1.Handle, input2.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/CosineSimilarity.cs
+++ b/src/TorchSharp/NN/CosineSimilarity.cs
@@ -37,6 +37,12 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_CosineSimilarity_ctor(long dim, double eps, out IntPtr pBoxedModule);
 
+            /// <summary>
+            /// Returns cosine similarity between x1 and x2, computed along dim. Inputs must have same shape.
+            /// </summary>
+            /// <param name="dim">Dimension where cosine similarity is computed. Default: 1</param>
+            /// <param name="eps">Small value to avoid division by zero. Default: 1e-8</param>
+            /// <returns></returns>
             static public CosineSimilarity CosineSimilarity(long dim = 1, double eps = 1e-8)
             {
                 var handle = THSNN_CosineSimilarity_ctor(dim, eps, out var boxedHandle);
@@ -46,10 +52,18 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                static public Tensor cosine_similarity(Tensor input1, Tensor input2, long dim = 1, double eps = 1e-8)
+                /// <summary>
+                /// Returns cosine similarity between x1 and x2, computed along dim. Inputs must have same shape.
+                /// </summary>
+                /// <param name="x1">First input.</param>
+                /// <param name="x2">Second input (of size matching x1).</param>
+                /// <param name="dim">Dimension where cosine similarity is computed. Default: 1</param>
+                /// <param name="eps">Small value to avoid division by zero. Default: 1e-8</param>
+                /// <returns></returns>
+                static public Tensor cosine_similarity(Tensor x1, Tensor x2, long dim = 1, double eps = 1e-8)
                 {
                     using (var f = nn.CosineSimilarity(dim, eps)) {
-                        return f.forward(input1, input2);
+                        return f.forward(x1, x2);
                     }
                 }
             }

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -23,7 +23,7 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_EmbeddingBag_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
 
-            public Tensor forward(Tensor input, Tensor offsets = null, Tensor perSampleWeights = null)
+            public Tensor forward(Tensor input, Tensor offsets, Tensor perSampleWeights)
             {
                 if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
                 if (!(offsets is null) && input.dtype != offsets.dtype) throw new ArgumentException("input and offsets must have the same element type.");
@@ -33,6 +33,32 @@ namespace TorchSharp
                 if (input.Dimensions == 2 && input.dtype == ScalarType.Int32) throw new NotImplementedException("EmbeddingBag for 32-bit integers -- there's some issue in the native runtime that prevents this from working.");
 
                 var res = THSNN_EmbeddingBag_forward(handle, input.Handle, (offsets is null) ? IntPtr.Zero : offsets.Handle, (perSampleWeights is null) ? IntPtr.Zero : perSampleWeights.Handle);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public override Tensor forward(Tensor input, Tensor offsets)
+            {
+                if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
+                if (!(offsets is null) && input.dtype != offsets.dtype) throw new ArgumentException("input and offsets must have the same element type.");
+                if (input.Dimensions == 1 && offsets is null) throw new ArgumentException("'offsets' must be non-null for a 1-D input.");
+                if (input.Dimensions == 2 && !(offsets is null)) throw new ArgumentException("'offsets' must be null for a 2-D input.");
+
+                if (input.Dimensions == 2 && input.dtype == ScalarType.Int32) throw new NotImplementedException("EmbeddingBag for 32-bit integers -- there's some issue in the native runtime that prevents this from working.");
+
+                var res = THSNN_EmbeddingBag_forward(handle, input.Handle, (offsets is null) ? IntPtr.Zero : offsets.Handle, IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public override Tensor forward(Tensor input)
+            {
+                if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
+                if (input.Dimensions == 1) throw new ArgumentException("'offsets' must be non-null for a 1-D input.");
+
+                if (input.Dimensions == 2 && input.dtype == ScalarType.Int32) throw new NotImplementedException("EmbeddingBag for 32-bit integers -- there's some issue in the native runtime that prevents this from working.");
+
+                var res = THSNN_EmbeddingBag_forward(handle, input.Handle, IntPtr.Zero, IntPtr.Zero);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -23,6 +23,15 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_EmbeddingBag_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
 
+            /// <summary>
+            /// Forward pass of EmbeddingBag.
+            /// </summary>
+            /// <param name="input">Tensor containing bags of indices into the embedding matrix.</param>
+            /// <param name="offsets">Only used when input is 1D. offsets determines the starting index position of each bag (sequence) in input.</param>
+            /// <param name="perSampleWeights">a tensor of float / double weights, or None to indicate all weights should be taken to be 1.
+            /// If specified, per_sample_weights must have exactly the same shape as input and is treated as having the same offsets, if those are not None.
+            /// Only supported for mode='sum'.</param>
+            /// <returns></returns>
             public Tensor forward(Tensor input, Tensor offsets, Tensor perSampleWeights)
             {
                 if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
@@ -37,6 +46,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
+            /// <summary>
+            /// Forward pass of EmbeddingBag.
+            /// </summary>
+            /// <param name="input">Tensor containing bags of indices into the embedding matrix.</param>
+            /// <param name="offsets">Only used when input is 1D. offsets determines the starting index position of each bag (sequence) in input.</param>
+            /// <returns></returns>
             public override Tensor forward(Tensor input, Tensor offsets)
             {
                 if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
@@ -51,6 +66,11 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
+            /// <summary>
+            /// Forward pass of EmbeddingBag.
+            /// </summary>
+            /// <param name="input">Tensor containing bags of indices into the embedding matrix.</param>
+            /// <returns></returns>
             public override Tensor forward(Tensor input)
             {
                 if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");

--- a/src/TorchSharp/NN/FeatureDropout.cs
+++ b/src/TorchSharp/NN/FeatureDropout.cs
@@ -37,18 +37,33 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_FeatureAlphaDropout_ctor(double probability, out IntPtr pBoxedModule);
 
-            static public FeatureAlphaDropout FeatureAlphaDropout(double probability = 0.5)
+            /// <summary>
+            /// Randomly masks out entire channels (a channel is a feature map, e.g. the j-th channel of the i-th sample in the batch input is a tensor input[i,j]) of the input tensor.
+            /// Instead of setting activations to zero, as in regular Dropout, the activations are set to the negative saturation value of the SELU activation function.
+            /// Each element will be masked independently on every forward call with probability p using samples from a Bernoulli distribution.The elements to be masked are
+            /// randomized on every forward call, and scaled and shifted to maintain zero mean and unit variance.
+            /// </summary>
+            /// <param name="p">Dropout probability of a channel to be zeroed. Default: 0.5</param>
+            static public FeatureAlphaDropout FeatureAlphaDropout(double p = 0.5)
             {
-                var handle = THSNN_FeatureAlphaDropout_ctor(probability, out var boxedHandle);
+                var handle = THSNN_FeatureAlphaDropout_ctor(p, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new FeatureAlphaDropout(handle, boxedHandle);
             }
 
             public static partial class functional
             {
-                static public Tensor feature_alpha_dropout(Tensor x, double probability = 0.5)
+                /// <summary>
+                /// Randomly masks out entire channels (a channel is a feature map, e.g. the j-th channel of the i-th sample in the batch input is a tensor input[i,j]) of the input tensor.
+                /// Instead of setting activations to zero, as in regular Dropout, the activations are set to the negative saturation value of the SELU activation function.
+                /// Each element will be masked independently on every forward call with probability p using samples from a Bernoulli distribution.The elements to be masked are
+                /// randomized on every forward call, and scaled and shifted to maintain zero mean and unit variance.
+                /// </summary>
+                /// <param name="x">Input tensor</param>
+                /// <param name="p">Dropout probability of a channel to be zeroed. Default: 0.5</param>
+                static public Tensor feature_alpha_dropout(Tensor x, double p = 0.5)
                 {
-                    using (var f = nn.FeatureAlphaDropout(probability)) {
+                    using (var f = nn.FeatureAlphaDropout(p)) {
                         return f.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Flatten.cs
+++ b/src/TorchSharp/NN/Flatten.cs
@@ -37,6 +37,12 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_Flatten_ctor(long startDim, long endDim, out IntPtr pBoxedModule);
 
+            /// <summary>
+            /// Flattens a contiguous range of dims into a tensor. For use with Sequential.
+            /// </summary>
+            /// <param name="startDim">First dim to flatten (default = 1).</param>
+            /// <param name="endDim">Last dim to flatten (default = -1).</param>
+            /// <returns></returns>
             static public Flatten Flatten(long startDim = 1, long endDim = -1)
             {
                 var handle = THSNN_Flatten_ctor(startDim, endDim, out var boxedHandle);

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -75,6 +75,13 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_Linear_ctor(long input_size, long output_size, bool bias, out IntPtr pBoxedModule);
 
+            /// <summary>
+            /// Applies a linear transformation to the incoming data.
+            /// </summary>
+            /// <param name="inputSize">Size of each input sample</param>
+            /// <param name="outputSize">Size of each output sample</param>
+            /// <param name="hasBias">If set to false, the layer will not learn an additive bias.</param>
+            /// <returns></returns>
             static public Linear Linear(long inputSize, long outputSize, bool hasBias = true)
             {
                 var res = THSNN_Linear_ctor(inputSize, outputSize, hasBias, out var boxedHandle);
@@ -84,6 +91,13 @@ namespace TorchSharp
 
             public static partial class functional
             {
+                /// <summary>
+                /// Applies a linear transformation to the incoming data.
+                /// </summary>
+                /// <param name="x">Input tensor</param>
+                /// <param name="inputSize">Size of each input sample</param>
+                /// <param name="outputSize">Size of each output sample</param>
+                /// <param name="hasBias">If set to false, the layer will not learn an additive bias.</param>
                 static public Tensor linear(Tensor x, long inputSize, long outputSize, bool hasBias = true)
                 {
                     using (var d = nn.Linear(inputSize, outputSize, hasBias)) {

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -481,6 +481,11 @@ namespace TorchSharp
                     IntPtr names, IntPtr parameters, IntPtr require_grad,
                     int length, ForwardFunctionC forward, out IntPtr pBoxedModule);
 
+                /// <summary>
+                /// Constructor for custom modules, i.e. those defined outside of TorchSharp.
+                /// </summary>
+                /// <param name="name">The name of the module. Useful for debugging purposes, mostly.</param>
+                /// <param name="parameters">The module parameters, i.e. its trainable weights and (non-trainable) "buffers."</param>
                 protected Module(string name, params parameter.Parameter[] parameters) : this(IntPtr.Zero, IntPtr.Zero)
                 {
                     var names = parameters.Select(p => Marshal.StringToHGlobalAnsi(p.Name)).ToArray();

--- a/src/TorchSharp/NN/PairwiseDistance.cs
+++ b/src/TorchSharp/NN/PairwiseDistance.cs
@@ -21,7 +21,7 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_PairwiseDistance_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
 
-            public Tensor forward(Tensor input1, Tensor input2)
+            public override Tensor forward(Tensor input1, Tensor input2)
             {
                 var res = THSNN_PairwiseDistance_forward(handle, input1.Handle, input2.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/GRU.cs
+++ b/src/TorchSharp/NN/Recurrent/GRU.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -27,7 +26,7 @@ namespace TorchSharp
             /// Defaults to 0 if not provided. If the GRU is bidirectional, num_directions should be 2, else it should be 1.</param>
             /// <returns></returns>
             /// <returns></returns>
-            public (Tensor, Tensor) forward(Tensor input, Tensor? h0 = null)
+            public new (Tensor, Tensor) forward(Tensor input, Tensor h0 = null)
             {
                 var res = THSNN_GRU_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero, out IntPtr hN);
                 if (res == IntPtr.Zero || hN == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -7,7 +7,6 @@ using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -33,7 +32,7 @@ namespace TorchSharp
             /// <param name="input">Tensor of shape (batch, input_size) containing the features of the input sequence.</param>
             /// <param name="h0">Tensor of shape (batch, hidden_size) containing the initial hidden state for each element in the batch.</param>
             /// <returns></returns>
-            public Tensor forward(Tensor input, Tensor? h0 = null)
+            public override Tensor forward(Tensor input, Tensor h0 = null)
             {
                 var hN = THSNN_GRUCell_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero);
                 if (hN == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/LSTM.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTM.cs
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
-
 #nullable enable
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -27,7 +26,7 @@ namespace TorchSharp
             /// <param name="h0">Tensor of shape (num_layers * num_directions, batch, hidden_size)containing the initial hidden state for each element in the batch.
             /// Defaults to 0 if not provided. If the RNN is bidirectional, num_directions should be 2, else it should be 1.</param>
             /// <returns></returns>
-            public (Tensor, Tensor) forward(Tensor input, Tensor? h0 = null)
+            public new (Tensor, Tensor) forward(Tensor input, Tensor h0 = null)
             {
                 var res = THSNN_RNN_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero, out IntPtr hN);
                 if (res == IntPtr.Zero || hN == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -7,7 +7,6 @@ using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -33,7 +32,7 @@ namespace TorchSharp
             /// <param name="input">Tensor of shape (batch, input_size) containing the features of the input sequence.</param>
             /// <param name="h0">Tensor of shape (batch, hidden_size) containing the initial hidden state for each element in the batch.</param>
             /// <returns></returns>
-            public Tensor forward(Tensor input, Tensor? h0 = null)
+            public override Tensor forward(Tensor input, Tensor h0 = null)
             {
                 var hN = THSNN_RNNCell_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero);
                 if (hN == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -30,6 +30,8 @@ namespace TorchSharp
 
                 THSNN_Sequential_push_back(handle, name, submodule.BoxedModule.handle);
                 torch.CheckForErrors();
+                // Keep the sub-module alive for at least as long as the Sequential object is alive.
+                _modules.Add(submodule);
             }
 
             internal Sequential(IntPtr handle) : base(handle, IntPtr.Zero)
@@ -45,6 +47,11 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
+
+            // There is no functional reason for this collection, but since the module
+            // handles are held in the native runtime, which calls back into managed code,
+            // the modules need to stay alive, and keeping a list of them will do that.
+            private List<torch.nn.Module> _modules = new List<nn.Module>();
         }
     }
 

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -48,6 +48,15 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
+            public override nn.Module apply(Action<nn.Module> fn)
+            {
+                // More efficient than asking C++ for the children. We already have the list, after all.
+                foreach (var m in _modules) m.apply(fn);
+                fn(this);
+                return this;
+
+            }
+
             // There is no functional reason for this collection, but since the module
             // handles are held in the native runtime, which calls back into managed code,
             // the modules need to stay alive, and keeping a list of them will do that.

--- a/src/TorchSharp/NN/Transformer.cs
+++ b/src/TorchSharp/NN/Transformer.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -31,7 +30,7 @@ namespace TorchSharp
             /// <param name="tgt_key_padding_mask">The ByteTensor mask for tgt keys per batch (optional).</param>
             /// <param name="memory_key_padding_mask">The ByteTensor mask for memory keys per batch (optional).</param>
             /// <returns></returns>
-            public Tensor forward(Tensor src, Tensor tgt, Tensor? src_mask = null, Tensor? tgt_mask = null, Tensor? memory_mask = null, Tensor? src_key_padding_mask = null, Tensor? tgt_key_padding_mask = null, Tensor? memory_key_padding_mask = null)
+            public Tensor forward(Tensor src, Tensor tgt, Tensor src_mask, Tensor tgt_mask = null, Tensor memory_mask = null, Tensor src_key_padding_mask = null, Tensor tgt_key_padding_mask = null, Tensor memory_key_padding_mask = null)
             {
                 var res = THSNN_Transformer_forward(handle,
                     src.Handle,
@@ -42,6 +41,26 @@ namespace TorchSharp
                     src_key_padding_mask?.Handle ?? IntPtr.Zero,
                     tgt_key_padding_mask?.Handle ?? IntPtr.Zero,
                     memory_key_padding_mask?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Take in and process masked source/target sequences.
+            /// </summary>
+            /// <param name="src">The sequence to the encoder (required).</param>
+            /// <param name="tgt">The sequence to the decoder (required).</param>
+            public override Tensor forward(Tensor src, Tensor tgt)
+            {
+                var res = THSNN_Transformer_forward(handle,
+                    src.Handle,
+                    tgt.Handle,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/src/TorchSharp/NN/TransformerDecoder.cs
+++ b/src/TorchSharp/NN/TransformerDecoder.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -29,7 +28,7 @@ namespace TorchSharp
             /// <param name="tgt_key_padding_mask">The mask for the tgt keys per batch (optional).</param>
             /// <param name="memory_key_padding_mask">The mask for the memory keys per batch (optional).</param>
             /// <returns></returns>
-            public Tensor forward(Tensor tgt, Tensor memory, Tensor? tgt_mask = null, Tensor? memory_mask = null, Tensor? tgt_key_padding_mask = null, Tensor? memory_key_padding_mask = null)
+            public Tensor forward(Tensor tgt, Tensor memory, Tensor tgt_mask, Tensor memory_mask = null, Tensor tgt_key_padding_mask = null, Tensor memory_key_padding_mask = null)
             {
                 var res = THSNN_TransformerDecoder_forward(handle,
                     tgt.Handle,
@@ -38,6 +37,24 @@ namespace TorchSharp
                     memory_mask?.Handle ?? IntPtr.Zero,
                     tgt_key_padding_mask?.Handle ?? IntPtr.Zero,
                     memory_key_padding_mask?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Pass the inputs (and mask) through the decoder layers in turn.
+            /// </summary>
+            /// <param name="tgt">The sequence to the decoder layer (required).</param>
+            /// <param name="memory">The sequence from the last layer of the encoder (required).</param>
+            public override Tensor forward(Tensor tgt, Tensor memory)
+            {
+                var res = THSNN_TransformerDecoder_forward(handle,
+                    tgt.Handle,
+                    memory.Handle,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/src/TorchSharp/NN/TransformerDecoderLayer.cs
+++ b/src/TorchSharp/NN/TransformerDecoderLayer.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -29,7 +28,7 @@ namespace TorchSharp
             /// <param name="tgt_key_padding_mask">The mask for the tgt keys per batch (optional).</param>
             /// <param name="memory_key_padding_mask">The mask for the memory keys per batch (optional).</param>
             /// <returns></returns>
-            public Tensor forward(Tensor tgt, Tensor memory, Tensor? tgt_mask = null, Tensor? memory_mask = null, Tensor? tgt_key_padding_mask = null, Tensor? memory_key_padding_mask = null)
+            public Tensor forward(Tensor tgt, Tensor memory, Tensor tgt_mask, Tensor memory_mask = null, Tensor tgt_key_padding_mask = null, Tensor memory_key_padding_mask = null)
             {
                 var res = THSNN_TransformerDecoderLayer_forward(handle,
                     tgt.Handle,
@@ -38,6 +37,24 @@ namespace TorchSharp
                     memory_mask?.Handle ?? IntPtr.Zero,
                     tgt_key_padding_mask?.Handle ?? IntPtr.Zero,
                     memory_key_padding_mask?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Pass the inputs (and mask) through the decoder layer.
+            /// </summary>
+            /// <param name="tgt">The sequence to the decoder layer (required).</param>
+            /// <param name="memory">The sequence from the last layer of the encoder (required).</param>
+            public override Tensor forward(Tensor tgt, Tensor memory)
+            {
+                var res = THSNN_TransformerDecoderLayer_forward(handle,
+                    tgt.Handle,
+                    memory.Handle,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/src/TorchSharp/NN/TransformerEncoder.cs
+++ b/src/TorchSharp/NN/TransformerEncoder.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -32,12 +31,43 @@ namespace TorchSharp
             /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
             /// <param name="src_key_padding_mask">The ByteTensor mask for src keys per batch (optional).</param>
             /// <returns></returns>
-            public Tensor forward(Tensor src, Tensor? src_mask = null, Tensor? src_key_padding_mask = null)
+            public Tensor forward(Tensor src, Tensor src_mask, Tensor src_key_padding_mask)
             {
                 var res = THSNN_TransformerEncoder_forward(handle,
                     src.Handle,
                     src_mask?.Handle ?? IntPtr.Zero,
                     src_key_padding_mask?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Pass the input through the encoder layers in turn.
+            /// </summary>
+            /// <param name="src">The sequence to the encoder (required).</param>
+            /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
+            /// <returns></returns>
+            public override Tensor forward(Tensor src, Tensor src_mask)
+            {
+                var res = THSNN_TransformerEncoder_forward(handle,
+                    src.Handle,
+                    src_mask?.Handle ?? IntPtr.Zero,
+                    IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Pass the input through the encoder layers in turn.
+            /// </summary>
+            /// <param name="src">The sequence to the encoder (required).</param>
+            /// <returns></returns>
+            public override Tensor forward(Tensor src)
+            {
+                var res = THSNN_TransformerEncoder_forward(handle,
+                    src.Handle,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/src/TorchSharp/NN/TransformerEncoderLayer.cs
+++ b/src/TorchSharp/NN/TransformerEncoderLayer.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -26,12 +25,41 @@ namespace TorchSharp
             /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
             /// <param name="src_key_padding_mask">The ByteTensor mask for src keys per batch (optional).</param>
             /// <returns></returns>
-            public Tensor forward(Tensor src, Tensor? src_mask = null, Tensor? src_key_padding_mask = null)
+            public Tensor forward(Tensor src, Tensor src_mask, Tensor src_key_padding_mask)
             {
                 var res = THSNN_TransformerEncoderLayer_forward(handle,
                     src.Handle,
                     src_mask?.Handle ?? IntPtr.Zero,
                     src_key_padding_mask?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Pass the input through the encoder layer.
+            /// </summary>
+            /// <param name="src">The sequence to the encoder (required).</param>
+            /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
+            public override Tensor forward(Tensor src, Tensor src_mask)
+            {
+                var res = THSNN_TransformerEncoderLayer_forward(handle,
+                    src.Handle,
+                    src_mask?.Handle ?? IntPtr.Zero,
+                    IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Pass the input through the encoder layer.
+            /// </summary>
+            /// <param name="src">The sequence to the encoder (required).</param>
+            public override Tensor forward(Tensor src)
+            {
+                var res = THSNN_TransformerEncoderLayer_forward(handle,
+                    src.Handle,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -760,7 +760,7 @@ namespace TorchSharp
             var loss = mse_loss(Reduction.Sum);
             var output = loss(eval, y);
 
-            seq.ZeroGrad();
+            seq.zero_grad();
 
             output.backward();
         }
@@ -782,7 +782,7 @@ namespace TorchSharp
             var loss = mse_loss(Reduction.Sum);
             var output = loss(eval, y);
 
-            seq.ZeroGrad();
+            seq.zero_grad();
 
             output.backward();
 
@@ -807,7 +807,7 @@ namespace TorchSharp
             var loss = mse_loss(Reduction.Sum);
             var output = loss(eval, y);
 
-            seq.ZeroGrad();
+            seq.zero_grad();
 
             output.backward();
 
@@ -834,7 +834,7 @@ namespace TorchSharp
             var loss = mse_loss();
             var output = loss(prediction, y);
 
-            linear.ZeroGrad();
+            linear.zero_grad();
 
             output.backward();
 
@@ -907,7 +907,7 @@ namespace TorchSharp
             var loss = mse_loss(Reduction.Sum);
             var output = loss(eval, y);
 
-            modT.ZeroGrad();
+            modT.zero_grad();
 
             output.backward();
             var gradCounts = 0;
@@ -925,7 +925,7 @@ namespace TorchSharp
             eval = modF.forward(x);
             output = loss(eval, y);
 
-            modF.ZeroGrad();
+            modF.zero_grad();
 
             output.backward();
             gradCounts = 0;

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -858,7 +858,7 @@ namespace TorchSharp
             Assert.False(x.requires_grad);
         }
 
-        private class CondModel : CustomModule
+        private class CondModel : Module
         {
             private Module fb = Linear(1000, 100, false);
             private Module fbT1 = Linear(100, 10, false);
@@ -1299,7 +1299,7 @@ namespace TorchSharp
             Assert.Equal(1000, param.shape[1]);
         }
 
-        private class TestModule : CustomModule
+        private class TestModule : Module
         {
             public TestModule(string name, Tensor tensor, bool withGrad)
                 : base(name, new parameter.Parameter(name, tensor, withGrad))

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -44,7 +44,7 @@ namespace TorchSharp
 
                 finalLoss = lossVal;
 
-                seq.ZeroGrad();
+                seq.zero_grad();
 
                 output.backward();
 
@@ -86,7 +86,7 @@ namespace TorchSharp
 
                 finalLoss = lossVal;
 
-                seq.ZeroGrad();
+                seq.zero_grad();
 
                 output.backward();
 


### PR DESCRIPTION
CustomModule was introduced as a base class for all non-framework modules, but had no corresponding class in the Pytorch API. This PR removes it from the API.

In addition, a couple of bug fixes and corrected APIs were added, and I added some doc comments that were missing.

This PR addresses issues #321 and the remaining problem in #318.