### PR TITLE
Fix THSJIT_TensorType_sizes signature

### DIFF
--- a/src/Native/LibTorchSharp/THSJIT.cpp
+++ b/src/Native/LibTorchSharp/THSJIT.cpp
@@ -599,7 +599,7 @@ int8_t THSJIT_TensorType_dtype(const JITTensorType type)
     }
 }
 
-void THSJIT_TensorType_sizes(const JITTensorType type, int64_t* (*allocator)(int64_t length))
+void THSJIT_TensorType_sizes(const JITTensorType type, int64_t* (*allocator)(size_t length))
 {
     //CATCH(
     auto& t = *type;

--- a/src/Native/LibTorchSharp/THSJIT.h
+++ b/src/Native/LibTorchSharp/THSJIT.h
@@ -57,7 +57,7 @@ EXPORT_API(int8_t) THSJIT_Type_kind(JITType handle);
 EXPORT_API(void*) THSJIT_Type_cast(const JITType type);
 
 EXPORT_API(int8_t) THSJIT_TensorType_dtype(const JITTensorType type);
-EXPORT_API(void) THSJIT_TensorType_sizes(const JITTensorType type, int64_t* (*allocator)(int64_t length));
+EXPORT_API(void) THSJIT_TensorType_sizes(const JITTensorType type, int64_t* (*allocator)(size_t length));
 
 EXPORT_API(void) THSJIT_Type_dispose(const JITType type);
 EXPORT_API(void) THSJIT_TensorType_dispose(const JITTensorType type);


### PR DESCRIPTION
All the other functions with an allocator use size_t. In addition, the `sz` variable in the implementation is `size_t`, and the p/invoke method in `LibTorchSharp.THSJIT.cs` uses the same delegate as the others.