### PR TITLE
Move null checking to compiler-side using nullable annotations

### DIFF
--- a/src/TorchSharp/Distributions/Transforms.cs
+++ b/src/TorchSharp/Distributions/Transforms.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
 namespace TorchSharp
 {
 
@@ -26,11 +27,11 @@ namespace TorchSharp
                 {
                     protected bool _bijective = false;
 
-                    protected constraints.Constraint _domain;
+                    protected constraints.Constraint _domain = null!;
 
-                    protected constraints.Constraint _codomain;
+                    protected constraints.Constraint _codomain = null!;
 
-                    protected Transform _inv = null;
+                    protected Transform? _inv = null;
 
                     public virtual int event_dim {
                         get {
@@ -42,7 +43,7 @@ namespace TorchSharp
 
                     public virtual Transform inv {
                         get {
-                            Transform result = null;
+                            Transform? result = null;
                             if (this._inv != null)
                                 result = _inv;
                             if (result == null) {
@@ -118,19 +119,19 @@ namespace TorchSharp
 
                     public override constraints.Constraint domain {
                         get {
-                            return _inv.domain;
+                            return _inv!.domain;
                         }
                     }
 
                     public override constraints.Constraint codomain {
                         get {
-                            return _inv.codomain;
+                            return _inv!.codomain;
                         }
                     }
 
                     public override bool bijective {
                         get {
-                            return _inv.bijective;
+                            return _inv!.bijective;
                         }
                     }
 
@@ -140,32 +141,32 @@ namespace TorchSharp
 
                     protected internal override Tensor log_abs_det_jacobian(Tensor x, Tensor y)
                     {
-                        return -_inv.log_abs_det_jacobian(y, x);
+                        return -_inv!.log_abs_det_jacobian(y, x);
                     }
 
                     protected internal override Tensor _call(Tensor x)
                     {
-                        return _inv._inverse(x);
+                        return _inv!._inverse(x);
                     }
 
                     protected internal override Tensor _inverse(Tensor y)
                     {
-                        return _inv._call(y);
+                        return _inv!._call(y);
                     }
 
                     protected internal override Tensor _sign()
                     {
-                        return _inv.sign;
+                        return _inv!.sign;
                     }
 
                     public override long[] forward_shape(long[] shape)
                     {
-                        return _inv.forward_shape(shape);
+                        return _inv!.forward_shape(shape);
                     }
 
                     public override long[] inverse_shape(long[] shape)
                     {
-                        return _inv.inverse_shape(shape);
+                        return _inv!.inverse_shape(shape);
                     }
                 }
 
@@ -173,8 +174,6 @@ namespace TorchSharp
                 {
                     public ComposeTransform(IEnumerable<Transform> parts, int cache_size = 0)
                     {
-                        if (parts == null) throw new ArgumentNullException("parts cannot be null");
-
                         _parts = parts.ToArray();
                         _reverse_parts = parts.Reverse().ToArray();
                     }
@@ -186,13 +185,13 @@ namespace TorchSharp
 
                     public override Transform inv {
                         get {
-                            Transform i = _inv;
+                            Transform? i = _inv;
 
                             if (i == null) {
                                 i = new ComposeTransform(_reverse_parts.Select(p => p.inv));
                                 _inv = i;
                             }
-                            return _inv;
+                            return _inv!;
                         }
                     }
 

--- a/src/TorchSharp/NN/Activation/PReLU.cs
+++ b/src/TorchSharp/NN/Activation/PReLU.cs
@@ -40,7 +40,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -60,7 +60,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Convolution/Convolution.cs
+++ b/src/TorchSharp/NN/Convolution/Convolution.cs
@@ -145,7 +145,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static TorchSharp.torch;
 using static TorchSharp.PInvoke.NativeMethods;
 
@@ -21,6 +22,7 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
+            [DisallowNull]
             public Parameter? weight {
                 get {
                     var res = THSNN_Embedding_weight(handle);
@@ -28,9 +30,7 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight cannot be set to 'null'");
-                    THSNN_Embedding_set_weight(handle, value is null ? IntPtr.Zero : value.Handle);
+                    THSNN_Embedding_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight", value);
                 }

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static TorchSharp.torch;
 using static TorchSharp.PInvoke.NativeMethods;
 
@@ -82,6 +83,7 @@ namespace TorchSharp
                 return base.call(input, null, null);
             }
 
+            [DisallowNull]
             public Parameter? weight {
                 get {
                     var res = THSNN_EmbeddingBag_weight(handle);
@@ -89,9 +91,7 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight cannot be set to 'null'");
-                    THSNN_EmbeddingBag_set_weight(handle, value is null ? IntPtr.Zero : value.Handle);
+                    THSNN_EmbeddingBag_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight", value);
                 }

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -70,7 +70,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -697,7 +697,6 @@ namespace TorchSharp
                 /// <returns>The tensor referenced by target</returns>
                 public virtual Tensor? get_buffer(string target)
                 {
-                    if (target is null) throw new ArgumentNullException("target");
                     if (_internal_buffers.TryGetValue(target, out var buffer)) {
                         return buffer.Item1;
                     }

--- a/src/TorchSharp/NN/Normalization/GroupNorm.cs
+++ b/src/TorchSharp/NN/Normalization/GroupNorm.cs
@@ -57,7 +57,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Normalization/LayerNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LayerNorm.cs
@@ -75,7 +75,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Normalization/NormBase.cs
+++ b/src/TorchSharp/NN/Normalization/NormBase.cs
@@ -87,7 +87,6 @@ namespace TorchSharp
             public Parameter weight {
                 get => _weight!;
                 set {
-                    if (value is null) throw new ArgumentNullException(nameof(weight));
                     if (value.Handle != _weight?.Handle) {
                         _weight?.Dispose();
                         _weight = (value.DetachFromDisposeScope() as Parameter)!;

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using static TorchSharp.PInvoke.NativeMethods;
@@ -28,6 +29,7 @@ namespace TorchSharp
                 return new Tensor(hN);
             }
 
+            [DisallowNull]
             public Parameter? bias_ih {
                 get {
                     var res = THSNN_GRUCell_bias_ih(handle);
@@ -35,14 +37,13 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("bias_ih cannot be set to 'null'");
-                    THSNN_GRUCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_GRUCell_set_bias_ih(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias_ih", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? bias_hh {
                 get {
                     var res = THSNN_GRUCell_bias_hh(handle);
@@ -50,14 +51,13 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("bias_hh cannot be set to 'null'");
-                    THSNN_GRUCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_GRUCell_set_bias_hh(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias_hh", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? weight_ih {
                 get {
                     var res = THSNN_GRUCell_weight_ih(handle);
@@ -65,14 +65,13 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight_ih cannot be set to 'null'");
-                    THSNN_GRUCell_set_weight_ih(handle, value is null ? IntPtr.Zero : value.Handle);
+                    THSNN_GRUCell_set_weight_ih(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight_ih", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? weight_hh {
                 get {
                     var res = THSNN_GRUCell_weight_hh(handle);
@@ -80,9 +79,7 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight_hh cannot be set to 'null'");
-                    THSNN_GRUCell_set_weight_hh(handle, value is null ? IntPtr.Zero : value.Handle);
+                    THSNN_GRUCell_set_weight_hh(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight_hh", value);
                 }

--- a/src/TorchSharp/NN/Recurrent/LSTMCell.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTMCell.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using static TorchSharp.PInvoke.NativeMethods;
@@ -30,6 +31,7 @@ namespace TorchSharp
 
             public new (Tensor, Tensor) call(Tensor input, (Tensor, Tensor)? h0_c0 = null) => base.call(input, h0_c0);
 
+            [DisallowNull]
             public Parameter? bias_ih {
                 get {
                     var res = THSNN_LSTMCell_bias_ih(handle);
@@ -37,14 +39,13 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("bias_ih cannot be set to 'null'");
-                    THSNN_LSTMCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_LSTMCell_set_bias_ih(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias_ih", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? bias_hh {
                 get {
                     var res = THSNN_LSTMCell_bias_hh(handle);
@@ -52,14 +53,13 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("bias_hh cannot be set to 'null'");
-                    THSNN_LSTMCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_LSTMCell_set_bias_hh(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias_hh", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? weight_ih {
                 get {
                     var res = THSNN_LSTMCell_weight_ih(handle);
@@ -67,14 +67,13 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight_ih cannot be set to 'null'");
-                    THSNN_LSTMCell_set_weight_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_LSTMCell_set_weight_ih(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight_ih", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? weight_hh {
                 get {
                     var res = THSNN_LSTMCell_weight_hh(handle);
@@ -82,9 +81,7 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight_hh cannot be set to 'null'");
-                    THSNN_LSTMCell_set_weight_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_LSTMCell_set_weight_hh(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight_hh", value);
                 }

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using static TorchSharp.PInvoke.NativeMethods;
@@ -30,6 +31,7 @@ namespace TorchSharp
                 return new Tensor(hN);
             }
 
+            [DisallowNull]
             public Parameter? bias_ih {
                 get {
                     var res = THSNN_RNNCell_bias_ih(handle);
@@ -37,15 +39,14 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("bias_ih cannot be set to 'null'");
-                    THSNN_RNNCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_RNNCell_set_bias_ih(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias_ih", value);
 
                 }
             }
 
+            [DisallowNull]
             public Parameter? bias_hh {
                 get {
                     var res = THSNN_RNNCell_bias_hh(handle);
@@ -53,15 +54,14 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("bias_hh cannot be set to 'null'");
-                    THSNN_RNNCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_RNNCell_set_bias_hh(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias_hh", value);
 
                 }
             }
 
+            [DisallowNull]
             public Parameter? weight_ih {
                 get {
                     var res = THSNN_RNNCell_weight_ih(handle);
@@ -69,14 +69,13 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight_ih cannot be set to 'null'");
-                    THSNN_RNNCell_set_weight_ih(handle, value is null ? IntPtr.Zero : value.Handle);
+                    THSNN_RNNCell_set_weight_ih(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight_ih", value);
                 }
             }
 
+            [DisallowNull]
             public Parameter? weight_hh {
                 get {
                     var res = THSNN_RNNCell_weight_hh(handle);
@@ -84,9 +83,7 @@ namespace TorchSharp
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    // Please ignore, for now, that the litorch call thinks you *can* set it to null.
-                    if (value is null) throw new ArgumentNullException("weight_hh cannot be set to 'null'");
-                    THSNN_RNNCell_set_weight_hh(handle, value is null ? IntPtr.Zero : value.Handle);
+                    THSNN_RNNCell_set_weight_hh(handle, value.Handle);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("weight_hh", value);
                 }

--- a/src/TorchSharp/netstandard.cs
+++ b/src/TorchSharp/netstandard.cs
@@ -402,6 +402,12 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets the return value condition.</summary>
         public bool ReturnValue { get; }
     }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute
+    {
+        public DisallowNullAttribute() { }
+    }
 }
 
 namespace System.Linq


### PR DESCRIPTION
- Remove redundant runtime null checks from non-nullable Parameter weight setters in Linear, Bilinear, Convolution, PReLU, GroupNorm, LayerNorm, and NormBase (already enforced by #nullable enable)
- Add [DisallowNull] to Parameter? properties in RNNCell, LSTMCell, GRUCell, Embedding, and EmbeddingBag where getter can return null but setter must not accept null
- Enable #nullable enable in Transforms.cs and remove runtime null check from ComposeTransform constructor
- Remove runtime null check from Module.get_buffer() (string parameter is non-nullable under #nullable enable)
- Add DisallowNullAttribute polyfill in netstandard.cs for netstandard2.0 compatibility