### PR TITLE
Expose Storage.data_ptr() as public API

### DIFF
--- a/src/TorchSharp/Tensor/Storage.cs
+++ b/src/TorchSharp/Tensor/Storage.cs
@@ -139,7 +139,7 @@ namespace TorchSharp
             /// A pointer to the raw data in memory.
             /// </summary>
             /// <returns></returns>
-            protected IntPtr data_ptr()
+            public IntPtr data_ptr()
             {
                 if (_tensor_data_ptr != IntPtr.Zero)
                     return _tensor_data_ptr;

--- a/src/TorchSharp/Tensor/Storage.cs
+++ b/src/TorchSharp/Tensor/Storage.cs
@@ -138,7 +138,29 @@ namespace TorchSharp
             /// <summary>
             /// A pointer to the raw data in memory.
             /// </summary>
-            /// <returns></returns>
+            /// <remarks>
+            /// <para>
+            /// The returned pointer refers to the underlying storage buffer of the associated tensor. Depending on the
+            /// device of the tensor, this pointer may reference CPU memory or device-specific memory (for example, CUDA
+            /// device memory). Callers must not assume that the pointer is always CPU-accessible.
+            /// </para>
+            /// <para>
+            /// The lifetime of the pointer is strictly tied to the lifetime and layout of the owning tensor/storage. The
+            /// pointer becomes invalid if the underlying tensor or storage is moved, reallocated, resized in a way that
+            /// changes the underlying buffer, or disposed. Code that dereferences the pointer must ensure that the
+            /// associated tensor/storage instance remains alive and is not modified or disposed for the entire duration
+            /// of pointer use (for example, by keeping a strong reference and/or using <see cref="GC.KeepAlive(object)"/>).
+            /// </para>
+            /// <para>
+            /// This API is intended for advanced interop and unsafe scenarios. The pointer must not be cached and reused
+            /// across operations that may cause the storage to be reallocated or moved, and callers are responsible for
+            /// any necessary synchronization with device operations before reading from or writing to the memory.
+            /// </para>
+            /// </remarks>
+            /// <returns>
+            /// An <see cref="IntPtr"/> that points to the first element in the storage buffer. The pointer is only valid
+            /// while the underlying tensor/storage remains alive and its storage is not reallocated or disposed.
+            /// </returns>
             public IntPtr data_ptr()
             {
                 if (_tensor_data_ptr != IntPtr.Zero)

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -8312,6 +8312,20 @@ namespace TorchSharp
         }
 
         [Fact]
+        [TestOf(nameof(Tensor.storage))]
+        public void Storage_DataPtr()
+        {
+            var data = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
+            var x = torch.tensor(data);
+
+            var st = x.storage<float>();
+            Assert.NotNull(st);
+
+            var ptr = st.data_ptr();
+            Assert.NotEqual(IntPtr.Zero, ptr);
+        }
+
+        [Fact]
         [TestOf(nameof(torch.stft))]
         public void Float32STFT()
         {


### PR DESCRIPTION
Change the access modifier of Storage.data_ptr() from protected to public, allowing external consumers to obtain the raw data pointer for interop with other native libraries (e.g. bitsandbytes).

Fixes #1454