### PR TITLE
Fix affine() IndexError with boolean mask indexing

### DIFF
--- a/src/Native/LibTorchSharp/THSVision.cpp
+++ b/src/Native/LibTorchSharp/THSVision.cpp
@@ -184,7 +184,7 @@ Tensor THSVision_ApplyGridTransform(Tensor i, Tensor g, const int8_t m, const fl
 
             if (m == 0) {
                 mask = mask < 0.5;
-                img[mask] = fill_img[mask];
+                img = torch::where(mask, fill_img, img);
             }
             else {
                 img = img * mask + (-mask + 1.0) * fill_img;

--- a/test/TorchSharpTest/TestTorchVision.cs
+++ b/test/TorchSharpTest/TestTorchVision.cs
@@ -1144,6 +1144,60 @@ namespace TorchVision
         }
 
         [Fact]
+        public void TestAffineTransform3D()
+        {
+            // 3D input: [C, H, W]
+            var img = torch.rand(new long[] { 1, 48, 48 });
+            var result = functional.affine(
+                img,
+                angle: 0f,
+                translate: new[] { 0, 0 },
+                scale: 1f,
+                shear: new[] { 1f, 1f },
+                fill: 0);
+            Assert.Equal(img.shape, result.shape);
+        }
+
+        [Fact]
+        public void TestAffineTransform4D()
+        {
+            // 4D input: [N, C, H, W] — reproduces issue #1502
+            var img = torch.rand(new long[] { 1, 1, 48, 48 });
+            var result = functional.affine(
+                img,
+                angle: 0f,
+                translate: new[] { 0, 0 },
+                scale: 1f,
+                shear: new[] { 1f, 1f },
+                fill: 0);
+            Assert.Equal(img.shape, result.shape);
+        }
+
+        [Fact]
+        public void TestAffineTransform4DBatch()
+        {
+            // 4D input with batch > 1
+            var img = torch.rand(new long[] { 4, 3, 32, 32 });
+            var result = functional.affine(
+                img,
+                angle: 15f,
+                translate: new[] { 5, 5 },
+                scale: 0.9f,
+                shear: new[] { 10f, 5f },
+                fill: 0);
+            Assert.Equal(img.shape, result.shape);
+        }
+
+        [Fact]
+        public void TestRotateWithFill()
+        {
+            // Rotate with fill also uses ApplyGridTransform — verify it works
+            var img = torch.rand(new long[] { 1, 1, 48, 48 });
+            var result = functional.rotate(img, 45f, InterpolationMode.Nearest, fill: new float[] { 0f });
+            Assert.Equal(img.shape, result.shape);
+        }
+
+        [Fact]
         public void Solarize_InvertedPixel_True()
         {
             {


### PR DESCRIPTION
Fixes  #1502

Replace img[mask] = fill_img[mask] with torch::where(mask, fill_img, img) in THSVision_ApplyGridTransform's Nearest-mode fill logic. The operator[] boolean mask indexing is not supported in recent LibTorch versions.

This fixes torchvision.transforms.functional.affine() and rotate() when called with a fill value and Nearest interpolation mode.