### PR TITLE
ci: add automated issue triage bot using GitHub Models

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,10 +12,12 @@ on:
 
 permissions:
   issues: write
+  models: read
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add a GitHub Actions workflow that automatically triages new issues by classifying them with gpt-4o-mini via GitHub Models and applying the appropriate label (bug, Missing Feature, question, enhancement, or breaking-change). Also posts a polite acknowledgment comment.

Features:
- Triggers on new issues and manual workflow dispatch
- Skips issues that already have triage labels (respects manual labels)
- Sanitizes LLM output to prevent markdown injection
- Robust error handling with timeouts and descriptive messages