### PR TITLE
Rename parameters in native code to be more standardized

### DIFF
--- a/src/Native/LibTorchSharp/THSJIT.cpp
+++ b/src/Native/LibTorchSharp/THSJIT.cpp
@@ -130,11 +130,11 @@ void THSJIT_Module_modules(const JITModule module, JITModule* (*allocator)(size_
 }
 
 void THSJIT_Module_named_modules(const JITModule module,
-    JITModule* (*allocator)(size_t length),
+    JITModule* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length))
 {
     auto modules = (*module)->named_modules();
-    JITModule* result = allocator(modules.size());
+    JITModule* result = allocator1(modules.size());
     const char** names = allocator2(modules.size());
     int i = 0;
     for (const auto& child : modules) {
@@ -146,11 +146,11 @@ void THSJIT_Module_named_modules(const JITModule module,
 }
 
 void THSJIT_Module_named_children(const JITModule module,
-    JITModule* (*allocator)(size_t length),
+    JITModule* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length))
 {
     auto modules = (*module)->named_children();
-    JITModule* result = allocator(modules.size());
+    JITModule* result = allocator1(modules.size());
     const char** names = allocator2(modules.size());
     int i = 0;
     for (const auto& child : modules) {
@@ -172,11 +172,11 @@ void THSJIT_Module_parameters(const JITModule module, Tensor* (*allocator)(size_
 }
 
 void THSJIT_Module_named_parameters(const JITModule module,
-    Tensor* (*allocator)(size_t length),
+    Tensor* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length))
 {
     auto parameters = (*module)->named_parameters();
-    Tensor* result = allocator(parameters.size());
+    Tensor* result = allocator1(parameters.size());
     const char** names = allocator2(parameters.size());
     int i = 0;
     for (const auto& child : parameters) {
@@ -187,11 +187,11 @@ void THSJIT_Module_named_parameters(const JITModule module,
 }
 
 void THSJIT_Module_named_buffers(const JITModule module,
-    Tensor* (*allocator)(size_t length),
+    Tensor* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length))
 {
     auto parameters = (*module)->named_buffers();
-    Tensor* result = allocator(parameters.size());
+    Tensor* result = allocator1(parameters.size());
     const char** names = allocator2(parameters.size());
     int i = 0;
     for (const auto& child : parameters) {
@@ -202,11 +202,11 @@ void THSJIT_Module_named_buffers(const JITModule module,
 }
 
 void THSJIT_Module_named_attributes(const JITModule module, bool recurse,
-    Tensor* (*allocator)(size_t length),
+    Tensor* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length))
 {
     auto attributes = (*module)->named_attributes(recurse);
-    Tensor* result = allocator(attributes.size());
+    Tensor* result = allocator1(attributes.size());
     const char** names = allocator2(attributes.size());
     int i = 0;
     for (const auto& child : attributes) {

--- a/src/Native/LibTorchSharp/THSJIT.h
+++ b/src/Native/LibTorchSharp/THSJIT.h
@@ -65,26 +65,26 @@ EXPORT_API(void) THSJIT_TensorType_dispose(const JITTensorType type);
 
 EXPORT_API(void) THSJIT_Module_modules(const JITModule module, JITModule* (*allocator)(size_t length));
 EXPORT_API(void) THSJIT_Module_named_modules(const JITModule module,
-    JITModule* (*allocator)(size_t length),
+    JITModule* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length));
 
 EXPORT_API(void) THSJIT_Module_named_children(const JITModule module,
-    JITModule* (*allocator)(size_t length),
+    JITModule* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length));
 
 EXPORT_API(JITMethod) THSJIT_Module_get_method(const JITModule module, const char* name);
 
 EXPORT_API(void) THSJIT_Module_parameters(const JITModule module, Tensor* (*allocator)(size_t length));
 EXPORT_API(void) THSJIT_Module_named_parameters(const JITModule module,
-    Tensor* (*allocator)(size_t length),
+    Tensor* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length));
 
 EXPORT_API(void) THSJIT_Module_named_buffers(const JITModule module,
-    Tensor* (*allocator)(size_t length),
+    Tensor* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length));
 
 EXPORT_API(void) THSJIT_Module_named_attributes(const JITModule module, bool recurse,
-    Tensor* (*allocator)(size_t length),
+    Tensor* (*allocator1)(size_t length),
     const char** (*allocator2)(size_t length));
 
 EXPORT_API(void) THSJIT_Module_set_attribute(const JITModule module, const char* name, Tensor tensor);

--- a/src/Native/LibTorchSharp/THSModule.cpp
+++ b/src/Native/LibTorchSharp/THSModule.cpp
@@ -98,10 +98,10 @@ Tensor THSNN_Module_get_parameter(const NNModule module, const char* name)
     CATCH_TENSOR(*(*module)->named_parameters().find(name));
 }
 
-void THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator1)(size_t length), bool recurse)
+void THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator)(size_t length), bool recurse)
 {
     auto parameters = (*module)->parameters(recurse);
-    Tensor* result1 = allocator1(parameters.size());
+    Tensor* result1 = allocator(parameters.size());
 
     for (size_t i = 0; i < parameters.size(); i++)
     {

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -15,7 +15,7 @@ EXPORT_API(void)        THSNN_Module_get_named_parameters(const NNModule module,
 EXPORT_API(void)        THSNN_Module_get_named_buffers(const NNModule module, Tensor* (*allocator1)(size_t length), const char** (*allocator2)(size_t length));
 EXPORT_API(void)        THSNN_Module_get_named_children(const NNModule module, NNModule* (*allocator1)(size_t length), const char** (*allocator2)(size_t length));
 EXPORT_API(void)        THSNN_Module_get_named_modules(const NNModule module, NNModule* (*allocator1)(size_t length), const char** (*allocator2)(size_t length));
-EXPORT_API(void)        THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator1)(size_t length), bool recurse);
+EXPORT_API(void)        THSNN_Module_get_parameters(const NNModule module, Tensor* (*allocator)(size_t length), bool recurse);
 EXPORT_API(bool)         THSNN_Module_is_training(NNModule module);
 EXPORT_API(void)        THSNN_Module_train(NNModule module, bool on);
 EXPORT_API(size_t)      THSNN_Module_children_size(const NNModule module);


### PR DESCRIPTION
This aligns parameter naming for these functions with the rest of the project.

See also: https://github.com/AssetRipper/AssetRipper.Bindings.LibTorchSharp/blob/a76753d26df195f667c003f8f10b3085882168a0/AssetRipper.Bindings.LibTorchSharp.SourceGenerator/ParameterNameChanges.cs#L7-L12