### PR TITLE
Add Tensor.to_sparse() API for sparse COO tensor conversion

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -1871,6 +1871,16 @@ Tensor THSTensor_to_dense(Tensor tensor)
     CATCH_TENSOR(tensor->to_dense());
 }
 
+Tensor THSTensor_to_sparse(Tensor tensor)
+{
+    CATCH_TENSOR(tensor->to_sparse());
+}
+
+Tensor THSTensor_to_sparse_with_dims(Tensor tensor, const int64_t sparse_dim)
+{
+    CATCH_TENSOR(tensor->to_sparse(sparse_dim));
+}
+
 void THSTensor_set_(Tensor tensor, const Tensor source)
 {
     CATCH(tensor->set_(*source););

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1396,6 +1396,9 @@ EXPORT_API(Tensor) THSTensor_trapezoid_dx(const Tensor y, const double dx, int64
 
 EXPORT_API(Tensor) THSTensor_to_dense(Tensor tensor);
 
+EXPORT_API(Tensor) THSTensor_to_sparse(Tensor tensor);
+EXPORT_API(Tensor) THSTensor_to_sparse_with_dims(Tensor tensor, const int64_t sparse_dim);
+
 EXPORT_API(Tensor) THSTensor_to_device(const Tensor tensor, const int device_type, const int device_index, const bool copy, const bool non_blocking);
 
 EXPORT_API(Tensor) THSTensor_to_type(const Tensor tensor, int8_t scalar_type, const bool copy, const bool non_blocking);

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
@@ -377,6 +377,12 @@ namespace TorchSharp.PInvoke
         internal static extern IntPtr THSTensor_to_dense(IntPtr handle);
 
         [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_sparse(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_sparse_with_dims(IntPtr handle, long sparse_dim);
+
+        [DllImport("LibTorchSharp")]
         internal static extern IntPtr THSTensor_clone(IntPtr handle);
 
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -1379,6 +1379,29 @@ namespace TorchSharp
             }
 
             /// <summary>
+            /// Converts a dense tensor to a sparse COO tensor.
+            /// </summary>
+            public Tensor to_sparse()
+            {
+                var res = NativeMethods.THSTensor_to_sparse(Handle);
+                if (res == IntPtr.Zero)
+                    CheckForErrors();
+                return new Tensor(res);
+            }
+
+            /// <summary>
+            /// Converts a dense tensor to a sparse COO tensor with the specified number of sparse dimensions.
+            /// </summary>
+            /// <param name="sparse_dim">The number of sparse dimensions.</param>
+            public Tensor to_sparse(int sparse_dim)
+            {
+                var res = NativeMethods.THSTensor_to_sparse_with_dims(Handle, sparse_dim);
+                if (res == IntPtr.Zero)
+                    CheckForErrors();
+                return new Tensor(res);
+            }
+
+            /// <summary>
             /// Returns a copy of the tensor input.
             /// </summary>
             public Tensor clone()


### PR DESCRIPTION
Add to_sparse() and to_sparse(int sparse_dim) methods to convert dense tensors to sparse COO format. This enables GCN and GAT graph neural network examples that require sparse matrix operations.

Changes across all 4 binding layers:
- THSTensor.h: declarations
- THSTensor.cpp: implementations
- LibTorchSharp.THSTensor.cs: P/Invoke
- Tensor.cs: managed C# methods