### PR TITLE
Replace deprecated libtorch APIs with torch::linalg equivalents

### DIFF
--- a/src/Native/LibTorchSharp/THSLinearAlgebra.cpp
+++ b/src/Native/LibTorchSharp/THSLinearAlgebra.cpp
@@ -351,14 +351,16 @@ Tensor THSLinalg_vecdot(const Tensor x, const Tensor y, const int64_t dim, Tenso
     CATCH_TENSOR(out == nullptr ? torch::linalg_vecdot(* x, *y, dim) : torch::linalg_vecdot_out(*out, *x, *y, dim))
 }
 
-Tensor THSTensor_lu_solve(const Tensor B, const Tensor LU, const Tensor pivots, bool left, bool adjoint, Tensor out)
+Tensor THSLinalg_lu_solve(const Tensor B, const Tensor LU, const Tensor pivots, bool left, bool adjoint, Tensor out)
 {
     CATCH_TENSOR(out == nullptr ? torch::linalg_lu_solve(*LU, *pivots, *B, left, adjoint) : torch::linalg_lu_solve_out(*out, *LU, *pivots, *B, left, adjoint))
 }
 
 Tensor THSTensor_cholesky(const Tensor tensor, const bool upper)
 {
-    CATCH_TENSOR(tensor->cholesky(upper))
+    // torch::cholesky is deprecated in favor of torch::linalg_cholesky.
+    // linalg_cholesky always returns lower-triangular; use .mH() for upper.
+    CATCH_TENSOR(upper ? torch::linalg_cholesky(*tensor).mH() : torch::linalg_cholesky(*tensor))
 }
 
 Tensor THSTensor_cholesky_inverse(const Tensor tensor, const bool upper)
@@ -441,7 +443,9 @@ Tensor THSTensor_lu(const Tensor tensor, bool pivot, bool get_infos, Tensor* inf
 
 Tensor THSTensor_lu_solve(const Tensor tensor, const Tensor LU_data, const Tensor LU_pivots)
 {
-    CATCH_TENSOR(tensor->lu_solve(*LU_data, *LU_pivots))
+    // tensor.lu_solve is deprecated in favor of torch::linalg_lu_solve.
+    // Note: linalg_lu_solve arg order is (LU, pivots, B).
+    CATCH_TENSOR(torch::linalg_lu_solve(*LU_data, *LU_pivots, *tensor))
 }
 
 Tensor THSTensor_lu_unpack(const Tensor LU_data, const Tensor LU_pivots, bool unpack_data, bool unpack_pivots, Tensor* L, Tensor* U)

--- a/src/Native/LibTorchSharp/THSLinearAlgebra.cpp
+++ b/src/Native/LibTorchSharp/THSLinearAlgebra.cpp
@@ -359,7 +359,8 @@ Tensor THSLinalg_lu_solve(const Tensor B, const Tensor LU, const Tensor pivots, 
 Tensor THSTensor_cholesky(const Tensor tensor, const bool upper)
 {
     // torch::cholesky is deprecated in favor of torch::linalg_cholesky.
-    // linalg_cholesky always returns lower-triangular; use .mH() for upper.
+    // Here we call torch::linalg_cholesky with its default (lower-triangular) output,
+    // and return its conjugate transpose via .mH() when upper is true.
     CATCH_TENSOR(upper ? torch::linalg_cholesky(*tensor).mH() : torch::linalg_cholesky(*tensor))
 }
 

--- a/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
+++ b/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
@@ -64,6 +64,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="upper">If upper is true, the returned matrix U is upper-triangular. If upper is false, the returned matrix L is lower-triangular</param>
             /// <returns></returns>
+            [Obsolete("torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be removed in a future release. Use torch.linalg.cholesky instead.", false)]
             public Tensor cholesky(bool upper = false)
             {
                 var res = THSTensor_cholesky(Handle, upper);

--- a/src/TorchSharp/Tensor/torch.BlasAndLapackOperations.cs
+++ b/src/TorchSharp/Tensor/torch.BlasAndLapackOperations.cs
@@ -131,7 +131,10 @@ namespace TorchSharp
 
         // https://pytorch.org/docs/stable/generated/torch.cholesky
 
+        [Obsolete("torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be removed in a future release. Use torch.linalg.cholesky instead.", false)]
+#pragma warning disable CS0618 // Obsolete
         public static Tensor cholesky(Tensor input) => input.cholesky();
+#pragma warning restore CS0618
 
         // https://pytorch.org/docs/stable/generated/torch.cholesky_inverse
         /// <summary>
@@ -250,6 +253,7 @@ namespace TorchSharp
         /// The pivots of the LU factorization from torch.lu() of size (∗,m), where *∗ is zero or more batch dimensions.
         /// The batch dimensions of LU_pivots must be equal to the batch dimensions of LU_data.</param>
         /// <returns></returns>
+        [Obsolete("torch.lu_solve is deprecated in favor of torch.linalg.lu_solve and will be removed in a future release. Use torch.linalg.lu_solve(LU, pivots, B) instead.", false)]
         public static Tensor lu_solve(Tensor b, Tensor LU_data, Tensor LU_pivots)
         {
             var solution = THSTensor_lu_solve(b.Handle, LU_data.Handle, LU_pivots.Handle);

--- a/src/TorchSharp/Tensor/torch.cs
+++ b/src/TorchSharp/Tensor/torch.cs
@@ -16,7 +16,10 @@ namespace TorchSharp
         /// <param name="input">The input matrix</param>
         /// <param name="upper">If upper is true, the returned matrix U is upper-triangular. If upper is false, the returned matrix L is lower-triangular</param>
         /// <returns></returns>
+        [Obsolete("torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be removed in a future release. Use torch.linalg.cholesky instead.", false)]
+#pragma warning disable CS0618 // Obsolete
         public static Tensor cholesky(Tensor input, bool upper) => input.cholesky(upper);
+#pragma warning restore CS0618
 
         /// <summary>
         /// Returns the matrix norm or vector norm of a given tensor.

--- a/test/TorchSharpTest/LinearAlgebra.cs
+++ b/test/TorchSharpTest/LinearAlgebra.cs
@@ -49,7 +49,7 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 2, 3, 3 }, A_LU.shape);
                 Assert.Equal(new long[] { 2, 3 }, pivots.shape);
 
-                var x = lu_solve(b, A_LU, pivots);
+                var x = linalg.lu_solve(A_LU, pivots, b);
                 Assert.Equal(new long[] { 2, 3, 1 }, x.shape);
 
                 var y = norm(bmm(A, x) - b);
@@ -67,7 +67,7 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 2, 3 }, pivots.shape);
                 Assert.Equal(new long[] { 2 }, infos.shape);
 
-                var x = lu_solve(b, A_LU, pivots);
+                var x = linalg.lu_solve(A_LU, pivots, b);
                 Assert.Equal(new long[] { 2, 3, 1 }, x.shape);
 
                 var y = norm(bmm(A, x) - b);

--- a/test/TorchSharpTest/LinearAlgebra.cs
+++ b/test/TorchSharpTest/LinearAlgebra.cs
@@ -306,6 +306,20 @@ namespace TorchSharp
         }
 
         [Fact]
+        [TestOf(nameof(Tensor.cholesky))]
+        public void CholeskyUpperTest()
+        {
+            var a = randn(new long[] { 3, 2, 2 }, float64);
+            a = a.matmul(a.swapdims(-2, -1));
+#pragma warning disable CS0618 // Obsolete
+            var u = a.cholesky(upper: true);
+#pragma warning restore CS0618
+
+            // U should be upper-triangular: U^T * U == A
+            Assert.True(a.allclose(u.swapaxes(-2, -1).matmul(u)));
+        }
+
+        [Fact]
         [TestOf(nameof(linalg.cholesky_ex))]
         public void CholeskyExTest()
         {

--- a/test/TorchSharpTest/LinearAlgebra.cs
+++ b/test/TorchSharpTest/LinearAlgebra.cs
@@ -315,7 +315,7 @@ namespace TorchSharp
             var u = a.cholesky(upper: true);
 #pragma warning restore CS0618
 
-            // U should be upper-triangular: U^T * U == A
+            // U should be upper-triangular: for real inputs U^T * U == A (more generally, U^H * U == A)
             Assert.True(a.allclose(u.swapaxes(-2, -1).matmul(u)));
         }
 

--- a/test/TorchSharpTest/LinearAlgebra.cs
+++ b/test/TorchSharpTest/LinearAlgebra.cs
@@ -316,7 +316,7 @@ namespace TorchSharp
 #pragma warning restore CS0618
 
             // U should be upper-triangular: for real inputs U^T * U == A (more generally, U^H * U == A)
-            Assert.True(a.allclose(u.swapaxes(-2, -1).matmul(u)));
+            Assert.True(a.allclose(u.mH.matmul(u)));
         }
 
         [Fact]


### PR DESCRIPTION
- THSTensor_cholesky: Replace tensor->cholesky(upper) with torch::linalg_cholesky, using .mH() for upper-triangular results
- THSTensor_lu_solve: Replace tensor->lu_solve() with torch::linalg_lu_solve
- Fix THSLinalg_lu_solve naming bug (was incorrectly named THSTensor_lu_solve)
- Add [Obsolete] attributes to C# wrappers for cholesky() and lu_solve()
- Update tests to use linalg.lu_solve instead of deprecated lu_solve