### PR TITLE
Fix modules ignoring default device when created via native P/Invoke …

### DIFF
--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -1138,10 +1138,8 @@ namespace TorchSharp
                 internal T MoveModule<T>(Device? device, ScalarType? dtype) where T : Module
                 {
                     T module = (T)this;
-
-                    return device != null ?
-                       (dtype.HasValue ? (T)module._to(device, dtype.Value, false) : (T)module._to(device.type, device.index, false)) :
-                       (dtype.HasValue ? (T)module._to(dtype.Value, false) : module);
+                    var (targetDevice, targetDtype) = GetDefaultDeviceAndType(device, dtype);
+                    return (T)module._to(targetDevice, targetDtype, false);
                 }
 
                 protected void ClearModules() { _internal_submodules.clear(); }


### PR DESCRIPTION
Fixes #1438 

MoveModule<T>() was returning modules unchanged when device=null, instead of resolving to torch.get_default_device(). This caused Embedding, EmbeddingBag, LSTM, GRU, RNN, LSTMCell, GRUCell, RNNCell, and PReLU to always be created on CPU regardless of the default device setting.

Fix MoveModule to use GetDefaultDeviceAndType() to resolve defaults, aligning behavior with managed modules like Linear and Conv2d.