### PR TITLE
Fix hfft real input test

### DIFF
--- a/src/Native/LibTorchSharp/THSFFT.cpp
+++ b/src/Native/LibTorchSharp/THSFFT.cpp
@@ -22,7 +22,8 @@ Tensor THSTensor_fft2(const Tensor tensor, const int64_t* s, const int64_t* dim,
 {
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
-    auto dArg = (dim == nullptr) ? c10::IntArrayRef({-2, -1}) : c10::IntArrayRef(dim, 2);
+    int64_t defaultDim[] = { -2, -1 };
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, 2);
 
     CATCH_TENSOR(torch::fft::fft2(*tensor, sArg, dArg, normArg));
 }
@@ -31,7 +32,8 @@ Tensor THSTensor_ifft2(const Tensor tensor, const int64_t* s, const int64_t* dim
 {
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
-    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+    int64_t defaultDim[] = { -2, -1 };
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, 2);
 
     CATCH_TENSOR(torch::fft::ifft2(*tensor, sArg, dArg, normArg));
 }
@@ -65,7 +67,8 @@ Tensor THSTensor_hfft2(const Tensor tensor, const int64_t* s, const int64_t* dim
 {
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
-    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+    int64_t defaultDim[] = { -2, -1 };
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, 2);
     CATCH_TENSOR(torch::fft::hfft2(*tensor, sArg, dArg, normArg));
 }
 
@@ -73,7 +76,8 @@ Tensor THSTensor_hfftn(const Tensor tensor, const int64_t* s, const int s_length
 {
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
-    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef({-2, -1}) : c10::IntArrayRef(dim, dim_length);
+    int64_t defaultDim[] = { -2, -1 };
+    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, dim_length);
 
     CATCH_TENSOR(torch::fft::hfftn(*tensor, sArg, dArg, normArg));
 }
@@ -89,7 +93,8 @@ Tensor THSTensor_ihfft2(const Tensor tensor, const int64_t* s, const int64_t* di
 {
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
-    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+    int64_t defaultDim[] = { -2, -1 };
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, 2);
     CATCH_TENSOR(torch::fft::ihfft2(*tensor, sArg, dArg, normArg));
 }
 
@@ -97,7 +102,8 @@ Tensor THSTensor_ihfftn(const Tensor tensor, const int64_t* s, const int s_lengt
 {
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
-    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, dim_length);
+    int64_t defaultDim[] = { -2, -1 };
+    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, dim_length);
 
     CATCH_TENSOR(torch::fft::ihfftn(*tensor, sArg, dArg, normArg));
 }

--- a/src/Native/LibTorchSharp/THSFFT.cpp
+++ b/src/Native/LibTorchSharp/THSFFT.cpp
@@ -76,8 +76,7 @@ Tensor THSTensor_hfftn(const Tensor tensor, const int64_t* s, const int s_length
 {
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
-    int64_t defaultDim[] = { -2, -1 };
-    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, dim_length);
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
 
     CATCH_TENSOR(torch::fft::hfftn(*tensor, sArg, dArg, normArg));
 }
@@ -102,8 +101,7 @@ Tensor THSTensor_ihfftn(const Tensor tensor, const int64_t* s, const int s_lengt
 {
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
-    int64_t defaultDim[] = { -2, -1 };
-    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef(defaultDim, 2) : c10::IntArrayRef(dim, dim_length);
+    auto dArg = (dim == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(dim, dim_length));
 
     CATCH_TENSOR(torch::fft::ihfftn(*tensor, sArg, dArg, normArg));
 }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -7167,15 +7167,15 @@ namespace TorchSharp
         }
 
         [Fact]
-        [TestOf(nameof(fft.hfft2))]
+        [TestOf(nameof(fft.hfftn))]
         public void Float32HFFTN()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
-            var output = fft.hfft2(input);
+            var output = fft.hfftn(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
             Assert.Equal(ScalarType.Float32, output.dtype);
 
-            var inverted = fft.ihfft2(output);
+            var inverted = fft.ihfftn(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
             Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -6881,12 +6881,12 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft))]
         public void Float32HFFT()
         {
-            var input = torch.arange(4);
+            var input = torch.arange(4, complex64);
             var output = fft.hfft(input);
             Assert.Equal(6, output.shape[0]);
             Assert.Equal(ScalarType.Float32, output.dtype);
 
-            var inverted = fft.ifft(output);
+            var inverted = fft.ihfft(output);
             Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
         }
 
@@ -6894,12 +6894,12 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft))]
         public void Float64HFFT()
         {
-            var input = torch.arange(4, float64);
+            var input = torch.arange(4, complex128);
             var output = fft.hfft(input);
             Assert.Equal(6, output.shape[0]);
             Assert.Equal(ScalarType.Float64, output.dtype);
 
-            var inverted = fft.ifft(output);
+            var inverted = fft.ihfft(output);
             Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
         }
 
@@ -7142,10 +7142,10 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft2))]
         public void Float32HFFT2()
         {
-            var input = torch.rand(new long[] { 5, 5, 5, 5 });
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfft2(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-            Assert.Equal(input.dtype, output.dtype);
+            Assert.Equal(ScalarType.Float32, output.dtype);
 
             var inverted = fft.ihfft2(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
@@ -7156,10 +7156,10 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft2))]
         public void Float64HFFT2()
         {
-            var input = torch.rand(new long[] { 5, 5, 5, 5 }, float64);
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex128);
             var output = fft.hfft2(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-            Assert.Equal(input.dtype, output.dtype);
+            Assert.Equal(ScalarType.Float64, output.dtype);
 
             var inverted = fft.ihfft2(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
@@ -7170,10 +7170,10 @@ namespace TorchSharp
         [TestOf(nameof(fft.hfft2))]
         public void Float32HFFTN()
         {
-            var input = torch.rand(new long[] { 5, 5, 5, 5 });
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfft2(input);
             Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-            Assert.Equal(input.dtype, output.dtype);
+            Assert.Equal(ScalarType.Float32, output.dtype);
 
             var inverted = fft.ihfft2(output);
             Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
@@ -7188,10 +7188,10 @@ namespace TorchSharp
 
                 // TODO: Something in this test makes if fail on Windows / Release and MacOS / Release
 
-                var input = torch.rand(new long[] { 5, 5, 5, 5 }, float64);
+                var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex128);
                 var output = fft.hfftn(input);
                 Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
-                Assert.Equal(input.dtype, output.dtype);
+                Assert.Equal(ScalarType.Float64, output.dtype);
 
                 var inverted = fft.ihfftn(output);
                 Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -6878,32 +6878,6 @@ namespace TorchSharp
         }
 
         [Fact]
-        [TestOf(nameof(fft.hfft))]
-        public void Float32HFFT()
-        {
-            var input = torch.arange(4, complex64);
-            var output = fft.hfft(input);
-            Assert.Equal(6, output.shape[0]);
-            Assert.Equal(ScalarType.Float32, output.dtype);
-
-            var inverted = fft.ihfft(output);
-            Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
-        }
-
-        [Fact]
-        [TestOf(nameof(fft.hfft))]
-        public void Float64HFFT()
-        {
-            var input = torch.arange(4, complex128);
-            var output = fft.hfft(input);
-            Assert.Equal(6, output.shape[0]);
-            Assert.Equal(ScalarType.Float64, output.dtype);
-
-            var inverted = fft.ihfft(output);
-            Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
-        }
-
-        [Fact]
         [TestOf(nameof(fft.rfft))]
         public void Float32RFFT()
         {
@@ -7140,7 +7114,7 @@ namespace TorchSharp
 
         [Fact]
         [TestOf(nameof(fft.hfft2))]
-        public void Float32HFFT2()
+        public void ComplexFloat32HFFT2()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfft2(input);
@@ -7154,7 +7128,7 @@ namespace TorchSharp
 
         [Fact]
         [TestOf(nameof(fft.hfft2))]
-        public void Float64HFFT2()
+        public void ComplexFloat64HFFT2()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex128);
             var output = fft.hfft2(input);
@@ -7168,7 +7142,7 @@ namespace TorchSharp
 
         [Fact]
         [TestOf(nameof(fft.hfftn))]
-        public void Float32HFFTN()
+        public void ComplexFloat32HFFTN()
         {
             var input = torch.rand(new long[] { 5, 5, 5, 5 }, complex64);
             var output = fft.hfftn(input);
@@ -7182,7 +7156,7 @@ namespace TorchSharp
 
         [Fact(Skip = "Fails on all Release builds.")]
         [TestOf(nameof(fft.hfftn))]
-        public void Float64HFFTN()
+        public void ComplexFloat64HFFTN()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 


### PR DESCRIPTION
PyTorch's fft.hfft/hfft2/hfftn require complex input tensors. The tests were passing real-valued tensors (Float32/Float64), which causes 'NYI' errors in newer PyTorch versions. Fixed by using complex64/complex128 input types and ihfft for inverse verification.