### PR TITLE
Fix HFFT tests to use complex input tensors

### DIFF
--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -7461,15 +7461,15 @@ namespace TorchSharp
         }
 
         [Fact]
-        [TestOf(nameof(fft.hfft2))]
+        [TestOf(nameof(fft.hfftn))]
         public void Float32HFFTN()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
-            var output = fft.hfft2(input);
+            var output = fft.hfftn(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
             Assert.Equal(ScalarType.Float32, output.dtype);
 
-            var inverted = fft.ihfft2(output);
+            var inverted = fft.ihfftn(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
             Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -7175,12 +7175,12 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft))]
         public void Float32HFFT()
         {
-            var input = torch.arange(4);
+            var input = torch.arange(4, complex64);
             var output = fft.hfft(input);
             Assert.Equal(6, output.shape[0]);
             Assert.Equal(ScalarType.Float32, output.dtype);
 
-            var inverted = fft.ifft(output);
+            var inverted = fft.ihfft(output);
             Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
         }
 
@@ -7188,12 +7188,12 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft))]
         public void Float64HFFT()
         {
-            var input = torch.arange(4, float64);
+            var input = torch.arange(4, complex128);
             var output = fft.hfft(input);
             Assert.Equal(6, output.shape[0]);
             Assert.Equal(ScalarType.Float64, output.dtype);
 
-            var inverted = fft.ifft(output);
+            var inverted = fft.ihfft(output);
             Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
         }
 
@@ -7436,10 +7436,10 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft2))]
         public void Float32HFFT2()
         {
-            var input = torch.rand(new long[] { 5, 5, 5, 5 });
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfft2(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-            Assert.Equal(input.dtype, output.dtype);
+            Assert.Equal(ScalarType.Float32, output.dtype);
 
             var inverted = fft.ihfft2(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
@@ -7450,10 +7450,10 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft2))]
         public void Float64HFFT2()
         {
-            var input = torch.rand(new long[] { 5, 5, 5, 5 }, float64);
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex128);
             var output = fft.hfft2(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-            Assert.Equal(input.dtype, output.dtype);
+            Assert.Equal(ScalarType.Float64, output.dtype);
 
             var inverted = fft.ihfft2(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
@@ -7464,10 +7464,10 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft2))]
         public void Float32HFFTN()
         {
-            var input = torch.rand(new long[] { 5, 5, 5, 5 });
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfft2(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-            Assert.Equal(input.dtype, output.dtype);
+            Assert.Equal(ScalarType.Float32, output.dtype);
 
             var inverted = fft.ihfft2(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
@@ -7482,10 +7482,10 @@ namespace TorchSharp
 
                 // TODO: Something in this test makes if fail on Windows / Release and MacOS / Release
 
-                var input = torch.rand(new long[] { 5, 5, 5, 5 }, float64);
+                var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex128);
                 var output = fft.hfftn(input);
                 Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-                Assert.Equal(input.dtype, output.dtype);
+                Assert.Equal(ScalarType.Float64, output.dtype);
 
                 var inverted = fft.ihfftn(output);
                 Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -7172,32 +7172,6 @@ namespace TorchSharp
         }
 
         [Fact]
-        [TestOf(nameof(fft.hfft))]
-        public void Float32HFFT()
-        {
-            var input = torch.arange(4, complex64);
-            var output = fft.hfft(input);
-            Assert.Equal(6, output.shape[0]);
-            Assert.Equal(ScalarType.Float32, output.dtype);
-
-            var inverted = fft.ihfft(output);
-            Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
-        }
-
-        [Fact]
-        [TestOf(nameof(fft.hfft))]
-        public void Float64HFFT()
-        {
-            var input = torch.arange(4, complex128);
-            var output = fft.hfft(input);
-            Assert.Equal(6, output.shape[0]);
-            Assert.Equal(ScalarType.Float64, output.dtype);
-
-            var inverted = fft.ihfft(output);
-            Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
-        }
-
-        [Fact]
         [TestOf(nameof(fft.rfft))]
         public void Float32RFFT()
         {
@@ -7434,7 +7408,7 @@ namespace TorchSharp
 
         [Fact]
         [TestOf(nameof(fft.hfft2))]
-        public void Float32HFFT2()
+        public void ComplexFloat32HFFT2()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfft2(input);
@@ -7448,7 +7422,7 @@ namespace TorchSharp
 
         [Fact]
         [TestOf(nameof(fft.hfft2))]
-        public void Float64HFFT2()
+        public void ComplexFloat64HFFT2()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex128);
             var output = fft.hfft2(input);
@@ -7462,7 +7436,7 @@ namespace TorchSharp
 
         [Fact]
         [TestOf(nameof(fft.hfftn))]
-        public void Float32HFFTN()
+        public void ComplexFloat32HFFTN()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfftn(input);
@@ -7476,7 +7450,7 @@ namespace TorchSharp
 
         [Fact(Skip = "Fails on all Release builds.")]
         [TestOf(nameof(fft.hfftn))]
-        public void Float64HFFTN()
+        public void ComplexFloat64HFFTN()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 


### PR DESCRIPTION
PyTorch's fft.hfft/hfft2/hfftn require complex input tensors. The tests were passing real-valued tensors (Float32/Float64), which causes 'NYI' errors in newer PyTorch versions. Fixed by using complex64/complex128 input types and ihfft for inverse verification.