### PR TITLE
Add documentation comment warning to only load trusted models

### DIFF
--- a/src/TorchSharp/Export/ExportedProgram.cs
+++ b/src/TorchSharp/Export/ExportedProgram.cs
@@ -37,6 +37,8 @@ namespace TorchSharp
             ///     package_path="model.pt2"
             /// )
             /// </code>
+            /// 
+            /// Only load models from trusted sources. Loading models from untrusted sources is a security risk.
             /// </remarks>
             public static ExportedProgram load(string filename)
             {
@@ -46,6 +48,7 @@ namespace TorchSharp
             /// <summary>
             /// Load a PyTorch ExportedProgram with typed output.
             /// </summary>
+            /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
             public static ExportedProgram<TResult> load<TResult>(string filename)
             {
                 return new ExportedProgram<TResult>(filename);

--- a/src/TorchSharp/JIT/ScriptModule.cs
+++ b/src/TorchSharp/JIT/ScriptModule.cs
@@ -854,7 +854,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule load(string filename, DeviceType device_type = DeviceType.CPU, long device_index = -1)
@@ -870,7 +871,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule load(byte[] bytes, DeviceType device_type = DeviceType.CPU, long device_index = -1)
             {
@@ -884,7 +886,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule load(string filename, Device map_location)
@@ -899,7 +902,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule load(byte[] bytes, Device map_location)
             {
@@ -912,7 +916,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule load(string filename, string map_location)
@@ -927,7 +932,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule load(byte[] bytes, string map_location)
             {
@@ -943,7 +949,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<TResult> load<TResult>(string filename, DeviceType device_type = DeviceType.CPU, long device_index = -1)
@@ -960,7 +967,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<TResult> load<TResult>(byte[] bytes, DeviceType device_type = DeviceType.CPU, long device_index = -1)
             {
@@ -975,7 +983,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<TResult> load<TResult>(string filename, Device map_location)
@@ -991,7 +1000,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<TResult> load<TResult>(byte[] bytes, Device map_location)
             {
@@ -1006,7 +1016,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<TResult> load<TResult>(string filename, string map_location)
@@ -1022,7 +1033,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<TResult> load<TResult>(byte[] bytes, string map_location)
             {
@@ -1039,7 +1051,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<T1, TResult> load<T1, TResult>(string filename, DeviceType device_type = DeviceType.CPU, long device_index = -1)
@@ -1057,7 +1070,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<T1, TResult> load<T1, TResult>(byte[] bytes, DeviceType device_type = DeviceType.CPU, long device_index = -1)
             {
@@ -1073,7 +1087,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<T1, TResult> load<T1, TResult>(string filename, Device map_location)
@@ -1090,7 +1105,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<T1, TResult> load<T1, TResult>(byte[] bytes, Device map_location)
             {
@@ -1106,7 +1122,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<T1, TResult> load<T1, TResult>(string filename, string map_location)
@@ -1123,7 +1140,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<T1, TResult> load<T1, TResult>(byte[] bytes, string map_location)
             {
@@ -1141,7 +1159,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<T1, T2, TResult> load<T1, T2, TResult>(string filename, DeviceType device_type = DeviceType.CPU, long device_index = -1)
@@ -1160,7 +1179,8 @@ namespace TorchSharp
             /// <param name="device_index">The optional device index.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<T1, T2, TResult> load<T1, T2, TResult>(byte[] bytes, DeviceType device_type = DeviceType.CPU, long device_index = -1)
             {
@@ -1177,7 +1197,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<T1, T2, TResult> load<T1, T2, TResult>(string filename, Device map_location)
@@ -1195,7 +1216,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<T1, T2, TResult> load<T1, T2, TResult>(byte[] bytes, Device map_location)
             {
@@ -1212,7 +1234,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             /// <exception cref="System.IO.FileNotFoundException">Raised if the file is not found.</exception>
             public static ScriptModule<T1, T2, TResult> load<T1, T2, TResult>(string filename, string map_location)
@@ -1230,7 +1253,8 @@ namespace TorchSharp
             /// <param name="map_location">The device type where the script module should be loaded.</param>
             /// <returns>A ScriptModule instance, whether the script originated as a module or function.</returns>
             /// <remarks>
-            /// All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from.If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.
+            /// <para>All previously saved modules, no matter their device, are first loaded onto CPU, and then are moved to the devices they were saved from. If this fails (e.g.because the run time system doesn’t have certain devices), an exception is raised.</para>
+            /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
             /// </remarks>
             public static ScriptModule<T1, T2, TResult> load<T1, T2, TResult>(byte[] bytes, string map_location)
             {

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -946,9 +946,10 @@ namespace TorchSharp
                 /// <param name="loadedParameters">A dictionary to populate with the list of parameters loaded and whether they were matched/skipped. Useful when loading in non-strict mode.</param>
                 /// <returns>The module, with parameters and buffers loaded.</returns>
                 /// <remarks>
-                /// Using a skip list only prevents tensors in the target module from being modified, it
+                /// <para>Using a skip list only prevents tensors in the target module from being modified, it
                 /// does not alter any logic related to checking for matching tensor element types or entries.
-                /// It may be necessary to also pass 'strict=false' to avoid exceptions.
+                /// It may be necessary to also pass 'strict=false' to avoid exceptions.</para>
+                /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
                 /// </remarks>
                 public virtual Module load(string location, bool strict = true, IList<string>? skip = null, Dictionary<string, bool>? loadedParameters = null)
                 {
@@ -975,9 +976,10 @@ namespace TorchSharp
                 /// <param name="loadedParameters">A dictionary to populate with the list of parameters loaded and whether they were matched/skipped. Useful when loading in non-strict mode.</param>
                 /// <returns>The module, with parameters and buffers loaded.</returns>
                 /// <remarks>
-                /// Using a skip list only prevents tensors in the target module from being modified, it
+                /// <para>Using a skip list only prevents tensors in the target module from being modified, it
                 /// does not alter any logic related to checking for matching tensor element types or entries.
-                /// It may be necessary to also pass 'strict=false' to avoid exceptions.
+                /// It may be necessary to also pass 'strict=false' to avoid exceptions.</para>
+                /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
                 /// </remarks>
                 public virtual Module load(System.IO.BinaryReader reader, bool strict = true, IList<string>? skip = null, Dictionary<string, bool>? loadedParameters = null)
                 {
@@ -1034,9 +1036,10 @@ namespace TorchSharp
                 /// <param name="loadedParameters">A dictionary to populate with the list of parameters loaded and whether they were matched/skipped. Useful when loading in non-strict mode.</param>
                 /// <returns>The module, with parameters and buffers loaded.</returns>
                 /// <remarks>
-                /// Using a skip list only prevents tensors in the target module from being modified, it
+                /// <para>Using a skip list only prevents tensors in the target module from being modified, it
                 /// does not alter any logic related to checking for matching tensor element types or entries.
-                /// It may be necessary to also pass 'strict=false' to avoid exceptions.
+                /// It may be necessary to also pass 'strict=false' to avoid exceptions.</para>
+                /// <para>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</para>
                 /// </remarks>
                 public Module load(System.IO.Stream stream, bool strict = true, IList<string>? skip = null, Dictionary<string, bool>? loadedParameters = null)
                 {
@@ -1047,9 +1050,7 @@ namespace TorchSharp
                 /// <summary>
                 /// Create a module and load its weights from disk.
                 /// </summary>
-                /// <typeparam name="T"></typeparam>
-                /// <param name="path"></param>
-                /// <returns></returns>
+                /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
                 public static Module Create<T>(string path)
                     where T : Module, new()
                 {


### PR DESCRIPTION
We should warn users not to load untrusted models.

This corresponds to [a similar warning in the PyTorch documentation](https://docs.pytorch.org/docs/2.12/generated/torch.load.html):

> `torch.load()` uses an unpickler under the hood. **Never load data from an untrusted source.**

Equivalent PR in ML.NET: https://github.com/dotnet/machinelearning/pull/7611