### PR TITLE
Fix native library loader silently failing when CUDA DLLs are missing

### DIFF
--- a/src/TorchSharp/Tensor/Factories/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Factories/Tensor.Factories.cs
@@ -649,7 +649,10 @@ namespace TorchSharp
         static torch()
         {
             deleters = new ConcurrentDictionary<TorchSharp.PInvoke.GCHandleDeleter, TorchSharp.PInvoke.GCHandleDeleter>();
-            TryInitializeDeviceType(DeviceType.CUDA);
+            if (!TryInitializeDeviceType(DeviceType.CUDA)) {
+                // CUDA not available, ensure CPU backend is loaded
+                LoadNativeBackend(false, out _);
+            }
         }
         #endregion
     }

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -158,7 +158,7 @@ namespace TorchSharp
                     ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 }
 
-                trace.AppendLine($"    Result from regular native load of LibTorchSharp is {ok}");
+                trace.AppendLine($"    Result from regular native load of backend libraries (CUDA preloads + torch_* + LibTorchSharp) is {ok}");
 
                 // Try dynamic load from package directories
                 if (!ok) {

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -153,11 +153,11 @@ namespace TorchSharp
                         TryLoadNativeLibraryByName("cusolver64_11", typeof(torch).Assembly, trace);
                     }
 
-                    TryLoadNativeLibraryByName("torch_cuda", typeof(torch).Assembly, trace);
-                    ok = TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("torch_cuda", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 } else {
-                    TryLoadNativeLibraryByName("torch_cpu", typeof(torch).Assembly, trace);
-                    ok = TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("torch_cpu", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 }
 
                 trace.AppendLine($"    Result from regular native load of backend libraries (CUDA preloads + torch_* + LibTorchSharp) is {ok}");

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -135,27 +135,29 @@ namespace TorchSharp
                         // Preloading these DLLs on windows seems to iron out problems where one native DLL
                         // requests a load of another through dynamic linking techniques.
                         //
-                        ok &= TryLoadNativeLibraryByName("cudnn_adv64_9", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cudnn_cnn64_9", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cudnn_ops64_9", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cudnn_graph64_9.dll", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cudnn_heuristic64_9.dll", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cudnn_engines_precompiled64_9.dll", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cudnn_engines_runtime_compiled64_9.dll", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("nvrtc-builtins64_128", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("caffe2_nvrtc", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("nvrtc64_120_0", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cublasLt64_12", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cufft64_11", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cusparse64_12", typeof(torch).Assembly, trace);
-                        ok &= TryLoadNativeLibraryByName("cusolver64_11", typeof(torch).Assembly, trace);
+                        // These are optional preloads to help Windows resolve transitive native dependencies.
+                        // Failures here are non-fatal -- the critical loads are torch_cuda and LibTorchSharp below.
+                        TryLoadNativeLibraryByName("cudnn_adv64_9", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cudnn_cnn64_9", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cudnn_ops64_9", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cudnn_graph64_9.dll", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cudnn_heuristic64_9.dll", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cudnn_engines_precompiled64_9.dll", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cudnn_engines_runtime_compiled64_9.dll", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("nvrtc-builtins64_128", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("caffe2_nvrtc", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("nvrtc64_120_0", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cublasLt64_12", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cufft64_11", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cusparse64_12", typeof(torch).Assembly, trace);
+                        TryLoadNativeLibraryByName("cusolver64_11", typeof(torch).Assembly, trace);
                     }
 
-                    ok &= TryLoadNativeLibraryByName("torch_cuda", typeof(torch).Assembly, trace);
-                    ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
+                    TryLoadNativeLibraryByName("torch_cuda", typeof(torch).Assembly, trace);
+                    ok = TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 } else {
-                    ok &= TryLoadNativeLibraryByName("torch_cpu", typeof(torch).Assembly, trace);
-                    ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
+                    TryLoadNativeLibraryByName("torch_cpu", typeof(torch).Assembly, trace);
+                    ok = TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 }
 
                 trace.AppendLine($"    Result from regular native load of backend libraries (CUDA preloads + torch_* + LibTorchSharp) is {ok}");
@@ -345,7 +347,12 @@ namespace TorchSharp
                 return false;
             }
 
-            LoadNativeBackend(deviceType == DeviceType.CUDA, out _);
+            try {
+                LoadNativeBackend(deviceType == DeviceType.CUDA, out _);
+            } catch (NotSupportedException) {
+                return false;
+            }
+
             if (deviceType == DeviceType.CUDA) {
                 return cuda.CallTorchCudaIsAvailable();
             } else {

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -117,7 +117,7 @@ namespace TorchSharp
             trace = null;
 
             if (!alreadyLoaded) {
-                bool ok;
+                bool ok = true;
                 trace = new StringBuilder();
                 trace.AppendLine($"");
                 trace.AppendLine($"TorchSharp: LoadNativeBackend: Initialising native backend, useCudaBackend = {useCudaBackend}");
@@ -135,27 +135,27 @@ namespace TorchSharp
                         // Preloading these DLLs on windows seems to iron out problems where one native DLL
                         // requests a load of another through dynamic linking techniques.
                         //
-                        ok = TryLoadNativeLibraryByName("cudnn_adv64_9", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cudnn_cnn64_9", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cudnn_ops64_9", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cudnn_graph64_9.dll", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cudnn_heuristic64_9.dll", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cudnn_engines_precompiled64_9.dll", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cudnn_engines_runtime_compiled64_9.dll", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("nvrtc-builtins64_128", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("caffe2_nvrtc", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("nvrtc64_120_0", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cublasLt64_12", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cufft64_11", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cusparse64_12", typeof(torch).Assembly, trace);
-                        ok = TryLoadNativeLibraryByName("cusolver64_11", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_adv64_9", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_cnn64_9", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_ops64_9", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_graph64_9.dll", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_heuristic64_9.dll", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_engines_precompiled64_9.dll", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cudnn_engines_runtime_compiled64_9.dll", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("nvrtc-builtins64_128", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("caffe2_nvrtc", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("nvrtc64_120_0", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cublasLt64_12", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cufft64_11", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cusparse64_12", typeof(torch).Assembly, trace);
+                        ok &= TryLoadNativeLibraryByName("cusolver64_11", typeof(torch).Assembly, trace);
                     }
 
-                    ok = TryLoadNativeLibraryByName("torch_cuda", typeof(torch).Assembly, trace);
-                    ok = TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("torch_cuda", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 } else {
-                    ok = TryLoadNativeLibraryByName("torch_cpu", typeof(torch).Assembly, trace);
-                    ok = TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("torch_cpu", typeof(torch).Assembly, trace);
+                    ok &= TryLoadNativeLibraryByName("LibTorchSharp", typeof(torch).Assembly, trace);
                 }
 
                 trace.AppendLine($"    Result from regular native load of LibTorchSharp is {ok}");


### PR DESCRIPTION
Change all 'ok = TryLoadNativeLibraryByName(...)' calls to 'ok &= ...' so that failures accumulate instead of being overwritten by subsequent successful loads. Initialize 'ok = true' before the loading chain.

Previously, each load call overwrote the result of the previous one, so if an early CUDA dependency (e.g. cudnn_adv64_9) failed to load but LibTorchSharp succeeded, 'ok' would be true. This caused:
- nativeBackendCudaLoaded set to true despite missing dependencies
- The fallback loading path was skipped
- The diagnostic trace (StringBuilder) was discarded
- Subsequent load attempts were skipped entirely
- CUDA operations failed later with cryptic errors

Now any single load failure keeps 'ok' as false, ensuring the fallback path is attempted and the full diagnostic trace is preserved in error messages.

Fixes dotnet/TorchSharp#1545