### PR TITLE
Add items() method to nn.Module for state_dict iteration

### DIFF
--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -511,6 +511,20 @@ namespace TorchSharp
                 public virtual IEnumerable<Module> children() => named_children().Select(np => np.module);
 
                 /// <summary>
+                /// Return an enumeration of the module's state_dict key/value pairs.
+                ///
+                /// This is equivalent to calling state_dict() and iterating over its entries.
+                /// Both parameters and persistent buffers are included.
+                /// </summary>
+                /// <returns>An enumerator of (name, tensor) tuples</returns>
+                public virtual IEnumerator<(string name, Tensor value)> items()
+                {
+                    foreach (var kv in state_dict()) {
+                        yield return (kv.Key, kv.Value);
+                    }
+                }
+
+                /// <summary>
                 /// Returns a dictionary containing a whole state of the module.
                 ///
                 /// Both parameters and persistent buffers(e.g.running averages) are included.Keys are corresponding parameter and buffer names.

--- a/src/TorchSharp/NN/ModuleDict.cs
+++ b/src/TorchSharp/NN/ModuleDict.cs
@@ -40,7 +40,7 @@ namespace TorchSharp
             /// Return an enumeration of the ParameterDict key/value pairs.
             /// </summary>
             /// <returns></returns>
-            public IEnumerator<(string, T)> items() => _list.GetEnumerator();
+            public new IEnumerator<(string, T)> items() => _list.GetEnumerator();
 
             /// <summary>
             /// Return the ParameterDict keys.

--- a/src/TorchSharp/NN/ParameterDict.cs
+++ b/src/TorchSharp/NN/ParameterDict.cs
@@ -40,7 +40,7 @@ namespace TorchSharp
             /// Return an enumeration of the ParameterDict key/value pairs.
             /// </summary>
             /// <returns></returns>
-            public IEnumerator<(string, Parameter)> items() => _list.GetEnumerator();
+            public new IEnumerator<(string, Parameter)> items() => _list.GetEnumerator();
 
             /// <summary>
             /// Return the ParameterDict keys.

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -3309,6 +3309,75 @@ namespace TorchSharp
             Assert.True(sd.ContainsKey("_linear2.weight"));
         }
 
+        [Fact]
+        public void TestModuleItems()
+        {
+            var lin = Linear(10, 5, true);
+            var sd = lin.state_dict();
+            var items = new List<(string, Tensor)>();
+
+            using (var enumerator = lin.items()) {
+                while (enumerator.MoveNext()) {
+                    items.Add(enumerator.Current);
+                }
+            }
+
+            // items() should return the same entries as state_dict()
+            Assert.Equal(sd.Count, items.Count);
+            foreach (var (name, value) in items) {
+                Assert.True(sd.ContainsKey(name));
+                Assert.Equal(sd[name].shape, value.shape);
+            }
+        }
+
+        [Fact]
+        public void TestModuleItemsWithSubmodules()
+        {
+            var seq = Sequential(
+                ("lin1", Linear(10, 5)),
+                ("lin2", Linear(5, 2)));
+            var sd = seq.state_dict();
+            var items = new List<(string, Tensor)>();
+
+            using (var enumerator = seq.items()) {
+                while (enumerator.MoveNext()) {
+                    items.Add(enumerator.Current);
+                }
+            }
+
+            Assert.Equal(sd.Count, items.Count);
+            Assert.Contains(items, i => i.Item1 == "lin1.weight");
+            Assert.Contains(items, i => i.Item1 == "lin2.weight");
+        }
+
+        [Fact]
+        public void TestModelMergeUsingItemsAndStateDict()
+        {
+            // Demonstrate model merging pattern using items() + state_dict() + load_state_dict()
+            // This is how users would merge models, matching the PyTorch pattern
+            var model1 = Linear(10, 5, true);
+            var model2 = Linear(10, 5, true);
+
+            var sd1 = model1.state_dict();
+            var sd2 = model2.state_dict();
+
+            var merged = new Dictionary<string, Tensor>();
+            using (var enumerator = model1.items()) {
+                while (enumerator.MoveNext()) {
+                    var (name, _) = enumerator.Current;
+                    merged[name] = (sd1[name] + sd2[name]) / 2;
+                }
+            }
+
+            model1.load_state_dict(merged);
+
+            // Verify the merged parameters are the average
+            var finalSd = model1.state_dict();
+            foreach (var key in merged.Keys) {
+                Assert.True(finalSd[key].allclose(merged[key]));
+            }
+        }
+
         private class TestModule3 : Module<Tensor, Tensor>
         {
             public TestModule3() : base(nameof(TestModule3)) { RegisterComponents(); }


### PR DESCRIPTION
Fixes #1474

Add items() method to nn.Module that returns an enumerator of (name, tensor) tuples from the module's state_dict. This enables easy iteration over all parameters and persistent buffers, consistent with the existing items() pattern in ModuleDict and ParameterDict.

This provides the items() API needed for model merging workflows (averaging parameters between models using state_dict + load_state_dict).

Changes:
- Add virtual items() method to Module class
- Add 'new' keyword to ModuleDict.items() and ParameterDict.items() to properly hide the base class method (different return types)
- Add tests for items() on simple and nested modules
- Add test demonstrating the model merge pattern from the issue