### PR TITLE
Dispose `Scalar`s implicitly created in `Tensor` operators

### DIFF
--- a/src/TorchSharp/Tensor/Tensor.Operators.cs
+++ b/src/TorchSharp/Tensor/Tensor.Operators.cs
@@ -12,66 +12,209 @@ namespace TorchSharp
             public static Tensor operator +(Tensor left, Scalar right) => left.add(right);
             public static Tensor operator +(Scalar left, Tensor right) => right.add(left);
 
-            public static Tensor operator +(Tensor left, int right) => left.add(right);
-            public static Tensor operator +(Tensor left, long right) => left.add(right);
-            public static Tensor operator +(Tensor left, float right) => left.add(right);
-            public static Tensor operator +(Tensor left, double right) => left.add(right);
+            public static Tensor operator +(Tensor left, int right)
+            {
+                using Scalar scalar = right;
+                return left.add(scalar);
+            }
+            public static Tensor operator +(Tensor left, long right)
+            {
+                using Scalar scalar = right;
+                return left.add(scalar);
+            }
+            public static Tensor operator +(Tensor left, float right)
+            {
+                using Scalar scalar = right;
+                return left.add(scalar);
+            }
+            public static Tensor operator +(Tensor left, double right)
+            {
+                using Scalar scalar = right;
+                return left.add(scalar);
+            }
 
-            public static Tensor operator +(int left, Tensor right) => right.add(left);
-            public static Tensor operator +(long left, Tensor right) => right.add(left);
-            public static Tensor operator +(float left, Tensor right) => right.add(left);
-            public static Tensor operator +(double left, Tensor right) => right.add(left);
+            public static Tensor operator +(int left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.add(scalar);
+            }
+            public static Tensor operator +(long left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.add(scalar);
+            }
+            public static Tensor operator +(float left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.add(scalar);
+            }
+            public static Tensor operator +(double left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.add(scalar);
+            }
 
             public static Tensor operator *(Tensor left, Tensor right) => left.mul(right);
             public static Tensor operator *(Tensor left, Scalar right) => left.mul(right);
             public static Tensor operator *(Scalar left, Tensor right) => right.mul(left);
 
-            public static Tensor operator *(Tensor left, int right) => left.mul(right);
-            public static Tensor operator *(Tensor left, long right) => left.mul(right);
-            public static Tensor operator *(Tensor left, float right) => left.mul(right);
-            public static Tensor operator *(Tensor left, double right) => left.mul(right);
+            public static Tensor operator *(Tensor left, int right)
+            {
+                using Scalar scalar = right;
+                return left.mul(scalar);
+            }
+            public static Tensor operator *(Tensor left, long right)
+            {
+                using Scalar scalar = right;
+                return left.mul(scalar);
+            }
+            public static Tensor operator *(Tensor left, float right)
+            {
+                using Scalar scalar = right;
+                return left.mul(scalar);
+            }
+            public static Tensor operator *(Tensor left, double right)
+            {
+                using Scalar scalar = right;
+                return left.mul(scalar);
+            }
 
-            public static Tensor operator *(int left, Tensor right) => right.mul(left);
-            public static Tensor operator *(long left, Tensor right) => right.mul(left);
-            public static Tensor operator *(float left, Tensor right) => right.mul(left);
-            public static Tensor operator *(double left, Tensor right) => right.mul(left);
+            public static Tensor operator *(int left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.mul(scalar);
+            }
+            public static Tensor operator *(long left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.mul(scalar);
+            }
+            public static Tensor operator *(float left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.mul(scalar);
+            }
+            public static Tensor operator *(double left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.mul(scalar);
+            }
 
             public static Tensor operator -(Tensor left, Tensor right) => left.sub(right);
             public static Tensor operator -(Tensor left, Scalar right) => left.sub(right);
             public static Tensor operator -(Scalar left, Tensor right) => right.negative().add(left);
 
-            public static Tensor operator -(Tensor left, int right) => left.sub(right);
-            public static Tensor operator -(Tensor left, long right) => left.sub(right);
-            public static Tensor operator -(Tensor left, float right) => left.sub(right);
-            public static Tensor operator -(Tensor left, double right) => left.sub(right);
+            public static Tensor operator -(Tensor left, int right)
+            {
+                using Scalar scalar = right;
+                return left.sub(scalar);
+            }
+            public static Tensor operator -(Tensor left, long right)
+            {
+                using Scalar scalar = right;
+                return left.sub(scalar);
+            }
+            public static Tensor operator -(Tensor left, float right)
+            {
+                using Scalar scalar = right;
+                return left.sub(scalar);
+            }
+            public static Tensor operator -(Tensor left, double right)
+            {
+                using Scalar scalar = right;
+                return left.sub(scalar);
+            }
 
-            public static Tensor operator -(int left, Tensor right) => right.negative().add(left);
-            public static Tensor operator -(long left, Tensor right) => right.negative().add(left);
-            public static Tensor operator -(float left, Tensor right) => right.negative().add(left);
-            public static Tensor operator -(double left, Tensor right) => right.negative().add(left);
+            public static Tensor operator -(int left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.negative().add(scalar);
+            }
+            public static Tensor operator -(long left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.negative().add(scalar);
+            }
+            public static Tensor operator -(float left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.negative().add(scalar);
+            }
+            public static Tensor operator -(double left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.negative().add(scalar);
+            }
 
             public static Tensor operator /(Tensor left, Tensor right) => left.div(right);
             public static Tensor operator /(Tensor left, Scalar right) => left.div(right);
             public static Tensor operator /(Scalar left, Tensor right) => right.reciprocal().mul(left);
 
-            public static Tensor operator /(Tensor left, int right) => left.div(right);
-            public static Tensor operator /(Tensor left, long right) => left.div(right);
-            public static Tensor operator /(Tensor left, float right) => left.div(right);
-            public static Tensor operator /(Tensor left, double right) => left.div(right);
+            public static Tensor operator /(Tensor left, int right)
+            {
+                using Scalar scalar = right;
+                return left.div(scalar);
+            }
+            public static Tensor operator /(Tensor left, long right)
+            {
+                using Scalar scalar = right;
+                return left.div(scalar);
+            }
+            public static Tensor operator /(Tensor left, float right)
+            {
+                using Scalar scalar = right;
+                return left.div(scalar);
+            }
+            public static Tensor operator /(Tensor left, double right)
+            {
+                using Scalar scalar = right;
+                return left.div(scalar);
+            }
 
-            public static Tensor operator /(int left, Tensor right) => right.reciprocal().mul(left);
-            public static Tensor operator /(long left, Tensor right) => right.reciprocal().mul(left);
-            public static Tensor operator /(float left, Tensor right) => right.reciprocal().mul(left);
-            public static Tensor operator /(double left, Tensor right) => right.reciprocal().mul(left);
-
+            public static Tensor operator /(int left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.reciprocal().mul(scalar);
+            }
+            public static Tensor operator /(long left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.reciprocal().mul(scalar);
+            }
+            public static Tensor operator /(float left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.reciprocal().mul(scalar);
+            }
+            public static Tensor operator /(double left, Tensor right)
+            {
+                using Scalar scalar = left;
+                return right.reciprocal().mul(scalar);
+            }
 
             public static Tensor operator %(Tensor left, Tensor right) => left.remainder(right);
             public static Tensor operator %(Tensor left, Scalar right) => left.remainder(right);
 
-            public static Tensor operator %(Tensor left, int right) => left.remainder(right);
-            public static Tensor operator %(Tensor left, long right) => left.remainder(right);
-            public static Tensor operator %(Tensor left, float right) => left.remainder(right);
-            public static Tensor operator %(Tensor left, double right) => left.remainder(right);
+            public static Tensor operator %(Tensor left, int right)
+            {
+                using Scalar scalar = right;
+                return left.remainder(scalar);
+            }
+            public static Tensor operator %(Tensor left, long right)
+            {
+                using Scalar scalar = right;
+                return left.remainder(scalar);
+            }
+            public static Tensor operator %(Tensor left, float right)
+            {
+                using Scalar scalar = right;
+                return left.remainder(scalar);
+            }
+            public static Tensor operator %(Tensor left, double right)
+            {
+                using Scalar scalar = right;
+                return left.remainder(scalar);
+            }
 
             public static Tensor operator &(Tensor left, Tensor right) => left.bitwise_and(right);
 

--- a/src/TorchSharp/Tensor/Tensor.Operators.cs
+++ b/src/TorchSharp/Tensor/Tensor.Operators.cs
@@ -15,43 +15,43 @@ namespace TorchSharp
             public static Tensor operator +(Tensor left, int right)
             {
                 using Scalar scalar = right;
-                return left.add(scalar);
+                return left + scalar;
             }
             public static Tensor operator +(Tensor left, long right)
             {
                 using Scalar scalar = right;
-                return left.add(scalar);
+                return left + scalar;
             }
             public static Tensor operator +(Tensor left, float right)
             {
                 using Scalar scalar = right;
-                return left.add(scalar);
+                return left + scalar;
             }
             public static Tensor operator +(Tensor left, double right)
             {
                 using Scalar scalar = right;
-                return left.add(scalar);
+                return left + scalar;
             }
 
             public static Tensor operator +(int left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.add(scalar);
+                return scalar + right;
             }
             public static Tensor operator +(long left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.add(scalar);
+                return scalar + right;
             }
             public static Tensor operator +(float left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.add(scalar);
+                return scalar + right;
             }
             public static Tensor operator +(double left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.add(scalar);
+                return scalar + right;
             }
 
             public static Tensor operator *(Tensor left, Tensor right) => left.mul(right);
@@ -61,43 +61,43 @@ namespace TorchSharp
             public static Tensor operator *(Tensor left, int right)
             {
                 using Scalar scalar = right;
-                return left.mul(scalar);
+                return left * scalar;
             }
             public static Tensor operator *(Tensor left, long right)
             {
                 using Scalar scalar = right;
-                return left.mul(scalar);
+                return left * scalar;
             }
             public static Tensor operator *(Tensor left, float right)
             {
                 using Scalar scalar = right;
-                return left.mul(scalar);
+                return left * scalar;
             }
             public static Tensor operator *(Tensor left, double right)
             {
                 using Scalar scalar = right;
-                return left.mul(scalar);
+                return left * scalar;
             }
 
             public static Tensor operator *(int left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.mul(scalar);
+                return scalar * right;
             }
             public static Tensor operator *(long left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.mul(scalar);
+                return scalar * right;
             }
             public static Tensor operator *(float left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.mul(scalar);
+                return scalar * right;
             }
             public static Tensor operator *(double left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.mul(scalar);
+                return scalar * right;
             }
 
             public static Tensor operator -(Tensor left, Tensor right) => left.sub(right);
@@ -107,43 +107,43 @@ namespace TorchSharp
             public static Tensor operator -(Tensor left, int right)
             {
                 using Scalar scalar = right;
-                return left.sub(scalar);
+                return left - scalar;
             }
             public static Tensor operator -(Tensor left, long right)
             {
                 using Scalar scalar = right;
-                return left.sub(scalar);
+                return left - scalar;
             }
             public static Tensor operator -(Tensor left, float right)
             {
                 using Scalar scalar = right;
-                return left.sub(scalar);
+                return left - scalar;
             }
             public static Tensor operator -(Tensor left, double right)
             {
                 using Scalar scalar = right;
-                return left.sub(scalar);
+                return left - scalar;
             }
 
             public static Tensor operator -(int left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.negative().add(scalar);
+                return scalar - right;
             }
             public static Tensor operator -(long left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.negative().add(scalar);
+                return scalar - right;
             }
             public static Tensor operator -(float left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.negative().add(scalar);
+                return scalar - right;
             }
             public static Tensor operator -(double left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.negative().add(scalar);
+                return scalar - right;
             }
 
             public static Tensor operator /(Tensor left, Tensor right) => left.div(right);
@@ -153,43 +153,43 @@ namespace TorchSharp
             public static Tensor operator /(Tensor left, int right)
             {
                 using Scalar scalar = right;
-                return left.div(scalar);
+                return left / scalar;
             }
             public static Tensor operator /(Tensor left, long right)
             {
                 using Scalar scalar = right;
-                return left.div(scalar);
+                return left / scalar;
             }
             public static Tensor operator /(Tensor left, float right)
             {
                 using Scalar scalar = right;
-                return left.div(scalar);
+                return left / scalar;
             }
             public static Tensor operator /(Tensor left, double right)
             {
                 using Scalar scalar = right;
-                return left.div(scalar);
+                return left / scalar;
             }
 
             public static Tensor operator /(int left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.reciprocal().mul(scalar);
+                return scalar / right;
             }
             public static Tensor operator /(long left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.reciprocal().mul(scalar);
+                return scalar / right;
             }
             public static Tensor operator /(float left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.reciprocal().mul(scalar);
+                return scalar / right;
             }
             public static Tensor operator /(double left, Tensor right)
             {
                 using Scalar scalar = left;
-                return right.reciprocal().mul(scalar);
+                return scalar / right;
             }
 
             public static Tensor operator %(Tensor left, Tensor right) => left.remainder(right);
@@ -198,22 +198,22 @@ namespace TorchSharp
             public static Tensor operator %(Tensor left, int right)
             {
                 using Scalar scalar = right;
-                return left.remainder(scalar);
+                return left % scalar;
             }
             public static Tensor operator %(Tensor left, long right)
             {
                 using Scalar scalar = right;
-                return left.remainder(scalar);
+                return left % scalar;
             }
             public static Tensor operator %(Tensor left, float right)
             {
                 using Scalar scalar = right;
-                return left.remainder(scalar);
+                return left % scalar;
             }
             public static Tensor operator %(Tensor left, double right)
             {
                 using Scalar scalar = right;
-                return left.remainder(scalar);
+                return left % scalar;
             }
 
             public static Tensor operator &(Tensor left, Tensor right) => left.bitwise_and(right);


### PR DESCRIPTION
This pull request modifies the `Tensor` operators involving primitives to immediately dispose the `Scalar` object they create, rather than waiting for the garbage collector.